### PR TITLE
[refactor]Utility 모듈 네이밍 컨벤션 통일 (Util -> Utils)

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -21,7 +21,7 @@ config :itsm, ItsmWeb.Endpoint,
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
   http: [
     ip: {127, 0, 0, 1},
-    port: 14000
+    port: 4000
     # thousand_island_options: [
     #   read_timeout: 300_000
     # ]

--- a/lib/itsm/admin/approvals.ex
+++ b/lib/itsm/admin/approvals.ex
@@ -12,7 +12,7 @@ defmodule Itsm.Admin.Approvals do
 
   def change_approval(%Approval{} = approval, attrs \\ %{}) do
     Approval.changeset(approval, attrs)
-    |> Itsm.Util.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
   end
 
   defdelegate create_approval(attrs \\ %{}), to: Itsm.Approvals
@@ -20,7 +20,7 @@ defmodule Itsm.Admin.Approvals do
   def update_approval(%Approval{} = approval, attrs) do
     approval
     |> Approval.admin_changeset(attrs)
-    |> Itsm.Util.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
     |> Repo.update()
   end
 

--- a/lib/itsm/admin/assets.ex
+++ b/lib/itsm/admin/assets.ex
@@ -12,7 +12,7 @@ defmodule Itsm.Admin.Assets do
 
   def change_asset(%Asset{} = asset, attrs \\ %{}) do
     Asset.changeset(asset, attrs)
-    |> Itsm.Util.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
   end
 
   defdelegate create_asset(attrs \\ %{}), to: Itsm.Assets
@@ -20,7 +20,7 @@ defmodule Itsm.Admin.Assets do
   def update_asset(%Asset{} = asset, attrs) do
     asset
     |> Asset.changeset(attrs)
-    |> Itsm.Util.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
     |> Repo.update()
   end
 

--- a/lib/itsm/admin/categories.ex
+++ b/lib/itsm/admin/categories.ex
@@ -9,7 +9,7 @@ defmodule Itsm.Admin.Categories do
 
   def change_category(%Category{} = category, attrs \\ %{}) do
     Category.changeset(category, attrs)
-    |> Itsm.Util.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
   end
 
   def create_category(attrs \\ %{}) do
@@ -21,7 +21,7 @@ defmodule Itsm.Admin.Categories do
   def update_category(%Category{} = category, attrs) do
     category
     |> Category.changeset(attrs)
-    |> Itsm.Util.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
     |> Repo.update()
   end
 

--- a/lib/itsm/attachments.ex
+++ b/lib/itsm/attachments.ex
@@ -2,7 +2,7 @@ defmodule Itsm.Attachments do
   import Ecto.Query, warn: false
 
   alias Itsm.Repo
-  alias Itsm.Util
+  alias Itsm.Utils
   alias Itsm.Attachments.Attachment
 
   def get_attachment!(id) do
@@ -20,7 +20,7 @@ defmodule Itsm.Attachments do
     attachments = attachments_callback.()
 
     Enum.reduce_while(attachments, {:ok, []}, fn attrs, {:ok, acc} ->
-      %Attachment{resource_type: Util.resource_name(resource), resource_id: resource.id}
+      %Attachment{resource_type: Utils.resource_name(resource), resource_id: resource.id}
       |> Attachment.changeset(attrs)
       |> repo.insert()
       |> case do

--- a/lib/itsm/comments.ex
+++ b/lib/itsm/comments.ex
@@ -5,7 +5,7 @@ defmodule Itsm.Comments do
   alias Itsm.Comments.Comment
   alias Itsm.Accounts.User
   alias Itsm.Requests
-  alias Itsm.Util
+  alias Itsm.Utils
 
   # 결과 처리
   def broadcast_result({:ok, %{comment: comment}}, topic_id) do
@@ -20,7 +20,7 @@ defmodule Itsm.Comments do
   def list_comments(resource) do
     Comment
     # "Request"
-    |> where([c], c.resource_type == ^Util.resource_name(resource))
+    |> where([c], c.resource_type == ^Utils.resource_name(resource))
     # ID 매칭
     |> where([c], c.resource_id == ^resource.id)
     |> order_by([c], asc: c.inserted_at)
@@ -32,7 +32,7 @@ defmodule Itsm.Comments do
   def changeset_comment(resource, %User{} = user, attrs \\ %{}) do
     %Comment{
       user: user,
-      resource_type: Util.resource_name(resource),
+      resource_type: Utils.resource_name(resource),
       resource_id: resource.id
     }
     |> Comment.changeset(attrs)

--- a/lib/itsm/utils.ex
+++ b/lib/itsm/utils.ex
@@ -1,4 +1,4 @@
-defmodule Itsm.Util do
+defmodule Itsm.Utils do
   @moduledoc """
   ITSM 개발에 필요한 BIZ모듈에서 사용할 Util메소드 정의 합니다.
   """

--- a/lib/itsm_web/components/layouts/admin.html.heex
+++ b/lib/itsm_web/components/layouts/admin.html.heex
@@ -9,20 +9,20 @@
           {gettext("Admin") <> " " <> gettext("Console")}
         </span>
       </div>
-
+      
       <div :if={@current_user} class="hidden lg:flex items-center gap-5 center">
         <nav class="flex gap-5">
           <.link
-            :for={menu <- ItsmWeb.RouterUtil.admin_menu_items()}
+            :for={menu <- ItsmWeb.RouterUtils.admin_menu_items()}
             href={menu.path}
             class="text-base font-bold text-gray-700 hover:text-kb-yellow transition-colors"
           >
             {Gettext.gettext(ItsmWeb.Gettext, menu.name)}
           </.link>
         </nav>
-
+        
         <div class="h-4 w-px bg-gray-300"></div>
-
+        
         <div class="flex items-center gap-4">
           <% is_ko = Gettext.get_locale(ItsmWeb.Gettext) == "ko" %>
           <div class="flex items-center gap-2">
@@ -49,9 +49,9 @@
               EN
             </span>
           </div>
-
+          
           <div class="h-4 w-px bg-gray-300 mx-1"></div>
-
+          
           <div class="flex items-center gap-3 text-sm font-medium">
             <span class="text-kb-dark-gray truncate max-w-[120px]">{@current_user.email}</span>
             <.link href={~p"/users/settings"} class="text-gray-400 hover:text-kb-blue">

--- a/lib/itsm_web/live/common_k_create_vm_live/form.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/form.ex
@@ -8,14 +8,14 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   alias Itsm.Service.Request
   alias Itsm.Team
   alias Itsm.Crews
-  alias ItsmWeb.LiveUtil
+  alias ItsmWeb.LiveUtils
 
   def mount(params, _session, socket) do
     crew_options = Accounts.crew_ids_names(socket.assigns.current_user)
 
     {:ok,
      socket
-     |> LiveUtil.allow_uploads()
+     |> LiveUtils.allow_uploads()
      |> assign(:crew_options, crew_options)
      |> apply_action(socket.assigns.live_action, params)}
   end
@@ -149,7 +149,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
     case Service.create_request(
            user,
            category,
-           fn -> LiveUtil.consume_attachments(socket) end,
+           fn -> LiveUtils.consume_attachments(socket) end,
            request_params
          ) do
       {:ok, request} ->
@@ -167,7 +167,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
       {:error, step, _changeset, _so_far_changeset} ->
         changeset =
           socket.assigns.form.source
-          |> Ecto.Changeset.add_error(:base, LiveUtil.translate_step_error(step))
+          |> Ecto.Changeset.add_error(:base, LiveUtils.translate_step_error(step))
           |> Map.put(:action, :insert)
 
         {:noreply,

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -8,7 +8,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
   alias Itsm.Comments
   alias Itsm.Comments.Comment
   alias Itsm.Requests
-  alias ItsmWeb.LiveUtil
+  alias ItsmWeb.LiveUtils
   alias Itsm.Workflow
   alias Itsm.Service
   alias ItsmWeb.CustomComponents
@@ -17,7 +17,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     {:ok,
      socket
      |> assign(:form, to_form(Comments.change_comment(%Comment{})))
-     |> LiveUtil.allow_uploads()}
+     |> LiveUtils.allow_uploads()}
   end
 
   def handle_params(%{"id" => id}, _uri, socket) do
@@ -374,7 +374,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     case Service.create_comment(
            request,
            current_user,
-           fn -> LiveUtil.consume_attachments(socket) end,
+           fn -> LiveUtils.consume_attachments(socket) end,
            comment_params
          ) do
       {:ok, _comment} ->

--- a/lib/itsm_web/live/crew_live/form_component.ex
+++ b/lib/itsm_web/live/crew_live/form_component.ex
@@ -2,7 +2,7 @@ defmodule ItsmWeb.CrewLive.FormComponent do
   use ItsmWeb, :live_component
 
   alias Itsm.Crews
-  alias ItsmWeb.LiveUtil
+  alias ItsmWeb.LiveUtils
 
   def update(%{crew: crew} = assigns, socket) do
     {:ok,
@@ -63,7 +63,7 @@ defmodule ItsmWeb.CrewLive.FormComponent do
       {:error, step} ->
         {:noreply,
          socket
-         |> put_flash(:error, LiveUtil.translate_error(step, :crew, "update_crew"))
+         |> put_flash(:error, LiveUtils.translate_error(step, :crew, "update_crew"))
          |> push_patch(to: socket.assigns.patch)}
 
       {:error, _step, %Ecto.Changeset{} = changeset} ->

--- a/lib/itsm_web/live/crew_live/index.ex
+++ b/lib/itsm_web/live/crew_live/index.ex
@@ -4,7 +4,7 @@ defmodule ItsmWeb.CrewLive.Index do
   alias Itsm.Crews
   alias Itsm.Crews.Crew
   alias Itsm.Accounts.User
-  alias ItsmWeb.LiveUtil
+  alias ItsmWeb.LiveUtils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
@@ -57,7 +57,7 @@ defmodule ItsmWeb.CrewLive.Index do
 
       {:error, step} ->
         {:noreply,
-         put_flash(socket, :error, LiveUtil.translate_error(step, :crew, "delete_crew"))}
+         put_flash(socket, :error, LiveUtils.translate_error(step, :crew, "delete_crew"))}
     end
   end
 

--- a/lib/itsm_web/live/crew_live/show.ex
+++ b/lib/itsm_web/live/crew_live/show.ex
@@ -3,7 +3,7 @@ defmodule ItsmWeb.CrewLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
-  alias ItsmWeb.LiveUtil
+  alias ItsmWeb.LiveUtils
 
   def mount(params, _session, socket) do
     back_path = params["return_to"] || ~p"/crews"
@@ -52,7 +52,7 @@ defmodule ItsmWeb.CrewLive.Show do
         {:noreply, put_flash(socket, :info, msg)}
 
       {:error, step} ->
-        {:noreply, put_flash(socket, :error, LiveUtil.translate_error(step, :crew))}
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
     end
   end
 
@@ -142,7 +142,7 @@ defmodule ItsmWeb.CrewLive.Show do
         {:noreply, put_flash(socket, :info, "Members added successfully")}
 
       {:error, step} ->
-        {:noreply, put_flash(socket, :error, LiveUtil.translate_error(step, :crew))}
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
     end
   end
 
@@ -154,7 +154,7 @@ defmodule ItsmWeb.CrewLive.Show do
         {:noreply, put_flash(socket, :info, "Leader changed successfully")}
 
       {:error, step} ->
-        {:noreply, put_flash(socket, :error, LiveUtil.translate_error(step, :crew))}
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
     end
   end
 end

--- a/lib/itsm_web/live/crew_live/table_components.ex
+++ b/lib/itsm_web/live/crew_live/table_components.ex
@@ -1,7 +1,7 @@
 defmodule ItsmWeb.CrewLive.TableComponents do
   use ItsmWeb, :html
 
-  alias ItsmWeb.LiveUtil
+  alias ItsmWeb.LiveUtils
 
   def crew_table(assigns) do
     assigns = assign_new(assigns, :action, fn -> [] end)
@@ -13,15 +13,15 @@ defmodule ItsmWeb.CrewLive.TableComponents do
       <:col :let={{_id, crew}} label={gettext("Description")}>{crew.description}</:col>
       
       <:col :let={{_id, crew}} label={gettext("Organization")}>
-        {Itsm.CommonCodes.get_label("계열사", LiveUtil.fetch_safe(crew.leader, :organization_code))}
+        {Itsm.CommonCodes.get_label("계열사", LiveUtils.fetch_safe(crew.leader, :organization_code))}
       </:col>
       
       <:col :let={{_id, crew}} label={gettext("Department")}>
-        {LiveUtil.fetch_safe(crew.leader, :department)}
+        {LiveUtils.fetch_safe(crew.leader, :department)}
       </:col>
       
       <:col :let={{_id, crew}} label={gettext("Leader")}>
-        {LiveUtil.fetch_safe(crew.leader, :display_name)}
+        {LiveUtils.fetch_safe(crew.leader, :display_name)}
       </:col>
       
       <%!--

--- a/lib/itsm_web/live_utils.ex
+++ b/lib/itsm_web/live_utils.ex
@@ -1,4 +1,4 @@
-defmodule ItsmWeb.LiveUtil do
+defmodule ItsmWeb.LiveUtils do
   @moduledoc """
   ITSM 개발에 필요한 LiveView에서 사용할 Util메소드 정의 합니다.
   """

--- a/lib/itsm_web/router_utils.ex
+++ b/lib/itsm_web/router_utils.ex
@@ -1,4 +1,4 @@
-defmodule ItsmWeb.RouterUtil do
+defmodule ItsmWeb.RouterUtils do
   def admin_menu_items do
     ItsmWeb.Router.__routes__()
     |> Enum.filter(fn route ->


### PR DESCRIPTION
현재 프로젝트 내 유틸리티 모듈들이 `*Util`과 `*Utils`가 혼용되거나, 단수형인 `Util`로 정의되어 있습니다. Elixir 및 Phoenix 생태계의 일반적인 관례에 따라 공통 기능을 제공하는 모듈명을 복수형인 **`Utils`**로 통일하여 코드 베이스의 일관성을 확보합니다.

다음 모듈들의 이름을 변경하고, 이를 참조하는 모든 소스 코드(Controller, LiveView, Component 등)를 업데이트합니다.

1.  **`ItsmWeb.Utils.Util`** -> **`ItsmWeb.Utils.Utils`** (또는 `Itsm.Utils`)
2.  **`ItsmWeb.LiveUtils.Util`** -> **`ItsmWeb.LiveUtils.Utils`**
3.  **`ItsmWeb.RouterUtils.Util`** -> **`ItsmWeb.RouterUtils.Utils`**

이슈 번호 : #88