### PR TITLE
3.12 Assets 관련

### DIFF
--- a/lib/itsm/assets.ex
+++ b/lib/itsm/assets.ex
@@ -10,6 +10,10 @@ defmodule Itsm.Assets do
   alias Itsm.Repo
   alias Itsm.OsInstances
 
+  # 추후 db_instance, was_instance 등이 추가되면 이곳에 preload를 덧붙이면 됩니다.
+  # @resource_preloads [:os_instance, :db_instances, :was_instances, :applications]
+  @resource_preloads [:os_instance]
+
   # ==================================================
   # PubSub
   # ==================================================
@@ -61,6 +65,16 @@ defmodule Itsm.Assets do
 
   """
   def get_asset!(id), do: Repo.get!(Asset, id)
+
+  @doc """
+  Asset 단건 조회 시 연관된 Instance를 함께 가져옵니다.
+  차후 db_instance, was_instance 등이 추가되면 이곳에 preload를 덧붙이면 됩니다.
+  """
+  def get_asset_with_relations!(id) do
+    Asset
+    |> Repo.get!(id)
+    |> Repo.preload(@resource_preloads)
+  end
 
   @doc """
   Creates a asset.

--- a/lib/itsm/assets/asset.ex
+++ b/lib/itsm/assets/asset.ex
@@ -25,6 +25,10 @@ defmodule Itsm.Assets.Asset do
 
     has_one :os_instance, Itsm.OsInstances.OsInstance
 
+    # 추후 추가
+    # has_many :db_instances, Itsm.DbInstances.DbInstance
+    # has_many :was_instances, Itsm.WasInstances.WasInstance
+
     belongs_to :service_crew, Itsm.Crews.Crew, type: :binary_id
     belongs_to :system_crew, Itsm.Crews.Crew, type: :binary_id
 

--- a/lib/itsm/assets/resource_card_data.ex
+++ b/lib/itsm/assets/resource_card_data.ex
@@ -1,0 +1,6 @@
+defprotocol Itsm.Assets.ResourceCardData do
+  @doc """
+  각 인스턴스 struct를 resource_card 컴포넌트가 이해하는   %{name, badge, details} 형태로 변환한다.
+  """
+  def to_card_item(instance)
+end

--- a/lib/itsm/os_instances/os_instance.ex
+++ b/lib/itsm/os_instances/os_instance.ex
@@ -25,4 +25,18 @@ defmodule Itsm.OsInstances.OsInstance do
     |> cast(attrs, [:ip, :os_type, :os_version, :cpu_core, :memory_gb, :asset_id, :crew_id])
     |> validate_required([:ip, :os_type, :os_version, :cpu_core, :memory_gb, :asset_id, :crew_id])
   end
+
+  defimpl Itsm.Assets.ResourceCardData, for: Itsm.OsInstances.OsInstance do
+    def to_card_item(os) do
+      %{
+        name: os.os_type,
+        badge: os.os_version,
+        details: [
+          {"IP Address", os.ip},
+          {"CPU Core", "#{os.cpu_core} Cores"},
+          {"Memory", "#{os.memory_gb} GB"}
+        ]
+      }
+    end
+  end
 end

