### PR TITLE
3.3(화) assets, os_instance 추가

### DIFF
--- a/lib/itsm/approvals.ex
+++ b/lib/itsm/approvals.ex
@@ -8,6 +8,7 @@ defmodule Itsm.Approvals do
   alias Itsm.Team.Member
   alias Itsm.Workflow
   alias Itsm.Requests
+  alias Itsm.Finalization
 
   # ==================================================
   # PubSub
@@ -108,6 +109,12 @@ defmodule Itsm.Approvals do
     # 트랜잭션 커밋 후 broadcast
     case result do
       {:ok, {preloaded_request, _approval}} ->
+        # TODO : Sync 호출 (자산 한번에 10개 이상 신청 대응)
+        # 상태가 :finish(또는 워크플로우에 맞는 완료 상태)일 때 바로 실행
+        if preloaded_request.status == :confirmation do
+          Finalization.execute_after_finish(preloaded_request)
+        end
+
         broadcast_approvals_list({:request_updated, preloaded_request})
         Requests.broadcast_request(preloaded_request.id, {:request_updated, preloaded_request})
         result

--- a/lib/itsm/assets.ex
+++ b/lib/itsm/assets.ex
@@ -7,6 +7,31 @@ defmodule Itsm.Assets do
   alias Itsm.Repo
 
   alias Itsm.Assets.Asset
+  alias Itsm.Repo
+  alias Itsm.OsInstances
+
+  # ==================================================
+  # PubSub
+  # ==================================================
+
+  def subscribe_assets_list do
+    Phoenix.PubSub.subscribe(Itsm.PubSub, "assets_list")
+  end
+
+  def subscribe_asset(asset_id) do
+    Phoenix.PubSub.subscribe(Itsm.PubSub, "asset:#{asset_id}")
+  end
+
+  def broadcast_asset(asset, event_name) do
+    # Index.ex의 handle_info와 포맷을 맞추기 위해 튜플로 묶습니다.
+    # 예: {Itsm.Assets, [:asset, :created], %Asset{}}
+    message = {__MODULE__, event_name, asset}
+    Phoenix.PubSub.broadcast(Itsm.PubSub, "assets_list", message)
+    Phoenix.PubSub.broadcast(Itsm.PubSub, "asset:#{asset.id}", message)
+
+    # 함수 체이닝을 위해 결과를 반환해 줍니다.
+    {:ok, asset}
+  end
 
   @doc """
   Returns the list of assets.
@@ -71,6 +96,10 @@ defmodule Itsm.Assets do
     asset
     |> Asset.changeset(attrs)
     |> Repo.update()
+    |> case do
+      {:ok, updated_asset} -> broadcast_asset(updated_asset, [:asset, :updated])
+      error -> error
+    end
   end
 
   @doc """
@@ -87,6 +116,10 @@ defmodule Itsm.Assets do
   """
   def delete_asset(%Asset{} = asset) do
     Repo.delete(asset)
+    |> case do
+      {:ok, deleted_asset} -> broadcast_asset(deleted_asset, [:asset, :deleted])
+      error -> error
+    end
   end
 
   @doc """
