### PR TITLE
[feat]브라우저지역에 따른 UTC시간을 지역시간으로 변경 FC추가

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,7 @@ import MaintainHeight from "./hooks/MaintainHeight";
 import SortableInputsFor from "./hooks/SortableInputsFor";
 import live_select from "live_select";
 import Raty from "../vendor/raty";
+import LocalTime from "./hooks/LocalTime";
 // import RatyHook from "./hooks/raty_hook";
 
 let csrfToken = document
@@ -35,6 +36,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     MaintainHeight,
     SortableInputsFor,
     ...live_select,
+    LocalTime,
     // Raty: RatyHook,
   },
   longPollFallbackMs: 2500,

--- a/assets/js/hooks/LocalTime.js
+++ b/assets/js/hooks/LocalTime.js
@@ -1,0 +1,24 @@
+LocalTime = {
+  mounted() {
+    // 요소의 textContent(UTC 시간)를 가져와서 Date 객체로 변환
+    // 서버에서 "2025-11-19T10:30:00Z" 형식으로 내려준다고 가정
+    const dt = new Date(this.el.getAttribute("datetime"));
+
+    // 옵션 설정: 초(second)를 제외하고 시, 분까지만 설정
+    const options = {
+      year: 'numeric',   // 2025년
+      month: 'numeric',  // 11월
+      day: 'numeric',    // 20일
+      hour: '2-digit',   // 10시
+      minute: '2-digit', // 51분
+      // second: '2-digit' // <-- 이 줄이 없으면 초는 안 나옵니다!
+    };
+
+    // 첫 번째 인자에 undefined를 넣으면 브라우저 기본 언어 설정(사용자 로케일)을 따릅니다.
+    // 한국어 강제 설정을 원하시면 'ko-KR'을 넣으세요.
+    this.el.textContent = dt.toLocaleString(undefined, options);
+
+    this.el.classList.remove("invisible")
+  }
+}
+export default LocalTime;

--- a/lib/itsm_web.ex
+++ b/lib/itsm_web.ex
@@ -90,6 +90,9 @@ defmodule ItsmWeb do
       # Core UI components
       import ItsmWeb.CoreComponents
 
+      # Itsm Components
+      import ItsmWeb.ItsmComponents
+
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS
 

--- a/lib/itsm_web/components/itsm_components.ex
+++ b/lib/itsm_web/components/itsm_components.ex
@@ -1,0 +1,23 @@
+defmodule ItsmWeb.ItsmComponents do
+  use Phoenix.Component
+
+  @doc """
+  Renders a time element that displays a localized time using a LiveView hook.
+  yyyy.mm.dd hh:mm
+  """
+  attr :at, :any, required: true, doc: "UTC DateTime struct or ISO string"
+  attr :id, :string, required: true
+
+  def local_time(assigns) do
+    ~H"""
+    <time
+      id={@id}
+      phx-hook="LocalTime"
+      datetime={@at}
+      class="invisible"
+    >
+      {@at}
+    </time>
+    """
+  end
+end

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -70,7 +70,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
           
           <:item title="Status">{@request.status}</:item>
           
-          <:item title="Due Date">{@request.due_date}</:item>
+          <:item title="Due Date"><.local_time id="due_date" at={@request.due_date} /></:item>
           
           <:item title="Requestor">{@request.requestor_name} ({@request.requestor_id})</:item>
           

--- a/lib/itsm_web/live/request_live/index.ex
+++ b/lib/itsm_web/live/request_live/index.ex
@@ -41,7 +41,7 @@ defmodule ItsmWeb.RequestLive.Index do
       
       <:col :let={{_id, request}} label="Env">{request.env}</:col>
       
-      <:col :let={{_id, request}} label="Due date">{request.due_date}</:col>
+      <:col :let={{id, request}} label="Due date"><.local_time id={id} at={request.due_date} /></:col>
       
       <:col :let={{_id, request}} label="Request Type">{request.category.request_name}</:col>
       


### PR DESCRIPTION
<.local_time id={id} at={date}.> Function Component 개발 및 가상 머신 신청 적용함