--- a/lib/itsm_web/components/resource_components.ex
+++ b/lib/itsm_web/components/resource_components.ex
@@ -1,0 +1,55 @@
+defmodule ItsmWeb.ResourceComponents do
+  use Phoenix.Component
+
+  import ItsmWeb.CoreComponents
+
+  @doc """
+  범용 리소스 카드. items는 [%{name, badge, details: [{label, value}]}] 형태.
+  리소스 요약이 필요할 경우에는 resource_badge 또는 resource_summary 컴포넌트를 별도로 만들어서 items에 추가하는 형태로 확장
+  """
+  attr :title, :string, required: true
+  attr :icon, :string, required: true
+  attr :icon_class, :string, default: "text-zinc-500"
+  attr :items, :list, required: true
+
+  def resource_card(assigns) do
+    ~H"""
+    <div class="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <div class="flex items-center gap-2 mb-4">
+        <%!-- <.icon name={@icon} class={["h-5 w-5", @icon_class]} /> --%>
+        <.icon name={@icon} class={"h-5 w-5 #{@icon_class}"} />
+        <h4 class="font-medium text-zinc-900">{@title}</h4>
+      </div>
+      
+      <%= if Enum.empty?(@items) do %>
+        <div class="flex h-32 flex-col items-center justify-center rounded-lg border border-dashed border-zinc-300 bg-zinc-50 text-center text-zinc-500">
+          <.icon name="hero-inbox" class="h-6 w-6 text-zinc-300 mb-2" />
+          <p class="text-sm">No {String.downcase(@title)} connected.</p>
+        </div>
+      <% else %>
+        <div class="space-y-4">
+          <%= for item <- @items do %>
+            <div class="rounded-lg border border-zinc-100 bg-zinc-50 p-4">
+              <div class="flex items-center justify-between mb-3">
+                <span class="font-semibold text-zinc-900">{item.name}</span>
+                <span class="inline-flex items-center rounded-md border border-zinc-200 bg-white px-2 py-0.5 text-xs font-medium text-zinc-600 shadow-sm">
+                  {item.badge}
+                </span>
+              </div>
+              
+              <div class="mt-4 space-y-3 text-sm">
+                <%= for {label, value} <- item.details do %>
+                  <div class="flex justify-between items-center border-b border-zinc-100 pb-2 last:border-0 last:pb-0">
+                    <span class="text-zinc-500">{label}</span>
+                    <span class="font-medium text-zinc-900">{value}</span>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/itsm_web/live/asset_live/show.ex
+++ b/lib/itsm_web/live/asset_live/show.ex
@@ -1,7 +1,9 @@
 defmodule ItsmWeb.AssetLive.Show do
   use ItsmWeb, :live_view
 
+  import ItsmWeb.ResourceComponents
   alias Itsm.Assets
+  alias Itsm.Assets.ResourceCardData
 
   @impl true
   def mount(_params, _session, socket) do
@@ -13,7 +15,44 @@ defmodule ItsmWeb.AssetLive.Show do
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:asset, Assets.get_asset!(id))}
+     |> assign(:asset, Assets.get_asset_with_relations!(id))}
+  end
+
+  # 리소스 섹션 정의 — 새 인스턴스 타입 추가 시 여기에 항목만 추가
+  defp resource_sections(asset) do
+    [
+      %{
+        title: "Operating System",
+        icon: "hero-computer-desktop",
+        icon_class: "text-indigo-500",
+        items: build_items(asset.os_instance)
+      }
+      # TODO : DB 추가 시 아래처럼 항목 추가
+      # %{
+      #   title: "Database",
+      #   icon: "hero-circle-stack",
+      #   icon_class: "text-emerald-500",
+      #   items: build_items(asset.db_instances)
+      # },
+      # TODO : WAS 추가 시 아래처럼 항목 추가
+      # %{
+      #   title: "WAS",
+      #   icon: "hero-cube",
+      #   icon_class: "text-orange-500",
+      #   items: build_was_data(asset.was_instances)
+      # }
+    ]
+  end
+
+  # Protocol 기반 범용 변환 함수
+  defp build_items(nil), do: []
+  defp build_items(%Ecto.Association.NotLoaded{}), do: []
+
+  defp build_items(instance) when is_struct(instance),
+    do: [ResourceCardData.to_card_item(instance)]
+
+  defp build_items(instances) when is_list(instances) do
+    Enum.map(instances, &ResourceCardData.to_card_item/1)
   end
 
   defp page_title(:show), do: "Show Asset"

--- a/lib/itsm_web/live/asset_live/show.html.heex
+++ b/lib/itsm_web/live/asset_live/show.html.heex
@@ -1,44 +1,111 @@
-<.header>
-  Asset {@asset.id}
-  <:subtitle>This is a asset record from your database.</:subtitle>
+<div class="mx-auto max-w-5xl">
+  <div class="flex flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
+    <div class="border-b border-zinc-200 bg-white p-6">
+      <div class="flex items-start gap-4">
+        <div class="flex h-14 w-14 items-center justify-center rounded-xl bg-blue-50 ring-1 ring-blue-200">
+          <.icon name="hero-server-solid" class="h-7 w-7 text-blue-600" />
+        </div>
+        
+        <div class="flex-1">
+          <div class="flex justify-between items-start">
+            <div>
+              <h2 class="text-xl font-semibold text-zinc-900">{@asset.name}</h2>
+              
+              <p class="mt-0.5 font-mono text-sm text-zinc-500">{@asset.id}</p>
+            </div>
+            
+            <div class="flex gap-2">
+              <.link patch={~p"/assets/#{@asset}/show/edit"} phx-click={JS.push_focus()}>
+                <.button class="flex items-center gap-2 bg-white text-zinc-700 border border-zinc-300 hover:bg-zinc-50">
+                  <.icon name="hero-pencil-square" class="h-4 w-4" /> Edit Asset
+                </.button>
+              </.link>
+            </div>
+          </div>
+          
+          <div class="mt-3 flex flex-wrap gap-2">
+            <span class="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700">
+              {@asset.category}
+            </span>
+            <span class="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-medium text-zinc-700">
+              {@asset.env}
+            </span>
+            <span class="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-medium text-zinc-700">
+              {@asset.affiliate}
+            </span>
+            <%= if @asset.is_dmz_zone do %>
+              <span class="inline-flex items-center gap-1 rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs font-medium text-red-700">
+                <.icon name="hero-shield-check-solid" class="h-3 w-3" /> DMZ Zone
+              </span>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      
+      <div class="my-6 border-t border-zinc-100"></div>
+      
+      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div class="flex items-center gap-2">
+          <.icon name="hero-map-pin" class="h-5 w-5 text-zinc-400" />
+          <div>
+            <p class="text-xs text-zinc-500">Location</p>
+            
+            <p class="text-sm font-medium text-zinc-900">{@asset.location}</p>
+          </div>
+        </div>
+        
+        <div class="flex items-center gap-2">
+          <.icon name="hero-building-office-2" class="h-5 w-5 text-zinc-400" />
+          <div>
+            <p class="text-xs text-zinc-500">Region</p>
+            
+            <p class="text-sm font-medium text-zinc-900">{@asset.region_type}</p>
+          </div>
+        </div>
+        
+        <div class="flex items-center gap-2">
+          <.icon name="hero-cloud" class="h-5 w-5 text-zinc-400" />
+          <div>
+            <p class="text-xs text-zinc-500">Infrastructure</p>
+            
+            <p class="text-sm font-medium text-zinc-900">{@asset.infra_type}</p>
+          </div>
+        </div>
+        
+        <div class="flex items-center gap-2">
+          <.icon name="hero-calendar" class="h-5 w-5 text-zinc-400" />
+          <div>
+            <p class="text-xs text-zinc-500">Created Date</p>
+            
+            <p class="text-sm font-medium text-zinc-900">
+              {Calendar.strftime(@asset.inserted_at, "%Y-%m-%d %H:%M")}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="flex-1 bg-zinc-50 p-6">
+      <h3 class="mb-4 text-sm font-semibold uppercase tracking-wide text-zinc-500">
+        Connected Resources
+      </h3>
+      
+      <div class="grid gap-4 lg:grid-cols-2">
+        <.resource_card
+          :for={section <- resource_sections(@asset)}
+          title={section.title}
+          icon={section.icon}
+          icon_class={section.icon_class}
+          items={section.items}
+        />
+      </div>
+    </div>
+  </div>
   
-  <:actions>
-    <.link patch={~p"/assets/#{@asset}/show/edit"} phx-click={JS.push_focus()}>
-      <.button>Edit asset</.button>
-    </.link>
-  </:actions>
-</.header>
-
-<.list>
-  <:item title={gettext("Name")}>{@asset.name}</:item>
-  
-  <:item title={gettext("Description")}>{@asset.description}</:item>
-  
-  <:item title={gettext("Affiliate")}>{@asset.affiliate}</:item>
-  
-  <:item title={gettext("Category")}>{@asset.category}</:item>
-  
-  <:item title={gettext("Region type")}>{@asset.region_type}</:item>
-  
-  <:item title={gettext("Infra type")}>{@asset.infra_type}</:item>
-  
-  <:item title={gettext("Environment")}>{@asset.env}</:item>
-  
-  <:item title={gettext("Location")}>{@asset.location}</:item>
-  
-  <:item title={gettext("Is dmz zone")}>{@asset.is_dmz_zone}</:item>
-  
-  <:item title={gettext("Created Date")}>
-    <div
-      id="created_date"
-      phx-hook="LocalTime.ToLocale"
-      format="datetime"
-      utc-value={@asset.inserted_at}
-    />
-  </:item>
-</.list>
-
-<.back navigate={~p"/assets"}>Back to assets</.back>
+  <div class="mt-6">
+    <.back navigate={~p"/assets"}>Back to assets</.back>
+  </div>
+</div>
 
 <.modal
   :if={@live_action == :edit}


### PR DESCRIPTION
Asset 상세(Show) 화면의 Connected Resources 영역을 **Protocol 기반 범용 구조**로 변경
_템플릿(show.html.heex)과 컴포넌트(resource_card_components.ex)는 수정 불필요_

```
lib/itsm/assets/resource_card_data.ex  #Protocol 정의 — to_card_item/1 계약(contract) 선언
lib/itsm_web/components/resource_components.ex #resource_card/1 범용 컴포넌트 (Show에서 분리)
```

새 인스턴스 타입 추가 시 수정이 필요한 부분
1. asset.ex — has_many :xx_instances, Itsm.XxInstances.XxInstance 추가
2. xx_instance.ex — 스키마 모듈 하단에 defimpl ResourceCardData 추가
3. assets.ex — @resource_preloads에 :xx_instances 추가
4. show.ex — resource_sections/1에 항목 추가