@@ -100,5 +133,71 @@ defmodule Itsm.Assets do
   """
   def change_asset(%Asset{} = asset, attrs \\ %{}) do
     Asset.changeset(asset, attrs)
+  end
+
+  @doc """
+  Asset과 OsInstance를 순차적으로 생성하되, 하나라도 실패하면 전체 롤백
+  """
+  def create_asset_with_os(request) do
+    # embeds_many 리스트를 가져옵니다. (비어있을 경우를 대비해 빈 리스트 기본값)
+    vm_list = request.common_k_create_vms || []
+
+    # 트랜잭션 시작
+    result =
+      Repo.transaction(fn ->
+        # VM 신청 대수만큼 반복(Loop)
+        Enum.map(vm_list, fn vm_data ->
+          # 1. Asset 속성 매핑 (vm_data에서 직접 추출)
+          asset_attrs = %{
+            name: vm_data.hostname,
+            description: vm_data.service_name,
+            category: request.category.category,
+            infra_type: "private_cloud",
+            env: request.env,
+            region_type: request.category.group,
+            affiliate: request.category.affiliate,
+            location: vm_data.location,
+            service_crew_id: request.requestor_crew_id,
+            system_crew_id: request.assignee_crew_id,
+            is_dmz_zone: vm_data.is_dmz_zone
+          }
+
+          with {:ok, asset} <- create_asset(asset_attrs),
+
+               # 2. OS 속성 매핑 (위에서 생성된 asset.id를 FK로 삽입)
+               os_attrs = %{
+                 os_type: vm_data.os_image,
+                 os_version: vm_data.os_version,
+                 ip: vm_data.ip || "0.0.0.0",
+                 cpu_core: vm_data.cpu,
+                 memory_gb: vm_data.memory,
+                 crew_id: request.assignee_crew_id,
+                 # FK 삽입
+                 asset_id: asset.id
+               },
+               {:ok, os_instance} <- OsInstances.create_os_instance(os_attrs) do
+            # 둘 다 성공하면 결과 반환
+            %{asset: asset, os_instance: os_instance}
+          else
+            # 실패 시 즉시 전체 트랜잭션 롤백
+
+            {:error, changeset} ->
+              Repo.rollback(changeset)
+          end
+        end)
+      end)
+
+    case result do
+      {:ok, created_items} ->
+        # created_items는 [%{asset: asset1, ...}, %{asset: asset2, ...}] 형태의 리스트입니다.
+        Enum.each(created_items, fn %{asset: asset} ->
+          broadcast_asset(asset, [:asset, :created])
+        end)
+
+        {:ok, created_items}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 end

--- a/lib/itsm/assets/asset.ex
+++ b/lib/itsm/assets/asset.ex
@@ -23,8 +23,10 @@ defmodule Itsm.Assets.Asset do
     # field :service_crew_id, :binary_id
     # field :system_crew_id, :binary_id
 
-    belongs_to :service_crew, Itsm.Team.Crew, type: :binary_id, primary_key: true
-    belongs_to :system_crew, Itsm.Team.Crew, type: :binary_id, primary_key: true
+    has_one :os_instance, Itsm.OsInstances.OsInstance
+
+    belongs_to :service_crew, Itsm.Team.Crew, type: :binary_id
+    belongs_to :system_crew, Itsm.Team.Crew, type: :binary_id
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/itsm/comments.ex
+++ b/lib/itsm/comments.ex
@@ -45,5 +45,18 @@ defmodule Itsm.Comments do
   def create_comment(resource, %User{} = user, attrs \\ %{}) do
     changeset_comment(resource, user, attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, comment} ->
+        # 🌟 1. Show.ex 화면을 위해 :user와 :attachments 둘 다 Preload!
+        preloaded_comment = Repo.preload(comment, [:user, :attachments])
+
+        # 🌟 2. 여기서 직접 PubSub 방송을 쏩니다! (기존 로직 활용)
+        Requests.broadcast_request(resource.id, {:comment_created, preloaded_comment})
+
+        {:ok, preloaded_comment}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 end

--- a/lib/itsm/finalization.ex
+++ b/lib/itsm/finalization.ex
@@ -1,0 +1,17 @@
+defmodule Itsm.Finalization do
+  alias Itsm.Assets
+
+  def execute_after_finish(request) do
+    do_execute(request.category.request_name, request)
+  end
+
+  # K리전 공동존 가상머신 생성 완료 시 -> Assets 컨텍스트 호출
+  defp do_execute("common_k_create_vm", request) do
+    Assets.create_asset_with_os(request)
+  end
+
+  # TODO: category name 기반 나머지 SR들
+  defp do_execute(_other_type, _request) do
+    {:ok, :no_action_needed}
+  end
+end

--- a/lib/itsm/os_instances.ex
+++ b/lib/itsm/os_instances.ex
@@ -1,0 +1,104 @@
+defmodule Itsm.OsInstances do
+  @moduledoc """
+  The OsInstances context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Itsm.Repo
+
+  alias Itsm.OsInstances.OsInstance
+
+  @doc """
+  Returns the list of os_instances.
+
+  ## Examples
+
+      iex> list_os_instances()
+      [%OsInstance{}, ...]
+
+  """
+  def list_os_instances do
+    Repo.all(OsInstance)
+  end
+
+  @doc """
+  Gets a single os_instance.
+
+  Raises `Ecto.NoResultsError` if the Os instance does not exist.
+
+  ## Examples
+
+      iex> get_os_instance!(123)
+      %OsInstance{}
+
+      iex> get_os_instance!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_os_instance!(id), do: Repo.get!(OsInstance, id)
+
+  @doc """
+  Creates a os_instance.
+
+  ## Examples
+
+      iex> create_os_instance(%{field: value})
+      {:ok, %OsInstance{}}
+
+      iex> create_os_instance(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_os_instance(attrs \\ %{}) do
+    %OsInstance{}
+    |> OsInstance.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a os_instance.
+
+  ## Examples
+
+      iex> update_os_instance(os_instance, %{field: new_value})
+      {:ok, %OsInstance{}}
+
+      iex> update_os_instance(os_instance, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_os_instance(%OsInstance{} = os_instance, attrs) do
+    os_instance
+    |> OsInstance.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a os_instance.
+
+  ## Examples
+
+      iex> delete_os_instance(os_instance)
+      {:ok, %OsInstance{}}
+
+      iex> delete_os_instance(os_instance)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_os_instance(%OsInstance{} = os_instance) do
+    Repo.delete(os_instance)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking os_instance changes.
+
+  ## Examples
+
+      iex> change_os_instance(os_instance)
+      %Ecto.Changeset{data: %OsInstance{}}
+
+  """
+  def change_os_instance(%OsInstance{} = os_instance, attrs \\ %{}) do
+    OsInstance.changeset(os_instance, attrs)
+  end
+end

--- a/lib/itsm/os_instances/os_instance.ex
+++ b/lib/itsm/os_instances/os_instance.ex
@@ -1,0 +1,28 @@
+defmodule Itsm.OsInstances.OsInstance do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "os_instances" do
+    field :os_type, :string
+    field :os_version, :string
+    field :ip, :string
+    field :cpu_core, :integer
+    field :memory_gb, :integer
+    # field :asset_id, :binary_id
+    # field :crew_id, :binary_id
+
+    belongs_to :asset, Itsm.Assets.Asset, type: :binary_id
+    belongs_to :crew, Itsm.Team.Crew, type: :binary_id
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(os_instance, attrs) do
+    os_instance
+    |> cast(attrs, [:ip, :os_type, :os_version, :cpu_core, :memory_gb, :asset_id, :crew_id])
+    |> validate_required([:ip, :os_type, :os_version, :cpu_core, :memory_gb, :asset_id, :crew_id])
+  end
+end

--- a/lib/itsm/service/category.ex
+++ b/lib/itsm/service/category.ex
@@ -12,8 +12,11 @@ defmodule Itsm.Service.Category do
     # group_code: "계열사"
     field :affiliate, :string
     field :request_name, :string
+    # 용도 : SLA 계산용
     field :duration, :integer, default: 60
-    # field :assignee_crew, :string
+
+    # 용도 : 서비스 요청 시 카테고리 구분 (서버, 네트워크, 보안, 미들웨어, 인터페이스 등)
+    field :category, :string
 
     belongs_to :assignee_crew, Itsm.Team.Crew, type: :binary_id
 

--- a/lib/itsm/service/common_k_create_vm.ex
+++ b/lib/itsm/service/common_k_create_vm.ex
@@ -4,18 +4,40 @@ defmodule Itsm.Service.CommonKCreateVm do
 
   embedded_schema do
     field :ip, :string
-    field :description, :string
+    field :service_name, :string
     field :hostname, :string
     # group_code: "운영체제"
     field :os_image, :string
     field :os_version, :string
-    field :cpu_memory, :string
+    # field :cpu_memory, :string
+    field :cpu, :integer
+    field :memory, :integer
+    field :is_dmz_zone, :boolean, default: false
+    field :location, :string
   end
 
   @doc false
   def changeset(common_k_create_vm, attrs) do
     common_k_create_vm
-    |> cast(attrs, [:hostname, :os_image, :cpu_memory, :description, :os_version])
-    |> validate_required([:hostname, :os_image, :cpu_memory, :description, :os_version])
+    |> cast(attrs, [
+      :hostname,
+      :os_image,
+      :cpu,
+      :memory,
+      :service_name,
+      :os_version,
+      :is_dmz_zone,
+      :location
+    ])
+    |> validate_required([
+      :hostname,
+      :os_image,
+      :cpu,
+      :memory,
+      :service_name,
+      :os_version,
+      :is_dmz_zone,
+      :location
+    ])
   end
 end

--- a/lib/itsm_web/components/create_comment_dialog.ex
+++ b/lib/itsm_web/components/create_comment_dialog.ex
@@ -78,9 +78,12 @@ defmodule ItsmWeb.CreateCommentDialog do
 
     with {:ok, _comment} <- Comments.create_comment(request, user, comment_params),
          {:ok, _} <- do_action(action, request, user) do
-      {:noreply, push_navigate(socket, to: ~p"/approvals")}
+      {:noreply,
+       socket
+       |> clear_flash()
+       |> push_patch(to: ~p"/approvals")}
     else
-      {:error, changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         IO.inspect(changeset, label: "Approval Error")
         {:noreply, put_flash(socket, :error, "Failed")}
     end

--- a/lib/itsm_web/live/approval_live/list.ex
+++ b/lib/itsm_web/live/approval_live/list.ex
@@ -102,21 +102,21 @@ defmodule ItsmWeb.ApprovalLive.List do
       <:col :let={{_id, request}} label={gettext("Title")}>
         <div class="w-[90px] truncate">{request.title}</div>
       </:col>
-
+      
       <:col :let={{_id, request}} label={gettext("Environment")}>{request.env}</:col>
-
+      
       <:col :let={{id, request}} label={gettext("Due Date")}>
         <span id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date}></span>
       </:col>
-
+      
       <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
-
+      
       <:col :let={{_id, request}} label={gettext("Requestor Name")}>{request.requestor_name}</:col>
-
+      
       <:col :let={{_id, request}} label={gettext("Status")}>
         {Workflow.status_label(:service_request, request)}
       </:col>
-
+      
       <:action :let={{_id, request}}><.action_cell request={request} /></:action>
     </.table>
     """

--- a/lib/itsm_web/live/asset_live/index.ex
+++ b/lib/itsm_web/live/asset_live/index.ex
@@ -6,6 +6,8 @@ defmodule ItsmWeb.AssetLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if connected?(socket), do: Assets.subscribe_assets_list()
+
     {:ok, stream(socket, :assets, Assets.list_assets())}
   end
 
@@ -32,16 +34,32 @@ defmodule ItsmWeb.AssetLive.Index do
     |> assign(:asset, nil)
   end
 
+  # @impl true
+  # def handle_info({ItsmWeb.AssetLive.FormComponent, {:saved, asset}}, socket) do
+  #   {:noreply, stream_insert(socket, :assets, asset)}
+  # end
+
+  # @impl true
+  # def handle_event("delete", %{"id" => id}, socket) do
+  #   asset = Assets.get_asset!(id)
+  #   {:ok, _} = Assets.delete_asset(asset)
+
+  #   {:noreply, stream_delete(socket, :assets, asset)}
+  # end
+
   @impl true
-  def handle_info({ItsmWeb.AssetLive.FormComponent, {:saved, asset}}, socket) do
+  def handle_info({Assets, [:asset, :created], asset}, socket) do
+    # 새 자산이 생성되면 스트림의 맨 위(at: 0)에 꽂아 넣습니다.
+    {:noreply, stream_insert(socket, :assets, asset, at: 0)}
+  end
+
+  def handle_info({Assets, [:asset, :updated], asset}, socket) do
+    # 자산이 수정되면 스트림에서 해당 항목을 교체합니다.
     {:noreply, stream_insert(socket, :assets, asset)}
   end
 
-  @impl true
-  def handle_event("delete", %{"id" => id}, socket) do
-    asset = Assets.get_asset!(id)
-    {:ok, _} = Assets.delete_asset(asset)
-
+  def handle_info({Assets, [:asset, :deleted], asset}, socket) do
+    # 자산이 삭제되면 스트림에서 뺍니다.
     {:noreply, stream_delete(socket, :assets, asset)}
   end
 end

--- a/lib/itsm_web/live/asset_live/show.html.heex
+++ b/lib/itsm_web/live/asset_live/show.html.heex
@@ -1,6 +1,7 @@
 <.header>
   Asset {@asset.id}
   <:subtitle>This is a asset record from your database.</:subtitle>
+  
   <:actions>
     <.link patch={~p"/assets/#{@asset}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit asset</.button>
@@ -10,14 +11,31 @@
 
 <.list>
   <:item title={gettext("Name")}>{@asset.name}</:item>
+  
   <:item title={gettext("Description")}>{@asset.description}</:item>
+  
   <:item title={gettext("Affiliate")}>{@asset.affiliate}</:item>
+  
   <:item title={gettext("Category")}>{@asset.category}</:item>
+  
   <:item title={gettext("Region type")}>{@asset.region_type}</:item>
+  
   <:item title={gettext("Infra type")}>{@asset.infra_type}</:item>
+  
   <:item title={gettext("Environment")}>{@asset.env}</:item>
+  
   <:item title={gettext("Location")}>{@asset.location}</:item>
+  
   <:item title={gettext("Is dmz zone")}>{@asset.is_dmz_zone}</:item>
+  
+  <:item title={gettext("Created Date")}>
+    <div
+      id="created_date"
+      phx-hook="LocalTime.ToLocale"
+      format="datetime"
+      utc-value={@asset.inserted_at}
+    />
+  </:item>
 </.list>
 
 <.back navigate={~p"/assets"}>Back to assets</.back>

--- a/lib/itsm_web/live/common_k_create_vm_live/form.html.heex
+++ b/lib/itsm_web/live/common_k_create_vm_live/form.html.heex
@@ -72,8 +72,8 @@
             phx-debounce="blur"
           />
           <.input
-            field={common_k_create_vm_f[:description]}
-            label={gettext("Description")}
+            field={common_k_create_vm_f[:service_name]}
+            label={gettext("Service Name")}
             type="text"
             phx-debounce="blur"
           />
@@ -94,10 +94,29 @@
             phx-debounce="blur"
           />
           <.input
-            field={common_k_create_vm_f[:cpu_memory]}
-            label="CPU/메모리"
-            type="text"
+            field={common_k_create_vm_f[:cpu]}
+            label="CPU (vCore)"
+            type="number"
             phx-debounce="blur"
+          />
+          <.input
+            field={common_k_create_vm_f[:memory]}
+            label="Memory (GB)"
+            type="number"
+            phx-debounce="blur"
+          />
+          <.input
+            field={common_k_create_vm_f[:location]}
+            type="select"
+            label={gettext("Location")}
+            prompt="Choose a value"
+            options={Itsm.CommonCodes.get_select_options("장소")}
+            phx-debounce="blur"
+          />
+          <.input
+            field={common_k_create_vm_f[:is_dmz_zone]}
+            label={gettext("Is DMZ?")}
+            type="checkbox"
           />
         </div>
         

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -48,13 +48,13 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
         />
         <.back navigate={~p"/requests"}>Back</.back>
       </div>
-      <%!-- Work Flow sidebar--%>
+       <%!-- Work Flow sidebar--%>
       <.workflow_sidebar
         workflow_type={:service_request}
         resource={@request}
       />
     </div>
-    <.attachment_modal :if={@selected_attachment} attachment={@selected_attachment} />
+     <.attachment_modal :if={@selected_attachment} attachment={@selected_attachment} />
     """
   end
 
@@ -66,9 +66,9 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     ~H"""
     <div class="border-b-2 border-zinc-200 pb-4 mb-4">
       <.header>
-        {@request.title}
+        {@request.category.name}
         <:subtitle>Request ID: {@request.id}</:subtitle>
-
+        
         <:actions>
           <.link navigate={~p"/common_k_create_vm/#{@request}/edit"} class="text-sm text-zinc-700">
             Edit
@@ -86,24 +86,22 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     ~H"""
     <.list>
       <:item title={gettext("Title")}>{@request.title}</:item>
-
+      
       <:item title={gettext("Description")}>{@request.description}</:item>
-
+      
       <:item title={gettext("Environment")}>{@request.env}</:item>
-
+      
       <:item title={gettext("Status")}>{Workflow.status_label(:service_request, @request)}</:item>
-
+      
       <:item title={gettext("Due Date")}>
-        <div id="due_date" phx-hook="LocalTime.ToLocale" format="date" utc-value={@request.due_date} />
+        <div
+          id="due_date"
+          phx-hook="LocalTime.ToLocale"
+          format="datetime"
+          utc-value={@request.due_date}
+        />
       </:item>
-
-      <:item title="Requestor">{@request.requestor_name}</:item>
-      <%!-- <:item title="Assignee">{@request.assignee_name || "-"}</:item> --%>
-      <:item title="Category">{@request.category.name}</:item>
-
-      <%!-- <:item title="Referenced Crew">
-        {Enum.map_join(@request.references, ", ", fn ref -> ref.crew.name end)}
-      </:item> --%>
+      
       <:item title="Referenced Crew">
         <div class="flex flex-wrap items-center gap-3">
           <CustomComponents.crew_tooltip :for={ref <- @request.references} crew={ref.crew} />
@@ -117,43 +115,61 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     ~H"""
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-zinc-700 mb-4">VM 생성 요청</h2>
-
+      
       <div class="space-y-4">
         <div
           :for={{vm, index} <- Enum.with_index(@vms, 1)}
           class="border border-zinc-200 rounded-lg p-4"
         >
           <h3 class="font-semibold text-zinc-800 mb-3">VM #{index}</h3>
-
+          
           <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2">
             <div>
               <dt class="text-sm font-medium text-zinc-500">호스트명</dt>
-
+              
               <dd class="text-sm text-zinc-900">{vm.hostname}</dd>
             </div>
-
+            
             <div>
-              <dt class="text-sm font-medium text-zinc-500">서버 설명</dt>
-
-              <dd class="text-sm text-zinc-900">{vm.description}</dd>
+              <dt class="text-sm font-medium text-zinc-500">서비스명</dt>
+              
+              <dd class="text-sm text-zinc-900">{vm.service_name}</dd>
             </div>
-
+            
             <div>
               <dt class="text-sm font-medium text-zinc-500">OS 종류</dt>
-
+              
               <dd class="text-sm text-zinc-900">{vm.os_image}</dd>
             </div>
-
+            
             <div>
               <dt class="text-sm font-medium text-zinc-500">OS 버전</dt>
-
+              
               <dd class="text-sm text-zinc-900">{vm.os_version}</dd>
             </div>
-
+            
             <div>
-              <dt class="text-sm font-medium text-zinc-500">CPU/메모리</dt>
-
-              <dd class="text-sm text-zinc-900">{vm.cpu_memory}</dd>
+              <dt class="text-sm font-medium text-zinc-500">CPU(vCore)</dt>
+              
+              <dd class="text-sm text-zinc-900">{vm.cpu}</dd>
+            </div>
+            
+            <div>
+              <dt class="text-sm font-medium text-zinc-500">Memory(GB)</dt>
+              
+              <dd class="text-sm text-zinc-900">{vm.memory}</dd>
+            </div>
+            
+            <div>
+              <dt class="text-sm font-medium text-zinc-500">{gettext("Location")}</dt>
+              
+              <dd class="text-sm text-zinc-900">{vm.location}</dd>
+            </div>
+            
+            <div>
+              <dt class="text-sm font-medium text-zinc-500">{gettext("Is DMZ?")}</dt>
+              
+              <dd class="text-sm text-zinc-900">{vm.is_dmz_zone}</dd>
             </div>
           </dl>
         </div>
@@ -166,7 +182,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     ~H"""
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-zinc-700 mb-4">첨부파일 ({length(@attachments)})</h2>
-
+      
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
         <div
           :for={attachment <- @attachments}
@@ -182,13 +198,13 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
               class="w-full h-full object-cover"
             />
           </div>
-
+          
           <div class="p-2 bg-white">
             <p class="text-xs text-zinc-700 truncate">{attachment.filename}</p>
-
+            
             <p class="text-xs text-zinc-400">{format_file_size(attachment.byte_size)}</p>
           </div>
-
+          
           <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
             <.icon name="hero-magnifying-glass-plus" class="w-8 h-8 text-white" />
           </div>
@@ -202,7 +218,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     ~H"""
     <div class="mt-8 bg-white rounded-lg shadow-sm border border-slate-200 p-6">
       <div class="text-lg font-semibold text-slate-900 mb-4">Activity & Comments</div>
-
+      
       <div id="comments" phx-update="stream">
         <.comment_item :for={{dom_id, comment} <- @streams.comments} comment={comment} id={dom_id} />
       </div>
@@ -224,13 +240,13 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
           >
           </span>
         </div>
-
+        
         <div class="bg-slate-50 rounded-lg p-3">
           <p class="text-sm text-slate-700 whitespace-pre-wrap">{@comment.comment}</p>
-
+          
           <div :if={Enum.any?(@comment.attachments)} class="mt-3 pt-2 border-t border-slate-200">
             <p class="text-xs text-slate-400 mb-2 font-medium">Attachments</p>
-
+            
             <div class="flex flex-wrap gap-2">
               <div
                 :for={attachment <- @comment.attachments}
@@ -242,7 +258,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
                 <div class="bg-blue-50 text-blue-600 rounded p-0.5">
                   <.icon name="hero-paper-clip" class="w-3 h-3" />
                 </div>
-
+                
                 <span class="text-xs text-slate-600 group-hover:text-blue-600 max-w-[158px] truncate">
                   {attachment.filename}
                 </span>
@@ -273,11 +289,11 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
             {length(@uploads.attachment.entries)}개 선택됨
           </span>
         </div>
-        <.button phx-disable-with="Saving..." class="text-xs px-3 py-1.5">Add Comment</.button>
+         <.button phx-disable-with="Saving..." class="text-xs px-3 py-1.5">Add Comment</.button>
       </div>
-
+      
       <.error :for={err <- upload_errors(@uploads.attachment)}>{Phoenix.Naming.humanize(err)}</.error>
-
+      
       <div
         :if={length(@uploads.attachment.entries) > 0}
         class="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-4"
@@ -289,11 +305,11 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
           <div class="aspect-square bg-zinc-100 rounded-md overflow-hidden mb-2">
             <.live_img_preview entry={entry} class="w-full h-full object-cover" />
           </div>
-
+          
           <p class="text-xs text-zinc-600 truncate px-1">{entry.client_name}</p>
-
+          
           <p class="text-xs text-zinc-400">{format_file_size(entry.client_size)}</p>
-
+          
           <button
             type="button"
             phx-click="cancel-upload"

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -243,3 +243,14 @@ msgstr "결제목록"
 
 msgid "Comments"
 msgstr "댓글목록"
+
+msgid "Service Name"
+msgstr "서비스명"
+
+msgid "Is DMZ?"
+msgstr "DMZ 설치여부"
+
+msgid "Task Name"
+msgstr "작업명"
+
+

--- a/priv/repo/migrations/20260226051834_create_os_instances.exs
+++ b/priv/repo/migrations/20260226051834_create_os_instances.exs
@@ -1,0 +1,21 @@
+defmodule Itsm.Repo.Migrations.CreateOsInstances do
+  use Ecto.Migration
+
+  def change do
+    create table(:os_instances, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :ip, :string
+      add :os_type, :string
+      add :os_version, :string
+      add :cpu_core, :integer
+      add :memory_gb, :integer
+      add :asset_id, references(:assets, on_delete: :nothing, type: :binary_id)
+      add :crew_id, references(:crews, on_delete: :nothing, type: :binary_id)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:os_instances, [:asset_id])
+    create index(:os_instances, [:crew_id])
+  end
+end

--- a/priv/repo/migrations/20260227004805_add_category_to_categories.exs
+++ b/priv/repo/migrations/20260227004805_add_category_to_categories.exs
@@ -1,0 +1,9 @@
+defmodule Itsm.Repo.Migrations.AddCategoryToCategories do
+  use Ecto.Migration
+
+  def change do
+    alter table(:categories) do
+      add :category, :string
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -197,6 +197,7 @@ bbbbb =
   request_name: "common_k_create_vm",
   affiliate: "FG",
   duration: 80,
+  category: "서버",
   assignee_crew_id: aaaaa.id
 }
 |> Repo.insert!()
@@ -211,6 +212,7 @@ bbbbb =
   request_name: "bank_k_resize_vm",
   affiliate: "B0",
   duration: 70,
+  category: "서버",
   assignee_crew_id: bbbbb.id
 }
 |> Repo.insert!()
@@ -266,14 +268,13 @@ defmodule Itsm.Repo.Seeds.InsertCommonCodes do
       %{code: "본사", label: "본사", description: "본사 입니다."},
       %{code: "여의도IT센터", label: "여의도IT센터", description: "여의도IT센터 입니다."},
       %{code: "김포IT센터", label: "김포IT센터", description: "김포IT센터 입니다."},
-      %{code: "지점", label: "지점", description: "지점 입니다."}
+      %{code: "영업점", label: "영업점", description: "영업점 입니다."}
     ]
 
     category = [
       %{code: "서버", label: "서버", description: "서버 자산입니다."},
       %{code: "네트워크", label: "네트워크", description: "네트워크 자산입니다."},
       %{code: "스토리지", label: "스토리지", description: "스토리지 자산입니다."},
-      %{code: "하이퍼바이저", label: "하이퍼바이저", description: "하이퍼바이저 자산입니다."},
       %{code: "어플라이언스", label: "어플라이언스", description: "어플라이언스 자산입니다."}
     ]
 
@@ -302,10 +303,11 @@ defmodule Itsm.Repo.Seeds.InsertCommonCodes do
     ]
 
     infra_type = [
-      %{code: "온프레미스", label: "온프레미스", description: "온프레미스 입니다."},
-      %{code: "AWS", label: "AWS", description: "AWS 입니다."},
-      %{code: "Azure", label: "Azure", description: "Azure 입니다."},
-      %{code: "어플라이언스", label: "어플라이언스", description: "어플라이언스 입니다."}
+      %{code: "bare_metal", label: "베어메탈", description: "일반 x86/Unix 물리 장비"},
+      %{code: "hypervisor", label: "하이퍼바이저", description: "VMware ESXi 등 가상화를 제공하는 물리 호스트"},
+      %{code: "private_cloud", label: "프라이빗 클라우드", description: "사내 하이퍼바이저 위에서 구동되는 가상 머신(VM)"},
+      %{code: "public_cloud", label: "퍼블릭 클라우드", description: "AWS, Azure 등 외부 클라우드 자원"},
+      %{code: "mainframe", label: "메인프레임", description: "코어뱅킹용 메인프레임 시스템"}
     ]
 
     reason = [

--- a/test/itsm/os_instances_test.exs
+++ b/test/itsm/os_instances_test.exs
@@ -1,0 +1,69 @@
+defmodule Itsm.OsInstancesTest do
+  use Itsm.DataCase
+
+  alias Itsm.OsInstances
+
+  describe "os_instances" do
+    alias Itsm.OsInstances.OsInstance
+
+    import Itsm.OsInstancesFixtures
+
+    @invalid_attrs %{os_type: nil, os_version: nil, ip: nil, hostname: nil, cpu_core: nil, memory_gb: nil}
+
+    test "list_os_instances/0 returns all os_instances" do
+      os_instance = os_instance_fixture()
+      assert OsInstances.list_os_instances() == [os_instance]
+    end
+
+    test "get_os_instance!/1 returns the os_instance with given id" do
+      os_instance = os_instance_fixture()
+      assert OsInstances.get_os_instance!(os_instance.id) == os_instance
+    end
+
+    test "create_os_instance/1 with valid data creates a os_instance" do
+      valid_attrs = %{os_type: :linux, os_version: "some os_version", ip: "some ip", hostname: "some hostname", cpu_core: 42, memory_gb: 42}
+
+      assert {:ok, %OsInstance{} = os_instance} = OsInstances.create_os_instance(valid_attrs)
+      assert os_instance.os_type == :linux
+      assert os_instance.os_version == "some os_version"
+      assert os_instance.ip == "some ip"
+      assert os_instance.hostname == "some hostname"
+      assert os_instance.cpu_core == 42
+      assert os_instance.memory_gb == 42
+    end
+
+    test "create_os_instance/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = OsInstances.create_os_instance(@invalid_attrs)
+    end
+
+    test "update_os_instance/2 with valid data updates the os_instance" do
+      os_instance = os_instance_fixture()
+      update_attrs = %{os_type: :windows, os_version: "some updated os_version", ip: "some updated ip", hostname: "some updated hostname", cpu_core: 43, memory_gb: 43}
+
+      assert {:ok, %OsInstance{} = os_instance} = OsInstances.update_os_instance(os_instance, update_attrs)
+      assert os_instance.os_type == :windows
+      assert os_instance.os_version == "some updated os_version"
+      assert os_instance.ip == "some updated ip"
+      assert os_instance.hostname == "some updated hostname"
+      assert os_instance.cpu_core == 43
+      assert os_instance.memory_gb == 43
+    end
+
+    test "update_os_instance/2 with invalid data returns error changeset" do
+      os_instance = os_instance_fixture()
+      assert {:error, %Ecto.Changeset{}} = OsInstances.update_os_instance(os_instance, @invalid_attrs)
+      assert os_instance == OsInstances.get_os_instance!(os_instance.id)
+    end
+
+    test "delete_os_instance/1 deletes the os_instance" do
+      os_instance = os_instance_fixture()
+      assert {:ok, %OsInstance{}} = OsInstances.delete_os_instance(os_instance)
+      assert_raise Ecto.NoResultsError, fn -> OsInstances.get_os_instance!(os_instance.id) end
+    end
+
+    test "change_os_instance/1 returns a os_instance changeset" do
+      os_instance = os_instance_fixture()
+      assert %Ecto.Changeset{} = OsInstances.change_os_instance(os_instance)
+    end
+  end
+end

--- a/test/support/fixtures/os_instances_fixtures.ex
+++ b/test/support/fixtures/os_instances_fixtures.ex
@@ -1,0 +1,25 @@
+defmodule Itsm.OsInstancesFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Itsm.OsInstances` context.
+  """
+
+  @doc """
+  Generate a os_instance.
+  """
+  def os_instance_fixture(attrs \\ %{}) do
+    {:ok, os_instance} =
+      attrs
+      |> Enum.into(%{
+        cpu_core: 42,
+        hostname: "some hostname",
+        ip: "some ip",
+        memory_gb: 42,
+        os_type: :linux,
+        os_version: "some os_version"
+      })
+      |> Itsm.OsInstances.create_os_instance()
+
+    os_instance
+  end
+end


### PR DESCRIPTION
Assets 생성 과정

0. SR을 통해 VM 생성 요청(work flow 진행)
1. Approvals 컨텍스트에서 SR의 status 변경 확인 (:finish -> :confirmation)
2. 상태 변경 확인되면 Finalization 모듈로 위임
3. Itsm.Finalization 컨택스트에서 request_name으로 작업 분기 (현재는 common_k_create_vm만 해당)
4. Itsm.Assets에서 전달받은 데이터를 바탕으로 실제 자산 데이터를 생성 (OsInstance 한번에 insert)

pubsub 연결도 해놓은 상태인데, 함수가 무거워진거 같기도 하고, 결합도도 증가한거 같아서 고민이 되네요.