### PR TITLE
프로젝트 커스텀 규칙이 적용된 ITSM 전용 어드민 제너레이터 구현

### DIFF
--- a/lib/itsm/admin/accounts.ex
+++ b/lib/itsm/admin/accounts.ex
@@ -3,10 +3,6 @@ defmodule Itsm.Admin.Accounts do
   alias Itsm.Repo
   alias Itsm.Accounts.User
 
-  def list_users do
-    Repo.all(User)
-  end
-
   def get_select_options() do
     User
     |> select([c], {c.display_name, c.id})

--- a/lib/itsm/admin/approvals.ex
+++ b/lib/itsm/admin/approvals.ex
@@ -3,28 +3,27 @@ defmodule Itsm.Admin.Approvals do
   alias Itsm.Repo
   alias Itsm.Service.Approval
 
-  def get_approval!(id), do: Repo.get!(Approval, id) |> Repo.preload(request: :category)
-
-  def list_approvals do
-    Repo.all(Approval)
-    |> Repo.preload(request: :category)
-  end
+  def get_approval!(id), do: Repo.get!(Approval, id)
 
   def change_approval(%Approval{} = approval, attrs \\ %{}) do
     Approval.changeset(approval, attrs)
-    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
 
   defdelegate create_approval(attrs \\ %{}), to: Itsm.Approvals
 
   def update_approval(%Approval{} = approval, attrs) do
     approval
-    |> Approval.admin_changeset(attrs)
-    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Approval.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
   end
 
   def delete_approval(%Approval{} = approval) do
     Repo.delete(approval)
+  end
+
+  def preload_category(%Approval{} = approval) do
+    approval |> Repo.preload(request: :category)
   end
 end

--- a/lib/itsm/admin/assets.ex
+++ b/lib/itsm/admin/assets.ex
@@ -6,13 +6,9 @@ defmodule Itsm.Admin.Assets do
 
   def get_asset!(id), do: Repo.get!(Asset, id)
 
-  def list_assets do
-    Repo.all(Asset)
-  end
-
   def change_asset(%Asset{} = asset, attrs \\ %{}) do
     Asset.changeset(asset, attrs)
-    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
 
   defdelegate create_asset(attrs \\ %{}), to: Itsm.Assets
@@ -20,7 +16,7 @@ defmodule Itsm.Admin.Assets do
   def update_asset(%Asset{} = asset, attrs) do
     asset
     |> Asset.changeset(attrs)
-    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
   end
 

--- a/lib/itsm/admin/categories.ex
+++ b/lib/itsm/admin/categories.ex
@@ -5,11 +5,9 @@ defmodule Itsm.Admin.Categories do
 
   defdelegate get_category!(id), to: Itsm.Categories
 
-  def list_categories, do: Repo.all(Category)
-
   def change_category(%Category{} = category, attrs \\ %{}) do
     Category.changeset(category, attrs)
-    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
 
   def create_category(attrs \\ %{}) do
@@ -21,11 +19,17 @@ defmodule Itsm.Admin.Categories do
   def update_category(%Category{} = category, attrs) do
     category
     |> Category.changeset(attrs)
-    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs[:inserted_at])
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
   end
 
   def delete_category(%Category{} = category) do
     Repo.delete(category)
+  end
+
+  def get_category_options do
+    Category
+    |> select([c], {c.name, c.id})
+    |> Repo.all()
   end
 end

--- a/lib/itsm/admin/comments.ex
+++ b/lib/itsm/admin/comments.ex
@@ -3,24 +3,27 @@ defmodule Itsm.Admin.Comments do
   alias Itsm.Repo
   alias Itsm.Comments.Comment
 
-  def list_comments do
-    Repo.all(Comment)
-    |> Repo.preload([:user])
+  def get_comment!(id), do: Repo.get!(Comment, id)
+
+  def change_comment(comment, attrs \\ %{}) do
+    Comment.changeset(comment, attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
-
-  def get_comment!(id), do: Repo.get!(Comment, id) |> Repo.preload([:user])
-
-  defdelegate change_comment(comment, attrs \\ %{}), to: Itsm.Comments
 
   defdelegate create_comment(resource, user, attrs \\ %{}), to: Itsm.Comments
 
   def update_comment(%Comment{} = comment, attrs) do
     comment
     |> Comment.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
   end
 
   def delete_comment(%Comment{} = comment) do
     Repo.delete(comment)
+  end
+
+  def preload_user(%Comment{} = comment) do
+    comment |> Repo.preload([:user])
   end
 end

--- a/lib/itsm/admin/common_codes.ex
+++ b/lib/itsm/admin/common_codes.ex
@@ -3,17 +3,11 @@ defmodule Itsm.Admin.CommonCodes do
   alias Itsm.Repo
   alias Itsm.Common.CommonCode
 
-  def list_common_codes do
-    Repo.all(CommonCode)
-  end
-
   def get_common_code!(id), do: Repo.get!(CommonCode, id)
 
-  def list_common_codes_group_by_group_code do
-    CommonCode
-    |> group_by([c], c.group_code)
-    |> select([c], %{group_code: c.group_code, count: count(c.id)})
-    |> Repo.all()
+  def change_common_code(%CommonCode{} = common_code, attrs \\ %{}) do
+    CommonCode.changeset(common_code, attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
 
   def create_common_code(attrs \\ %{}) do
@@ -25,6 +19,7 @@ defmodule Itsm.Admin.CommonCodes do
   def update_common_code(%CommonCode{} = common_code, attrs) do
     common_code
     |> CommonCode.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
   end
 
@@ -32,11 +27,5 @@ defmodule Itsm.Admin.CommonCodes do
     Repo.delete(common_code)
   end
 
-  def change_common_code(%CommonCode{} = common_code, attrs \\ %{}) do
-    CommonCode.changeset(common_code, attrs)
-  end
-
-  defdelegate list_common_codes_by_group(group_code), to: Itsm.CommonCodes
   defdelegate get_select_options(group_code), to: Itsm.CommonCodes
-  defdelegate get_label(group_code, code), to: Itsm.CommonCodes
 end

--- a/lib/itsm/admin/crews.ex
+++ b/lib/itsm/admin/crews.ex
@@ -8,18 +8,17 @@ defmodule Itsm.Admin.Crews do
 
   defdelegate get_crew!(id), to: Itsm.Crews
 
-  def list_crews do
-    Repo.all(Crew)
-    |> Repo.preload(:leader)
+  def change_crew(%Crew{} = crew, attrs \\ %{}) do
+    Crew.changeset(crew, attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
-
-  defdelegate change_crew(crew, attrs \\ %{}), to: Itsm.Crews
 
   defdelegate create_crew(leader, attrs \\ %{}), to: Itsm.Crews
 
   def update_crew(%Crew{} = crew, attrs) do
     crew
     |> Crew.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
     |> case do
       {:ok, crew} ->
@@ -44,5 +43,15 @@ defmodule Itsm.Admin.Crews do
       {:error, _} = error ->
         error
     end
+  end
+
+  def preload_leader(%Crew{} = crew) do
+    crew |> Repo.preload(:leader)
+  end
+
+  def get_crew_options() do
+    Crew
+    |> select([c], {c.name, c.id})
+    |> Repo.all()
   end
 end

--- a/lib/itsm/paging.ex
+++ b/lib/itsm/paging.ex
@@ -13,7 +13,7 @@ defmodule Itsm.Paging do
         do: default_columns,
         else: parse_columns(params["search_columns"])
 
-    joined_query = build_query_base(query_base, search_columns)
+    {joined_query, modules_map} = build_query_base(query_base, search_columns)
 
     query =
       if search != "" do
@@ -21,13 +21,33 @@ defmodule Itsm.Paging do
           where:
             ^Enum.reduce(search_columns, false, fn col_info, acc ->
               {b_name, field_name} = get_last_binding_and_field(col_info)
+              module = Map.get(modules_map, b_name)
 
-              case b_name do
-                :main ->
-                  dynamic([p], ilike(field(p, ^field_name), ^"%#{search}%") or ^acc)
+              if module do
+                type = module.__schema__(:type, field_name)
+                search_pattern = "%#{search}%"
 
-                _ ->
-                  dynamic([{^b_name, b}], ilike(field(b, ^field_name), ^"%#{search}%") or ^acc)
+                search_int =
+                  case Integer.parse(search) do
+                    {num, _} -> num
+                    :error -> nil
+                  end
+
+                cond do
+                  type in [:string, :binary] ->
+                    dynamic([{^b_name, x}], ilike(field(x, ^field_name), ^search_pattern) or ^acc)
+
+                  type in [:integer, :id, :decimal] and not is_nil(search_int) ->
+                    dynamic([{^b_name, x}], field(x, ^field_name) == ^search_int or ^acc)
+
+                  true ->
+                    dynamic(
+                      [{^b_name, x}],
+                      ilike(type(field(x, ^field_name), :string), ^search_pattern) or ^acc
+                    )
+                end
+              else
+                acc
               end
             end)
       else
@@ -37,11 +57,13 @@ defmodule Itsm.Paging do
     total_count = Repo.aggregate(query, :count, :id)
     total_pages = if total_count == 0, do: 1, else: ceil(total_count / page_size)
 
+    optimized_preloads = build_optimized_preloads(query_base, preloads)
+
     entries =
       query
       |> limit(^page_size)
       |> offset(^offset_val)
-      |> preload(^preloads)
+      |> preload(^optimized_preloads)
       |> Repo.all()
 
     formatted_columns =
@@ -64,34 +86,38 @@ defmodule Itsm.Paging do
 
     %{
       entries: entries,
-      total_pages: total_pages,
-      total_count: total_count,
-      columns_options: build_options(default_columns),
-      current_path: URI.parse(url).path,
-      params: params
+      results: %{
+        total_pages: total_pages,
+        total_count: total_count,
+        columns_options: build_options(default_columns),
+        current_path: URI.parse(url).path,
+        params: params
+      }
     }
   end
 
-  def build_query_base(query_base, search_columns) do
+  defp build_query_base(query_base, search_columns) do
+    initial_state = {from(m in query_base, as: :main), %{main: query_base}}
+
     search_columns
     |> List.wrap()
-    |> Enum.reduce(query_base, fn
-      col_info, query when is_tuple(col_info) ->
-        ensure_join(query, col_info)
+    |> Enum.reduce(initial_state, fn
+      col_info, {query, modules} when is_tuple(col_info) ->
+        ensure_join(query, modules, col_info)
 
-      _col, query ->
-        query
+      _col, acc ->
+        acc
     end)
   end
 
-  def build_options(default_columns) do
+  defp build_options(default_columns) do
     [{"전체", ""}] ++
       Enum.map(default_columns, fn col ->
         {flatten_label(col), flatten_value(col)}
       end)
   end
 
-  def parse_columns(columns) do
+  defp parse_columns(columns) do
     columns
     |> List.wrap()
     |> Enum.reject(&(&1 in ["", nil]))
@@ -129,31 +155,65 @@ defmodule Itsm.Paging do
     {:main, field}
   end
 
-  defp ensure_join(query, assoc_name) when is_atom(assoc_name) do
-    if has_named_binding?(query, assoc_name) do
-      query
-    else
-      join(query, :left, [p], a in assoc(p, ^assoc_name), as: ^assoc_name)
-    end
+  defp ensure_join(query, modules, assoc_name) when is_atom(assoc_name) do
+    do_ensure_join(query, modules, :main, assoc_name)
   end
 
-  defp ensure_join(query, {parent, child}) do
-    query = ensure_join(query, parent)
+  defp ensure_join(query, modules, {parent, child}) do
+    {query, modules} = ensure_join(query, modules, parent)
 
     case child do
       {child_assoc, next_step} ->
-        query =
-          if has_named_binding?(query, child_assoc) do
-            query
-          else
-            join(query, :left, [{^parent, p}], c in assoc(p, ^child_assoc), as: ^child_assoc)
-          end
-
-        ensure_join(query, {child_assoc, next_step})
+        {query, modules} = do_ensure_join(query, modules, parent, child_assoc)
+        ensure_join(query, modules, {child_assoc, next_step})
 
       field when is_atom(field) ->
-        query
+        {query, modules}
     end
+  end
+
+  defp do_ensure_join(query, modules, parent_name, assoc_name) do
+    if has_named_binding?(query, assoc_name) do
+      {query, modules}
+    else
+      parent_mod = Map.fetch!(modules, parent_name)
+      %{related: child_mod} = parent_mod.__schema__(:association, assoc_name)
+
+      new_query =
+        join(query, :left, [{^parent_name, p}], a in assoc(p, ^assoc_name), as: ^assoc_name)
+
+      new_modules = Map.put(modules, assoc_name, child_mod)
+
+      {new_query, new_modules}
+    end
+  end
+
+  defp build_optimized_preloads(schema, preloads) do
+    Enum.map(preloads, fn
+      assoc when is_atom(assoc) ->
+        assoc
+
+      {assoc, content} ->
+        target_schema = schema.__schema__(:association, assoc).queryable
+        {nested_preloads, fields} = Enum.split_with(List.wrap(content), &is_tuple/1)
+        optimized_nested = build_optimized_preloads(target_schema, nested_preloads)
+        required_keys = get_required_keys(nested_preloads, target_schema)
+        final_fields = Enum.uniq(required_keys ++ fields)
+
+        query = from(s in target_schema, select: ^final_fields)
+        query = if optimized_nested == [], do: query, else: preload(query, ^optimized_nested)
+
+        {assoc, query}
+    end)
+  end
+
+  defp get_required_keys(nested_preloads, target_schema) do
+    [
+      :id
+      | Enum.map(nested_preloads, &target_schema.__schema__(:association, elem(&1, 0)).owner_key)
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
   end
 
   defp flatten_value(col) when col in ["", nil, [], [""]], do: [""]
@@ -171,7 +231,9 @@ defmodule Itsm.Paging do
   defp flatten_label(col), do: translate_label(col)
 
   defp translate_label(atom) when is_atom(atom) do
-    label = atom |> Atom.to_string() |> String.replace("_", " ") |> String.capitalize()
+    label =
+      atom |> Atom.to_string() |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
+
     Gettext.gettext(ItsmWeb.Gettext, label)
   end
 

--- a/lib/itsm/service/approval.ex
+++ b/lib/itsm/service/approval.ex
@@ -57,22 +57,8 @@ defmodule Itsm.Service.Approval do
 
   def admin_changeset(approval, attrs) do
     approval
-    |> cast(attrs, [
-      :status,
-      :approver_name,
-      :action,
-      :approver_id,
-      :request_id,
-      :inserted_at
-    ])
-    |> validate_required([
-      :status,
-      :approver_name,
-      :action,
-      :approver_id,
-      :request_id
-    ])
-    |> assoc_constraint(:approver)
-    |> assoc_constraint(:request)
+    |> changeset(attrs)
+    |> cast(attrs, [:inserted_at])
+    |> validate_required([:inserted_at])
   end
 end

--- a/lib/itsm/utils.ex
+++ b/lib/itsm/utils.ex
@@ -10,6 +10,19 @@ defmodule Itsm.Utils do
 
   def maybe_put_change(changeset, _field, nil), do: changeset
 
-  def maybe_put_change(changeset, field, value),
-    do: Ecto.Changeset.put_change(changeset, field, value)
+  def maybe_put_change(changeset, field, value) when is_binary(value) do
+    parse_and_put(changeset, field, value, DateTime.from_iso8601(value))
+  end
+
+  def maybe_put_change(changeset, field, value) do
+    Ecto.Changeset.put_change(changeset, field, value)
+  end
+
+  defp parse_and_put(changeset, field, _value, {:ok, dt, _offset}) do
+    Ecto.Changeset.put_change(changeset, field, DateTime.truncate(dt, :second))
+  end
+
+  defp parse_and_put(changeset, field, value, {:error, _reason}) do
+    Ecto.Changeset.put_change(changeset, field, value)
+  end
 end

--- a/lib/itsm_web/components/calendar/calendar_component.html.heex
+++ b/lib/itsm_web/components/calendar/calendar_component.html.heex
@@ -12,7 +12,5 @@
     start_col_class={@start_col_class}
     days={@days}
     errors={@errors}
-    min={@min}
-    max={@max}
   />
 </div>

--- a/lib/itsm_web/components/itsm_components.ex
+++ b/lib/itsm_web/components/itsm_components.ex
@@ -57,8 +57,6 @@ defmodule ItsmWeb.ItsmComponents do
   attr :label, :string, default: nil
   attr :start_col_class, :any, default: nil
   attr :days, :list, default: [], doc: "[%{disabled: boolean, date: Date, day: integer}]"
-  attr :min, :any, default: nil
-  attr :max, :any, default: nil
   attr :view_date, :any, default: nil
   attr :selected_date_time, :any, default: nil
   attr :show_time, :boolean, default: false
@@ -112,8 +110,6 @@ defmodule ItsmWeb.ItsmComponents do
             phx-update="ignore"
             readonly
             value={@selected_date_time}
-            min={@min}
-            max={@max}
           />
           <div
             {@rests[:selected_date_time]}
@@ -208,7 +204,7 @@ defmodule ItsmWeb.ItsmComponents do
             data-disabled={date.disabled || nil}
             class={[
               index == 0 && @start_col_class,
-              "p-2 text-sm rounded-lg transition-all"
+              "p-2 text-sm rounded-lg transition-all cursor-pointer hover:bg-gray-100"
             ]}
             phx-update="ignore"
           >
@@ -231,7 +227,6 @@ defmodule ItsmWeb.ItsmComponents do
               min="0"
               max="23"
               phx-target={@target}
-              phx-debounce="300"
               phx-update="ignore"
               class="w-24 bg-transparent text-center font-mono text-lg focus:outline-none focus:text-blue-600"
             /> <span class="text-gray-400 font-bold">:</span>
@@ -245,7 +240,6 @@ defmodule ItsmWeb.ItsmComponents do
               min="0"
               max="59"
               phx-target={@target}
-              phx-debounce="300"
               phx-update="ignore"
               class="w-24 bg-transparent text-center font-mono text-lg focus:outline-none focus:text-blue-600"
             />
@@ -299,7 +293,7 @@ defmodule ItsmWeb.ItsmComponents do
             multiple
             size="1"
             phx-hook="InputSelect.selectAll"
-            value={@results.params.search_columns || [""]}
+            value={@results.params.search_columns}
           />
         </div>
 

--- a/lib/itsm_web/components/layouts/admin.html.heex
+++ b/lib/itsm_web/components/layouts/admin.html.heex
@@ -9,7 +9,7 @@
           {gettext("Admin") <> " " <> gettext("Console")}
         </span>
       </div>
-      
+
       <div :if={@current_user} class="hidden lg:flex items-center gap-5 center">
         <nav class="flex gap-5">
           <.link
@@ -20,9 +20,9 @@
             {Gettext.gettext(ItsmWeb.Gettext, menu.name)}
           </.link>
         </nav>
-        
+
         <div class="h-4 w-px bg-gray-300"></div>
-        
+
         <div class="flex items-center gap-4">
           <% is_ko = Gettext.get_locale(ItsmWeb.Gettext) == "ko" %>
           <div class="flex items-center gap-2">
@@ -49,9 +49,9 @@
               EN
             </span>
           </div>
-          
+
           <div class="h-4 w-px bg-gray-300 mx-1"></div>
-          
+
           <div class="flex items-center gap-3 text-sm font-medium">
             <span class="text-kb-dark-gray truncate max-w-[120px]">{@current_user.email}</span>
             <.link href={~p"/users/settings"} class="text-gray-400 hover:text-kb-blue">
@@ -72,5 +72,5 @@
 </header>
 
 <main class="px-4 py-20 sm:px-6 lg:px-8">
-  <div class="mx-auto max-w-4xl">{@inner_content}</div>
+  <div class="mx-auto max-w-4xl"><.flash_group flash={@flash} /> {@inner_content}</div>
 </main>

--- a/lib/itsm_web/components/table_container/table_component.ex
+++ b/lib/itsm_web/components/table_container/table_component.ex
@@ -3,15 +3,15 @@ defmodule ItsmWeb.TableContainerComponent do
 
   @impl true
   def update(assigns, socket) do
-    {:ok, socket |> assign(assigns)}
+    {:ok, socket |> assign(assigns) |> init_default_value()}
   end
 
   @impl true
   def handle_event("update-filters", params, socket) do
     query_params = %{
-      "search" => params["search"] || "",
+      "search" => params["search"],
       "page" => 1,
-      "page_size" => params["page_size"] || 10,
+      "page_size" => params["page_size"],
       "search_columns" => params["search_columns"]
     }
 
@@ -19,5 +19,24 @@ defmodule ItsmWeb.TableContainerComponent do
      push_patch(socket,
        to: "#{socket.assigns.results.current_path}?#{Plug.Conn.Query.encode(query_params)}"
      )}
+  end
+
+  defp init_default_value(socket) do
+    current_results = get_in(socket.assigns, [:results]) || %{}
+
+    default_params = %{search: "", page: 1, page_size: 10, search_columns: [""]}
+    safe_params = Map.merge(default_params, current_results[:params] || %{})
+
+    updated_results =
+      Map.merge(current_results, %{
+        params: safe_params,
+        columns_options: current_results[:columns_options] || [""],
+        current_path: current_results[:current_path] || "",
+        total_count: current_results[:total_count] || 0,
+        total_pages: current_results[:total_pages] || 0
+      })
+
+    socket
+    |> assign(:results, updated_results)
   end
 end

--- a/lib/itsm_web/live/admin/approval_live/form_component.ex
+++ b/lib/itsm_web/live/admin/approval_live/form_component.ex
@@ -10,7 +10,8 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
      |> assign(assigns)
      |> assign_new(:form, fn ->
        to_form(Approvals.change_approval(approval))
-     end)}
+     end)
+     |> assign_new_options()}
   end
 
   @impl true
@@ -40,7 +41,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
           field={@form[:approver_id]}
           type="select"
           label={gettext("Approver")}
-          options={Itsm.Admin.Accounts.get_select_options()}
+          options={@approver_options}
         />
         <.input field={@form[:comment]} type="text" label={gettext("Comment")} />
         <.itsm_calendar
@@ -50,7 +51,9 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
           show_time
           default_selected_date_time={@form[:inserted_at].value}
         />
-        <:actions><.button phx-disable-with="Saving...">Save Approval</.button></:actions>
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Approval</.button>
+        </:actions>
       </.simple_form>
     </div>
     """
@@ -67,11 +70,14 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
     save_approval(socket, socket.assigns.action, approval_params)
   end
 
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:approver_options, fn -> Itsm.Admin.Accounts.get_select_options() end)
+  end
+
   defp save_approval(socket, :edit, approval_params) do
     case Approvals.update_approval(socket.assigns.approval, approval_params) do
-      {:ok, approval} ->
-        notify_parent({:saved, approval})
-
+      {:ok, _approval} ->
         {:noreply,
          socket
          |> put_flash(:info, "Approval updated successfully")
@@ -81,6 +87,4 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/approval_live/index.ex
+++ b/lib/itsm_web/live/admin/approval_live/index.ex
@@ -23,13 +23,8 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
     {:noreply, stream_delete(socket, :approvals, approval)}
   end
 
-  @impl true
-  def handle_info({ItsmWeb.Admin.ApprovalLive.FormComponent, {:saved, approval}}, socket) do
-    {:noreply, stream_insert(socket, :approvals, approval)}
-  end
-
   defp apply_action(socket, :index, params, url) do
-    results =
+    value =
       Paging.search_and_pagination(
         params,
         url,
@@ -39,12 +34,12 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
           :action,
           :approver_name
         ],
-        request: :category
+        request: [category: :name]
       )
 
     socket
-    |> assign(:results, results)
-    |> stream(:approvals, results.entries, reset: true)
+    |> assign(:results, value.results)
+    |> stream(:approvals, value.entries, reset: true)
     |> assign(:page_title, "Listing Approvals")
     |> assign(:approval, nil)
   end

--- a/lib/itsm_web/live/admin/approval_live/index.html.heex
+++ b/lib/itsm_web/live/admin/approval_live/index.html.heex
@@ -1,7 +1,7 @@
 <.header>
   Listing Approvals
 </.header>
-<.itsm_table_container results={@results}>
+<.itsm_table_container results={assigns[:results]}>
   <.table
     id="approvals"
     rows={@streams.approvals}
@@ -10,16 +10,12 @@
     <:col :let={{_id, approval}} label={gettext("Category")}>
       {approval.request.category.name}
     </:col>
-
     <:col :let={{_id, approval}} label={gettext("Status")}>{approval.status}</:col>
-
     <:col :let={{_id, approval}} label={gettext("Approver")}>{approval.approver_name}</:col>
-
     <:action :let={{_id, approval}}>
       <div class="sr-only"><.link navigate={~p"/admin/approvals/#{approval}"}>Show</.link></div>
       <.link patch={~p"/admin/approvals/#{approval}/edit"}>Edit</.link>
     </:action>
-
     <:action :let={{id, approval}}>
       <.link
         phx-click={JS.push("delete", value: %{id: approval.id}) |> hide("##{id}")}
@@ -30,11 +26,12 @@
     </:action>
   </.table>
 </.itsm_table_container>
+
 <.modal
   :if={@live_action == :edit}
   id="approval-modal"
   show
-  on_cancel={JS.patch(~p"/admin/approvals?#{@results.params}")}
+  on_cancel={JS.patch(~p"/admin/approvals?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.Admin.ApprovalLive.FormComponent}
@@ -43,6 +40,6 @@
     action={@live_action}
     approval={@approval}
     current_user={@current_user}
-    patch={~p"/admin/approvals?#{@results.params}"}
+    patch={~p"/admin/approvals?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/approval_live/show.ex
+++ b/lib/itsm_web/live/admin/approval_live/show.ex
@@ -13,7 +13,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:approval, Approvals.get_approval!(id))}
+     |> assign(:approval, Approvals.get_approval!(id) |> Approvals.preload_category())}
   end
 
   defp page_title(:show), do: "Show Approval"

--- a/lib/itsm_web/live/admin/approval_live/show.html.heex
+++ b/lib/itsm_web/live/admin/approval_live/show.html.heex
@@ -1,7 +1,6 @@
 <.header>
   Approval {@approval.id}
   <:subtitle>This is a approval record from your database.</:subtitle>
-
   <:actions>
     <.link patch={~p"/admin/approvals/#{@approval}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit approval</.button>
@@ -11,27 +10,21 @@
 
 <.list>
   <:item title={gettext("Category")}>{@approval.request.category.name}</:item>
-
   <:item title={gettext("Status")}>{@approval.status}</:item>
-
-  <:item title={gettext("Approver name")}>{@approval.approver_name}</:item>
-
-  <:item title={gettext("Inserted at")}>
+  <:item title={gettext("Approver Name")}>{@approval.approver_name}</:item>
+  <:item title={gettext("Inserted At")}>
     <span
       id={"approval-inserted-at-#{@approval.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@approval.inserted_at}
-    >
-    </span>
+    />
   </:item>
-
-  <:item title={gettext("Updated at")}>
+  <:item title={gettext("Updated At")}>
     <span
       id={"approval-updated-at-#{@approval.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@approval.updated_at}
-    >
-    </span>
+    />
   </:item>
 </.list>
 

--- a/lib/itsm_web/live/admin/asset_live/form_component.ex
+++ b/lib/itsm_web/live/admin/asset_live/form_component.ex
@@ -4,6 +4,17 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
   alias Itsm.Admin.Assets
 
   @impl true
+  def update(%{asset: asset} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_new(:form, fn ->
+       to_form(Assets.change_asset(asset))
+     end)
+     |> assign_new_options()}
+  end
+
+  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -79,17 +90,6 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
   end
 
   @impl true
-  def update(%{asset: asset} = assigns, socket) do
-    {:ok,
-     socket
-     |> initialize_options()
-     |> assign(assigns)
-     |> assign_new(:form, fn ->
-       to_form(Assets.change_asset(asset))
-     end)}
-  end
-
-  @impl true
   def handle_event("validate", %{"asset" => asset_params}, socket) do
     changeset = Assets.change_asset(socket.assigns.asset, asset_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
@@ -99,22 +99,19 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
     save_asset(socket, socket.assigns.action, asset_params)
   end
 
-  defp initialize_options(socket) do
-    assign(socket,
-      affiliate_options: Itsm.CommonCodes.get_select_options("계열사"),
-      category_options: Itsm.CommonCodes.get_select_options("카테고리"),
-      region_type_options: Itsm.CommonCodes.get_select_options("지역_유형"),
-      infra_type_options: Itsm.CommonCodes.get_select_options("인프라_유형"),
-      env_options: Itsm.CommonCodes.get_select_options("운영_구분"),
-      location_options: Itsm.CommonCodes.get_select_options("장소")
-    )
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:affiliate_options, fn -> Itsm.CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:category_options, fn -> Itsm.CommonCodes.get_select_options("카테고리") end)
+    |> assign_new(:region_type_options, fn -> Itsm.CommonCodes.get_select_options("지역_유형") end)
+    |> assign_new(:infra_type_options, fn -> Itsm.CommonCodes.get_select_options("인프라_유형") end)
+    |> assign_new(:env_options, fn -> Itsm.CommonCodes.get_select_options("운영_구분") end)
+    |> assign_new(:location_options, fn -> Itsm.CommonCodes.get_select_options("장소") end)
   end
 
   defp save_asset(socket, :edit, asset_params) do
     case Assets.update_asset(socket.assigns.asset, asset_params) do
-      {:ok, asset} ->
-        notify_parent({:saved, asset})
-
+      {:ok, _asset} ->
         {:noreply,
          socket
          |> put_flash(:info, "Asset updated successfully")
@@ -127,9 +124,7 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
 
   defp save_asset(socket, :new, asset_params) do
     case Assets.create_asset(asset_params) do
-      {:ok, asset} ->
-        notify_parent({:saved, asset})
-
+      {:ok, _asset} ->
         {:noreply,
          socket
          |> put_flash(:info, "Asset created successfully")
@@ -139,6 +134,4 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/asset_live/index.ex
+++ b/lib/itsm_web/live/admin/asset_live/index.ex
@@ -3,38 +3,16 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
 
   alias Itsm.Admin.Assets
   alias Itsm.Assets.Asset
+  alias Itsm.Paging
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, stream(socket, :assets, Assets.list_assets())}
+    {:ok, stream(socket, :assets, [])}
   end
 
   @impl true
-  def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-  end
-
-  defp apply_action(socket, :edit, %{"id" => id}) do
-    socket
-    |> assign(:page_title, "Edit Asset")
-    |> assign(:asset, Assets.get_asset!(id))
-  end
-
-  defp apply_action(socket, :new, _params) do
-    socket
-    |> assign(:page_title, "New Asset")
-    |> assign(:asset, %Asset{})
-  end
-
-  defp apply_action(socket, :index, _params) do
-    socket
-    |> assign(:page_title, "Listing Assets")
-    |> assign(:asset, nil)
-  end
-
-  @impl true
-  def handle_info({ItsmWeb.AssetLive.FormComponent, {:saved, asset}}, socket) do
-    {:noreply, stream_insert(socket, :assets, asset)}
+  def handle_params(params, url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
   @impl true
@@ -43,5 +21,38 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
     {:ok, _} = Assets.delete_asset(asset)
 
     {:noreply, stream_delete(socket, :assets, asset)}
+  end
+
+  defp apply_action(socket, :index, params, url) do
+    value =
+      Paging.search_and_pagination(params, url, Asset, [
+        :env,
+        :name,
+        :description,
+        :location,
+        :category,
+        :affiliate,
+        :region_type,
+        :infra_type,
+        :is_dmz_zone
+      ])
+
+    socket
+    |> assign(:results, value.results)
+    |> stream(:assets, value.entries, reset: true)
+    |> assign(:page_title, "Listing Assets")
+    |> assign(:asset, nil)
+  end
+
+  defp apply_action(socket, :new, _params, _url) do
+    socket
+    |> assign(:page_title, "New Asset")
+    |> assign(:asset, %Asset{})
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}, _url) do
+    socket
+    |> assign(:page_title, "Edit Asset")
+    |> assign(:asset, Assets.get_asset!(id))
   end
 end

--- a/lib/itsm_web/live/admin/asset_live/index.html.heex
+++ b/lib/itsm_web/live/admin/asset_live/index.html.heex
@@ -1,47 +1,49 @@
 <.header>
   Listing Assets
   <:actions>
-    <.link patch={~p"/assets/new"}>
+    <.link patch={~p"/admin/assets/new"}>
       <.button>New Asset</.button>
     </.link>
   </:actions>
 </.header>
 
-<.table
-  id="assets"
-  rows={@streams.assets}
-  row_click={fn {_id, asset} -> JS.navigate(~p"/assets/#{asset}") end}
->
-  <:col :let={{_id, asset}} label={gettext("Name")}>{asset.name}</:col>
-  <:col :let={{_id, asset}} label={gettext("Description")}>{asset.description}</:col>
-  <:col :let={{_id, asset}} label={gettext("Affiliate")}>{asset.affiliate}</:col>
-  <:col :let={{_id, asset}} label={gettext("Category")}>{asset.category}</:col>
-  <:col :let={{_id, asset}} label={gettext("Region type")}>{asset.region_type}</:col>
-  <:col :let={{_id, asset}} label={gettext("Infra type")}>{asset.infra_type}</:col>
-  <:col :let={{_id, asset}} label={gettext("Environment")}>{asset.env}</:col>
-  <:col :let={{_id, asset}} label={gettext("Location")}>{asset.location}</:col>
-  <:col :let={{_id, asset}} label={gettext("Is dmz zone")}>{asset.is_dmz_zone}</:col>
-  <:action :let={{_id, asset}}>
-    <div class="sr-only">
-      <.link navigate={~p"/assets/#{asset}"}>Show</.link>
-    </div>
-    <.link patch={~p"/assets/#{asset}/edit"}>Edit</.link>
-  </:action>
-  <:action :let={{id, asset}}>
-    <.link
-      phx-click={JS.push("delete", value: %{id: asset.id}) |> hide("##{id}")}
-      data-confirm="Are you sure?"
-    >
-      Delete
-    </.link>
-  </:action>
-</.table>
+<.itsm_table_container results={assigns[:results]}>
+  <.table
+    id="assets"
+    rows={@streams.assets}
+    row_click={fn {_id, asset} -> JS.navigate(~p"/admin/assets/#{asset}") end}
+  >
+    <:col :let={{_id, asset}} label={gettext("Name")}>{asset.name}</:col>
+    <:col :let={{_id, asset}} label={gettext("Description")}>{asset.description}</:col>
+    <:col :let={{_id, asset}} label={gettext("Affiliate")}>{asset.affiliate}</:col>
+    <:col :let={{_id, asset}} label={gettext("Category")}>{asset.category}</:col>
+    <:col :let={{_id, asset}} label={gettext("Region type")}>{asset.region_type}</:col>
+    <:col :let={{_id, asset}} label={gettext("Infra type")}>{asset.infra_type}</:col>
+    <:col :let={{_id, asset}} label={gettext("Environment")}>{asset.env}</:col>
+    <:col :let={{_id, asset}} label={gettext("Location")}>{asset.location}</:col>
+    <:col :let={{_id, asset}} label={gettext("Is dmz zone")}>{asset.is_dmz_zone}</:col>
+    <:action :let={{_id, asset}}>
+      <div class="sr-only">
+        <.link navigate={~p"/admin/assets/#{asset}"}>Show</.link>
+      </div>
+      <.link patch={~p"/admin/assets/#{asset}/edit"}>Edit</.link>
+    </:action>
+    <:action :let={{id, asset}}>
+      <.link
+        phx-click={JS.push("delete", value: %{id: asset.id}) |> hide("##{id}")}
+        data-confirm="Are you sure?"
+      >
+        Delete
+      </.link>
+    </:action>
+  </.table>
+</.itsm_table_container>
 
 <.modal
   :if={@live_action in [:new, :edit]}
   id="asset-modal"
   show
-  on_cancel={JS.patch(~p"/assets")}
+  on_cancel={JS.patch(~p"/admin/assets?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.AssetLive.FormComponent}
@@ -49,6 +51,6 @@
     title={@page_title}
     action={@live_action}
     asset={@asset}
-    patch={~p"/assets"}
+    patch={~p"/admin/assets?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/asset_live/show.html.heex
+++ b/lib/itsm_web/live/admin/asset_live/show.html.heex
@@ -2,7 +2,7 @@
   Asset {@asset.id}
   <:subtitle>This is a asset record from your database.</:subtitle>
   <:actions>
-    <.link patch={~p"/assets/#{@asset}/show/edit"} phx-click={JS.push_focus()}>
+    <.link patch={~p"/admin/assets/#{@asset}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit asset</.button>
     </.link>
   </:actions>
@@ -13,36 +13,34 @@
   <:item title={gettext("Description")}>{@asset.description}</:item>
   <:item title={gettext("Affiliate")}>{@asset.affiliate}</:item>
   <:item title={gettext("Category")}>{@asset.category}</:item>
-  <:item title={gettext("Region type")}>{@asset.region_type}</:item>
-  <:item title={gettext("Infra type")}>{@asset.infra_type}</:item>
+  <:item title={gettext("Region Type")}>{@asset.region_type}</:item>
+  <:item title={gettext("Infra Type")}>{@asset.infra_type}</:item>
   <:item title={gettext("Environment")}>{@asset.env}</:item>
   <:item title={gettext("Location")}>{@asset.location}</:item>
-  <:item title={gettext("Is dmz zone")}>{@asset.is_dmz_zone}</:item>
-  <:item title={gettext("Inserted at")}>
+  <:item title={gettext("Is Dmz Zone")}>{@asset.is_dmz_zone}</:item>
+  <:item title={gettext("Inserted At")}>
     <span
       id={"asset-inserted-at-#{@asset.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@asset.inserted_at}
-    >
-    </span>
+    />
   </:item>
-  <:item title={gettext("Updated at")}>
+  <:item title={gettext("Updated At")}>
     <span
       id={"asset-updated-at-#{@asset.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@asset.updated_at}
-    >
-    </span>
+    />
   </:item>
 </.list>
 
-<.back navigate={~p"/assets"}>Back to assets</.back>
+<.back navigate={~p"/admin/assets"}>Back to assets</.back>
 
 <.modal
   :if={@live_action == :edit}
   id="asset-modal"
   show
-  on_cancel={JS.patch(~p"/assets/#{@asset}")}
+  on_cancel={JS.patch(~p"/admin/assets/#{@asset}")}
 >
   <.live_component
     module={ItsmWeb.AssetLive.FormComponent}
@@ -50,6 +48,6 @@
     title={@page_title}
     action={@live_action}
     asset={@asset}
-    patch={~p"/assets/#{@asset}"}
+    patch={~p"/admin/assets/#{@asset}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/category_live/form_component.ex
+++ b/lib/itsm_web/live/admin/category_live/form_component.ex
@@ -5,16 +5,13 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
 
   @impl true
   def update(%{category: category} = assigns, socket) do
-    assignee_crews_options =
-      Itsm.Crews.list_crews() |> Enum.map(fn crew -> {crew.name, crew.id} end)
-
     {:ok,
      socket
      |> assign(assigns)
      |> assign_new(:form, fn ->
        to_form(Categories.change_category(category))
      end)
-     |> assign_new(:assignee_crews_options, fn -> assignee_crews_options end)}
+     |> assign_new_options()}
   end
 
   @impl true
@@ -89,11 +86,14 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
     save_category(socket, socket.assigns.action, category_params)
   end
 
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:assignee_crews_options, fn -> Itsm.Admin.Crews.get_crew_options() end)
+  end
+
   defp save_category(socket, :edit, category_params) do
     case Categories.update_category(socket.assigns.category, category_params) do
-      {:ok, category} ->
-        notify_parent({:saved, category})
-
+      {:ok, _category} ->
         {:noreply,
          socket
          |> put_flash(:info, "Category updated successfully")
@@ -106,9 +106,7 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
 
   defp save_category(socket, :new, category_params) do
     case Categories.create_category(category_params) do
-      {:ok, category} ->
-        notify_parent({:saved, category})
-
+      {:ok, _category} ->
         {:noreply,
          socket
          |> put_flash(:info, "Category created successfully")
@@ -118,6 +116,4 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/category_live/index.ex
+++ b/lib/itsm_web/live/admin/category_live/index.ex
@@ -7,7 +7,7 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, stream(socket, :categories, [])}
+    {:ok, socket |> stream(:categories, []) |> assign_new_options()}
   end
 
   @impl true
@@ -23,13 +23,14 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
     {:noreply, stream_delete(socket, :categories, category)}
   end
 
-  @impl true
-  def handle_info({ItsmWeb.Admin.CategoryLive.FormComponent, {:saved, category}}, socket) do
-    {:noreply, stream_insert(socket, :categories, category)}
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:affiliate_options, fn -> Itsm.CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:group_options, fn -> Itsm.CommonCodes.get_select_options("지역_유형") end)
   end
 
   defp apply_action(socket, :index, params, url) do
-    results =
+    value =
       Paging.search_and_pagination(params, url, Category, [
         :name,
         :description,
@@ -40,8 +41,8 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
       ])
 
     socket
-    |> assign(:results, results)
-    |> stream(:categories, results.entries, reset: true)
+    |> assign(:results, value.results)
+    |> stream(:categories, value.entries, reset: true)
     |> assign(:page_title, "Listing Categories")
     |> assign(:category, nil)
   end

--- a/lib/itsm_web/live/admin/category_live/index.html.heex
+++ b/lib/itsm_web/live/admin/category_live/index.html.heex
@@ -6,32 +6,24 @@
     </.link>
   </:actions>
 </.header>
-<.itsm_table_container results={@results}>
+<.itsm_table_container results={assigns[:results]}>
   <.table
     id="categories"
     rows={@streams.categories}
     row_click={fn {_id, category} -> JS.navigate(~p"/admin/categories/#{category}") end}
   >
     <:col :let={{_id, category}} label={gettext("Name")}>{category.name}</:col>
-
     <:col :let={{_id, category}} label={gettext("Description")}>{category.description}</:col>
-
     <:col :let={{_id, category}} label={gettext("Affiliate")}>
-      {Itsm.CommonCodes.get_label("계열사", category.affiliate)}
+      {ItsmWeb.LiveUtils.find_label(@affiliate_options, category.affiliate)}
     </:col>
-
     <:col :let={{_id, category}} label={gettext("Request name")}>{category.request_name}</:col>
-
     <:col :let={{_id, category}} label={gettext("Group")}>
-      {Itsm.CommonCodes.get_label("지역_유형", category.group)}
+      {ItsmWeb.LiveUtils.find_label(@group_options, category.group)}
     </:col>
-
     <:col :let={{_id, category}} label={gettext("Category")}>{category.category}</:col>
-
     <:col :let={{_id, category}} label={gettext("Duration")}>{category.duration}</:col>
-
     <:col :let={{_id, category}} label={gettext("Active")}>{category.active}</:col>
-
     <:action :let={{_id, category}}>
       <div class="sr-only"><.link navigate={~p"/admin/categories/#{category}"}>Show</.link></div>
       <.link patch={~p"/admin/categories/#{category}/edit"}>Edit</.link>
@@ -51,7 +43,7 @@
   :if={@live_action in [:new, :edit]}
   id="category-modal"
   show
-  on_cancel={JS.patch(~p"/admin/categories?#{@results.params}")}
+  on_cancel={JS.patch(~p"/admin/categories?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.Admin.CategoryLive.FormComponent}
@@ -59,6 +51,6 @@
     title={@page_title}
     action={@live_action}
     category={@category}
-    patch={~p"/admin/categories?#{@results.params}"}
+    patch={~p"/admin/categories?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/category_live/show.html.heex
+++ b/lib/itsm_web/live/admin/category_live/show.html.heex
@@ -1,7 +1,6 @@
 <.header>
   Category {@category.id}
   <:subtitle>This is a category record from your database.</:subtitle>
-
   <:actions>
     <.link patch={~p"/admin/categories/#{@category}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit category</.button>
@@ -11,37 +10,26 @@
 
 <.list>
   <:item title={gettext("Name")}>{@category.name}</:item>
-
   <:item title={gettext("Description")}>{@category.description}</:item>
-
   <:item title={gettext("Affiliate")}>{@category.affiliate}</:item>
-
-  <:item title={gettext("Request name")}>{@category.request_name}</:item>
-
+  <:item title={gettext("Request Name")}>{@category.request_name}</:item>
   <:item title={gettext("Group")}>{@category.group}</:item>
-
   <:item title={gettext("Category")}>{@category.category}</:item>
-
   <:item title={gettext("Duration")}>{@category.duration}</:item>
-
   <:item title={gettext("Active")}>{@category.active}</:item>
-
-  <:item title={gettext("Inserted at")}>
+  <:item title={gettext("Inserted At")}>
     <span
       id={"category-inserted-at-#{@category.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@category.inserted_at}
-    >
-    </span>
+    />
   </:item>
-
-  <:item title={gettext("Updated at")}>
+  <:item title={gettext("Updated At")}>
     <span
       id={"category-updated-at-#{@category.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@category.updated_at}
-    >
-    </span>
+    />
   </:item>
 </.list>
 

--- a/lib/itsm_web/live/admin/comment_live/form_component.ex
+++ b/lib/itsm_web/live/admin/comment_live/form_component.ex
@@ -56,9 +56,7 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
 
   defp save_comment(socket, :edit, comment_params) do
     case Comments.update_comment(socket.assigns.comment, comment_params) do
-      {:ok, comment} ->
-        notify_parent({:saved, comment})
-
+      {:ok, _comment} ->
         {:noreply,
          socket
          |> put_flash(:info, "Comment updated successfully")
@@ -68,6 +66,4 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/comment_live/index.ex
+++ b/lib/itsm_web/live/admin/comment_live/index.ex
@@ -23,18 +23,19 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
     {:noreply, stream_delete(socket, :comments, comment)}
   end
 
-  @impl true
-  def handle_info({ItsmWeb.Admin.CommentLive.FormComponent, {:saved, comment}}, socket) do
-    {:noreply, stream_insert(socket, :comments, comment)}
-  end
-
   defp apply_action(socket, :index, params, url) do
-    results =
-      Paging.search_and_pagination(params, url, Comment, [:comment, {:user, :display_name}])
+    value =
+      Paging.search_and_pagination(
+        params,
+        url,
+        Comment,
+        [:comment, {:user, :display_name}],
+        user: :display_name
+      )
 
     socket
-    |> assign(:results, results)
-    |> stream(:comments, results.entries, reset: true)
+    |> assign(:results, value.results)
+    |> stream(:comments, value.entries, reset: true)
     |> assign(:page_title, "Listing Comments")
     |> assign(:comment, nil)
   end

--- a/lib/itsm_web/live/admin/comment_live/index.html.heex
+++ b/lib/itsm_web/live/admin/comment_live/index.html.heex
@@ -1,23 +1,19 @@
 <.header>
   Listing Comments
 </.header>
-<.itsm_table_container results={@results}>
+<.itsm_table_container results={assigns[:results]}>
   <.table
     id="comments"
     rows={@streams.comments}
     row_click={fn {_id, comment} -> JS.navigate(~p"/admin/comments/#{comment}") end}
   >
     <:col :let={{_id, comment}} label={gettext("Resource")}>{comment.resource_type}</:col>
-
     <:col :let={{_id, comment}} label={gettext("Comment")}>{comment.comment}</:col>
-
     <:col :let={{_id, comment}} label={gettext("User")}>{comment.user.display_name}</:col>
-
     <:action :let={{_id, comment}}>
       <div class="sr-only"><.link navigate={~p"/admin/comments/#{comment}"}>Show</.link></div>
       <.link patch={~p"/admin/comments/#{comment}/edit"}>Edit</.link>
     </:action>
-
     <:action :let={{id, comment}}>
       <.link
         phx-click={JS.push("delete", value: %{id: comment.id}) |> hide("##{id}")}
@@ -28,11 +24,12 @@
     </:action>
   </.table>
 </.itsm_table_container>
+
 <.modal
-  :if={@live_action == :edit}
+  :if={@live_action in [:new, :edit]}
   id="comment-modal"
   show
-  on_cancel={JS.patch(~p"/admin/comments?#{@results.params}")}
+  on_cancel={JS.patch(~p"/admin/comments?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.Admin.CommentLive.FormComponent}
@@ -40,6 +37,6 @@
     title={@page_title}
     action={@live_action}
     comment={@comment}
-    patch={~p"/admin/comments?#{@results.params}"}
+    patch={~p"/admin/comments?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/comment_live/show.ex
+++ b/lib/itsm_web/live/admin/comment_live/show.ex
@@ -13,7 +13,7 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:comment, Comments.get_comment!(id))}
+     |> assign(:comment, Comments.get_comment!(id) |> Comments.preload_user())}
   end
 
   defp page_title(:show), do: "Show Comment"

--- a/lib/itsm_web/live/admin/comment_live/show.html.heex
+++ b/lib/itsm_web/live/admin/comment_live/show.html.heex
@@ -1,7 +1,6 @@
 <.header>
   Comment {@comment.id}
   <:subtitle>This is a comment record from your database.</:subtitle>
-
   <:actions>
     <.link patch={~p"/admin/comments/#{@comment}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit comment</.button>
@@ -11,27 +10,21 @@
 
 <.list>
   <:item title={gettext("Resource")}>{@comment.resource_type}</:item>
-
   <:item title={gettext("Comment")}>{@comment.comment}</:item>
-
   <:item title={gettext("User")}>{@comment.user.display_name}</:item>
-
-  <:item title={gettext("Inserted at")}>
+  <:item title={gettext("Inserted At")}>
     <span
       id={"comment-inserted-at-#{@comment.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@comment.inserted_at}
-    >
-    </span>
+    />
   </:item>
-
-  <:item title={gettext("Updated at")}>
+  <:item title={gettext("Updated At")}>
     <span
       id={"comment-updated-at-#{@comment.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@comment.updated_at}
-    >
-    </span>
+    />
   </:item>
 </.list>
 

--- a/lib/itsm_web/live/admin/common_code_live/form_component.ex
+++ b/lib/itsm_web/live/admin/common_code_live/form_component.ex
@@ -63,9 +63,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
 
   defp save_common_code(socket, :edit, common_code_params) do
     case CommonCodes.update_common_code(socket.assigns.common_code, common_code_params) do
-      {:ok, common_code} ->
-        notify_parent({:saved, common_code})
-
+      {:ok, _common_code} ->
         {:noreply,
          socket
          |> put_flash(:info, "Common Code updated successfully")
@@ -78,9 +76,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
 
   defp save_common_code(socket, :new, common_code_params) do
     case CommonCodes.create_common_code(common_code_params) do
-      {:ok, common_code} ->
-        notify_parent({:saved, common_code})
-
+      {:ok, _common_code} ->
         {:noreply,
          socket
          |> put_flash(:info, "Common Code created successfully")
@@ -90,6 +86,4 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/common_code_live/index.ex
+++ b/lib/itsm_web/live/admin/common_code_live/index.ex
@@ -23,18 +23,13 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
     {:noreply, stream_delete(socket, :common_codes, common_code)}
   end
 
-  @impl true
-  def handle_info({ItsmWeb.Admin.CommonCodeLive.FormComponent, {:saved, common_code}}, socket) do
-    {:noreply, stream_insert(socket, :common_codes, common_code)}
-  end
-
   defp apply_action(socket, :index, params, url) do
-    results =
-      Paging.search_and_pagination(params, url, CommonCode, [:label, :code])
+    value =
+      Paging.search_and_pagination(params, url, CommonCode, [:group_code, :label, :code])
 
     socket
-    |> assign(:results, results)
-    |> stream(:common_codes, results.entries, reset: true)
+    |> assign(:results, value.results)
+    |> stream(:common_codes, value.entries, reset: true)
     |> assign(:page_title, "Listing Common codes")
     |> assign(:common_code, nil)
   end

--- a/lib/itsm_web/live/admin/common_code_live/index.html.heex
+++ b/lib/itsm_web/live/admin/common_code_live/index.html.heex
@@ -6,7 +6,7 @@
     </.link>
   </:actions>
 </.header>
-<.itsm_table_container results={@results}>
+<.itsm_table_container results={assigns[:results]}>
   <.table
     id="common_codes_table"
     rows={@streams.common_codes}
@@ -41,7 +41,7 @@
   :if={@live_action in [:new, :edit]}
   id="codes-modal"
   show
-  on_cancel={JS.patch(~p"/admin/common_codes?#{@results.params}")}
+  on_cancel={JS.patch(~p"/admin/common_codes?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.Admin.CommonCodeLive.FormComponent}
@@ -49,6 +49,6 @@
     title={@page_title}
     action={@live_action}
     common_code={@common_code}
-    patch={~p"/admin/common_codes?#{@results.params}"}
+    patch={~p"/admin/common_codes?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/common_code_live/show.html.heex
+++ b/lib/itsm_web/live/admin/common_code_live/show.html.heex
@@ -9,28 +9,25 @@
 </.header>
 
 <.list>
-  <:item title={gettext("Group code")}>{@common_code.group_code}</:item>
+  <:item title={gettext("Group Code")}>{@common_code.group_code}</:item>
   <:item title={gettext("Code")}>{@common_code.code}</:item>
   <:item title={gettext("Label")}>{@common_code.label}</:item>
   <:item title={gettext("Description")}>{@common_code.description}</:item>
-  <:item title={gettext("Sort order")}>{@common_code.sort_order}</:item>
-  <:item title={gettext("Is active")}>{@common_code.is_active}</:item>
-  <:item title={gettext("Inserted at")}>
+  <:item title={gettext("Sort Order")}>{@common_code.sort_order}</:item>
+  <:item title={gettext("Is Active")}>{@common_code.is_active}</:item>
+  <:item title={gettext("Inserted At")}>
     <span
       id={"common_code-inserted-at-#{@common_code.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@common_code.inserted_at}
-    >
-    </span>
+    />
   </:item>
-
-  <:item title={gettext("Updated at")}>
+  <:item title={gettext("Updated At")}>
     <span
       id={"common_code-updated-at-#{@common_code.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@common_code.updated_at}
-    >
-    </span>
+    />
   </:item>
 </.list>
 

--- a/lib/itsm_web/live/admin/crew_live/form_component.ex
+++ b/lib/itsm_web/live/admin/crew_live/form_component.ex
@@ -21,7 +21,7 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
         {@title}
         <:subtitle>Use this form to manage crew records in your database.</:subtitle>
       </.header>
-      
+
       <.simple_form
         for={@form}
         id="crew-form"
@@ -57,9 +57,7 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
 
   defp save_crew(socket, :edit, crew_params) do
     case Crews.update_crew(socket.assigns.crew, crew_params) do
-      {:ok, crew} ->
-        notify_parent({:saved, crew})
-
+      {:ok, _crew} ->
         {:noreply,
          socket
          |> put_flash(:info, "Crew updated successfully")
@@ -74,9 +72,7 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
     current_user = socket.assigns.current_user
 
     case Crews.create_crew(current_user, crew_params) do
-      {:ok, crew} ->
-        notify_parent({:saved, crew})
-
+      {:ok, _crew} ->
         {:noreply,
          socket
          |> put_flash(:info, "Crew created successfully")
@@ -86,6 +82,4 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/crew_live/index.ex
+++ b/lib/itsm_web/live/admin/crew_live/index.ex
@@ -23,13 +23,8 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
     {:noreply, stream_delete(socket, :crews, crew)}
   end
 
-  @impl true
-  def handle_info({ItsmWeb.Admin.CrewLive.FormComponent, {:saved, crew}}, socket) do
-    {:noreply, stream_insert(socket, :crews, crew)}
-  end
-
   defp apply_action(socket, :index, params, url) do
-    results =
+    value =
       Paging.search_and_pagination(params, url, Crew, [
         :name,
         :description,
@@ -37,8 +32,8 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
       ])
 
     socket
-    |> assign(:results, results)
-    |> stream(:crews, results.entries, reset: true)
+    |> assign(:results, value.results)
+    |> stream(:crews, value.entries, reset: true)
     |> assign(:page_title, "Listing Crews")
     |> assign(:crew, nil)
   end

--- a/lib/itsm_web/live/admin/crew_live/index.html.heex
+++ b/lib/itsm_web/live/admin/crew_live/index.html.heex
@@ -2,21 +2,18 @@
   Listing Crews
   <:actions><.link patch={~p"/admin/crews/new"}><.button>New Crew</.button></.link></:actions>
 </.header>
-<.itsm_table_container results={@results}>
+<.itsm_table_container results={assigns[:results]}>
   <.table
     id="crews"
     rows={@streams.crews}
     row_click={fn {_id, crew} -> JS.navigate(~p"/admin/crews/#{crew}") end}
   >
     <:col :let={{_id, crew}} label={gettext("Name")}>{crew.name}</:col>
-
     <:col :let={{_id, crew}} label={gettext("Description")}>{crew.description}</:col>
-
     <:action :let={{_id, crew}}>
       <div class="sr-only"><.link navigate={~p"/admin/crews/#{crew}"}>Show</.link></div>
       <.link patch={~p"/admin/crews/#{crew}/edit"}>Edit</.link>
     </:action>
-
     <:action :let={{id, crew}}>
       <.link
         phx-click={JS.push("delete", value: %{id: crew.id}) |> hide("##{id}")}
@@ -27,11 +24,12 @@
     </:action>
   </.table>
 </.itsm_table_container>
+
 <.modal
   :if={@live_action in [:new, :edit]}
   id="crew-modal"
   show
-  on_cancel={JS.patch(~p"/admin/crews?#{@results.params}")}
+  on_cancel={JS.patch(~p"/admin/crews?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.Admin.CrewLive.FormComponent}
@@ -40,6 +38,6 @@
     action={@live_action}
     crew={@crew}
     current_user={@current_user}
-    patch={~p"/admin/crews?#{@results.params}"}
+    patch={~p"/admin/crews?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/crew_live/show.html.heex
+++ b/lib/itsm_web/live/admin/crew_live/show.html.heex
@@ -1,7 +1,6 @@
 <.header>
   Crew {@crew.id}
   <:subtitle>This is a crew record from your database.</:subtitle>
-
   <:actions>
     <.link patch={~p"/admin/crews/#{@crew}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit crew</.button>
@@ -10,26 +9,21 @@
 </.header>
 
 <.list>
-  <:item title="Name">{@crew.name}</:item>
-
-  <:item title="Description">{@crew.description}</:item>
-
-  <:item title={gettext("Inserted at")}>
+  <:item title={gettext("Name")}>{@crew.name}</:item>
+  <:item title={gettext("Description")}>{@crew.description}</:item>
+  <:item title={gettext("Inserted At")}>
     <span
       id={"crew-inserted-at-#{@crew.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@crew.inserted_at}
-    >
-    </span>
+    />
   </:item>
-
-  <:item title={gettext("Updated at")}>
+  <:item title={gettext("Updated At")}>
     <span
       id={"crew-updated-at-#{@crew.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@crew.updated_at}
-    >
-    </span>
+    />
   </:item>
 </.list>
 

--- a/lib/itsm_web/live/admin/request_live/form_component.ex
+++ b/lib/itsm_web/live/admin/request_live/form_component.ex
@@ -10,7 +10,8 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
      |> assign(assigns)
      |> assign_new(:form, fn ->
        to_form(Requests.change_request(request))
-     end)}
+     end)
+     |> assign_new_options()}
   end
 
   @impl true
@@ -43,7 +44,7 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
           type="select"
           label={gettext("Category")}
           prompt="Choose a value"
-          options={Itsm.Admin.Categories.list_categories() |> Enum.map(&{&1.name, &1.id})}
+          options={@category_options}
         />
         <.itsm_calendar
           :if={@action == :edit}
@@ -69,11 +70,16 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
     save_request(socket, socket.assigns.action, request_params)
   end
 
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:category_options, fn ->
+      Itsm.Admin.Categories.get_category_options()
+    end)
+  end
+
   defp save_request(socket, :edit, request_params) do
     case Requests.update_request(socket.assigns.request, request_params) do
-      {:ok, request} ->
-        notify_parent({:saved, request})
-
+      {:ok, _request} ->
         {:noreply,
          socket
          |> put_flash(:info, "Request updated successfully")
@@ -86,9 +92,7 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
 
   defp save_request(socket, :new, request_params) do
     case Requests.create_request(socket.assigns.current_user, request_params) do
-      {:ok, request} ->
-        notify_parent({:saved, request})
-
+      {:ok, _request} ->
         {:noreply,
          socket
          |> put_flash(:info, "Request created successfully")
@@ -98,6 +102,4 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
-
-  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/live/admin/request_live/index.ex
+++ b/lib/itsm_web/live/admin/request_live/index.ex
@@ -23,13 +23,8 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
     {:noreply, stream_delete(socket, :requests, request)}
   end
 
-  @impl true
-  def handle_info({ItsmWeb.Admin.RequestLive.FormComponent, {:saved, request}}, socket) do
-    {:noreply, stream_insert(socket, :requests, request)}
-  end
-
   defp apply_action(socket, :index, params, url) do
-    results =
+    value =
       Paging.search_and_pagination(
         params,
         url,
@@ -40,12 +35,12 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
           :env,
           :requestor_name
         ],
-        [:category]
+        category: [:request_name, :name]
       )
 
     socket
-    |> assign(:results, results)
-    |> stream(:requests, results.entries, reset: true)
+    |> assign(:results, value.results)
+    |> stream(:requests, value.entries, reset: true)
     |> assign(:page_title, "Listing Requests")
     |> assign(:request, nil)
   end

--- a/lib/itsm_web/live/admin/request_live/index.html.heex
+++ b/lib/itsm_web/live/admin/request_live/index.html.heex
@@ -1,38 +1,28 @@
 <.header>
   Listing Requests
 </.header>
-<.itsm_table_container results={@results}>
+<.itsm_table_container results={assigns[:results]}>
   <.table
     id="requests"
     rows={@streams.requests}
-    row_click={fn {_id, request} -> JS.navigate("/admin/requests/#{request.id}") end}
+    row_click={fn {_id, request} -> JS.navigate(~p"/admin/requests/#{request.id}") end}
   >
     <:col :let={{_id, request}} label={gettext("Title")}>{request.title}</:col>
-
-    <:col
-      :let={{_id, request}}
-      label={gettext("Description")}
-    >
+    <:col :let={{_id, request}} label={gettext("Description")}>
       <div class="w-[90px] truncate">{request.description}</div>
     </:col>
-
     <:col :let={{_id, request}} label={gettext("Environment")}>{request.env}</:col>
-
     <:col :let={{id, request}} label={gettext("Due Date")}>
       <div id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date} />
     </:col>
-
     <:col :let={{_id, request}} label={gettext("Request Type")}>
       {request.category.request_name}
     </:col>
-
     <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
-
     <:action :let={{_id, request}}>
       <div class="sr-only"><.link navigate={~p"/admin/requests/#{request}"}>Show</.link></div>
-      <.link navigate={"/admin/requests/#{request.id}/edit"}>Edit</.link>
+      <.link patch={~p"/admin/requests/#{request.id}/edit"}>Edit</.link>
     </:action>
-
     <:action :let={{id, request}}>
       <.link
         phx-click={JS.push("delete", value: %{id: request.id}) |> hide("##{id}")}
@@ -43,11 +33,12 @@
     </:action>
   </.table>
 </.itsm_table_container>
+
 <.modal
   :if={@live_action == :edit}
   id="request-modal"
   show
-  on_cancel={JS.patch(~p"/admin/requests?#{@results.params}")}
+  on_cancel={JS.patch(~p"/admin/requests?#{assigns[:results][:params] || %{}}")}
 >
   <.live_component
     module={ItsmWeb.Admin.RequestLive.FormComponent}
@@ -55,6 +46,6 @@
     title={@page_title}
     action={@live_action}
     request={@request}
-    patch={~p"/admin/requests?#{@results.params}"}
+    patch={~p"/admin/requests?#{assigns[:results][:params] || %{}}"}
   />
 </.modal>

--- a/lib/itsm_web/live/admin/request_live/show.html.heex
+++ b/lib/itsm_web/live/admin/request_live/show.html.heex
@@ -1,7 +1,6 @@
 <.header>
   Request {@request.id}
   <:subtitle>This is a request record from your database.</:subtitle>
-
   <:actions>
     <.link patch={~p"/admin/requests/#{@request}/show/edit"} phx-click={JS.push_focus()}>
       <.button>Edit request</.button>
@@ -11,25 +10,20 @@
 
 <.list>
   <:item title={gettext("Title")}>{@request.title}</:item>
-
   <:item title={gettext("Description")}>
     <div class="w-[90px] truncate">{@request.description}</div>
   </:item>
-
   <:item title={gettext("Environment")}>{@request.env}</:item>
-
   <:item title={gettext("Due Date")}>
-    <div
-      id={"due-date-" <> to_string(@request.id)}
+    <span
+      id={"due-date-#{@request.id}"}
       phx-hook="LocalTime.ToLocale"
       utc-value={@request.due_date}
     />
   </:item>
-
   <:item title={gettext("Request Type")}>
     {@request.category.request_name}
   </:item>
-
   <:item title={gettext("Request Name")}>{@request.category.name}</:item>
 </.list>
 

--- a/lib/itsm_web/live_utils.ex
+++ b/lib/itsm_web/live_utils.ex
@@ -65,4 +65,17 @@ defmodule ItsmWeb.LiveUtils do
        }}
     end)
   end
+
+  def titleize(term) do
+    term
+    |> to_string()
+    |> String.split(~r/[-_ ]/)
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  def find_label(options, target) do
+    Enum.find_value(options, "알 수 없음", fn {label, value} ->
+      if value == target, do: label
+    end)
+  end
 end

--- a/lib/itsm_web/router.ex
+++ b/lib/itsm_web/router.ex
@@ -187,6 +187,13 @@ defmodule ItsmWeb.Router do
 
       live "/common_codes/:id", Admin.CommonCodeLive.Show, :show
       live "/common_codes/:id/show/edit", Admin.CommonCodeLive.Show, :edit
+
+      live "/assets", Admin.AssetLive.Index, :index
+      live "/assets/new", Admin.AssetLive.Index, :new
+      live "/assets/:id/edit", Admin.AssetLive.Index, :edit
+
+      live "/assets/:id", Admin.AssetLive.Show, :show
+      live "/assets/:id/show/edit", Admin.AssetLive.Show, :edit
     end
   end
 

--- a/lib/mix/tasks/gen.Itsm.admin_html.ex
+++ b/lib/mix/tasks/gen.Itsm.admin_html.ex
@@ -1,0 +1,284 @@
+defmodule Mix.Tasks.Phx.Gen.Itsm.AdminHtml do
+  @shortdoc "Generates context and controller for an HTML resource"
+
+  @moduledoc """
+  Generates controller with view, templates, schema and context for an HTML resource.
+
+      mix phx.gen.html Accounts User users name:string age:integer
+
+  The first argument, `Accounts`, is the resource's context.
+  A context is an Elixir module that serves as an API boundary for closely related resources.
+
+  The second argument, `User`, is the resource's schema.
+  A schema is an Elixir module responsible for mapping database fields into an Elixir struct.
+  The `User` schema above specifies two fields with their respective colon-delimited data types:
+  `name:string` and `age:integer`. See `mix phx.gen.schema` for more information on attributes.
+
+  > Note: A resource may also be split
+  > over distinct contexts (such as `Accounts.User` and `Payments.User`).
+
+  This generator adds the following files to `lib/`:
+
+    * a controller in `lib/my_app_web/controllers/user_controller.ex`
+    * default CRUD HTML templates in `lib/my_app_web/controllers/user_html`
+    * an HTML view collocated with the controller in `lib/my_app_web/controllers/user_html.ex`
+    * a schema in `lib/my_app/accounts/user.ex`, with an `users` table
+    * a context module in `lib/my_app/accounts.ex` for the accounts API
+
+  Additionally, this generator creates the following files:
+
+    * a migration for the schema in `priv/repo/migrations`
+    * a controller test module in `test/my_app/controllers/user_controller_test.exs`
+    * a context test module in `test/my_app/accounts_test.exs`
+    * a context test helper module in `test/support/fixtures/accounts_fixtures.ex`
+
+  If the context already exists, this generator injects functions for the given resource into
+  the context, context test, and context test helper modules.
+
+  ## Umbrella app configuration
+
+  By default, Phoenix injects both web and domain specific functionality into the same
+  application. When using umbrella applications, those concerns are typically broken
+  into two separate apps, your context application - let's call it `my_app` - and its web
+  layer, which Phoenix assumes to be `my_app_web`.
+
+  You can teach Phoenix to use this style via the `:context_app` configuration option
+  in your `my_app_umbrella/config/config.exs`:
+
+      config :my_app_web,
+        ecto_repos: [Stuff.Repo],
+        generators: [context_app: :my_app]
+
+  Alternatively, the `--context-app` option may be supplied to the generator:
+
+      mix phx.gen.html Sales User users --context-app my_app
+
+  If you delete the `:context_app` configuration option, Phoenix will automatically put generated web files in
+  `my_app_umbrella/apps/my_app_web_web`.
+
+  If you change the value of `:context_app` to `:new_value`, `my_app_umbrella/apps/new_value_web`
+  must already exist or you will get the following error:
+
+     ** (Mix) no directory for context_app :new_value found in my_app_web's deps.
+
+  ## Web namespace
+
+  By default, the controller and HTML view will be namespaced by the schema name.
+  You can customize the web module namespace by passing the `--web` flag with a
+  module name, for example:
+
+      mix phx.gen.html Sales User users --web Sales
+
+  Which would generate a `lib/app_web/controllers/sales/user_controller.ex` and
+  `lib/app_web/controllers/sales/user_html.ex`.
+
+  ## Customizing the context, schema, tables and migrations
+
+  In some cases, you may wish to bootstrap HTML templates, controllers,
+  and controller tests, but leave internal implementation of the context
+  or schema to yourself. You can use the `--no-context` and `--no-schema`
+  flags for file generation control.
+
+  You can also change the table name or configure the migrations to
+  use binary ids for primary keys, see `mix phx.gen.schema` for more
+  information.
+  """
+  use Mix.Task
+
+  alias Mix.Phoenix.{Context, Schema}
+  alias Mix.Tasks.Phx.Gen
+
+  @doc false
+  def run(args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise(
+        "mix phx.gen.html must be invoked from within your *_web application root directory"
+      )
+    end
+
+    Mix.Phoenix.ensure_live_view_compat!(__MODULE__)
+
+    {context, schema} = Gen.Context.build(args)
+    Gen.Context.prompt_for_code_injection(context)
+
+    binding = [context: context, schema: schema, inputs: inputs(schema)]
+    paths = Mix.Phoenix.generator_paths()
+
+    prompt_for_conflicts(context)
+
+    context
+    |> copy_new_files(paths, binding)
+    |> print_shell_instructions()
+  end
+
+  defp prompt_for_conflicts(context) do
+    context
+    |> files_to_be_generated()
+    |> Kernel.++(context_files(context))
+    |> Mix.Phoenix.prompt_for_conflicts()
+  end
+
+  defp context_files(%Context{generate?: true} = context) do
+    Gen.Context.files_to_be_generated(context)
+  end
+
+  defp context_files(%Context{generate?: false}) do
+    []
+  end
+
+  @doc false
+  def files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
+    singular = schema.singular
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    test_prefix = Mix.Phoenix.web_test_path(context_app)
+    web_path = to_string(schema.web_path)
+    controller_pre = Path.join([web_prefix, "controllers", web_path])
+    test_pre = Path.join([test_prefix, "controllers", web_path])
+
+    [
+      {:eex, "controller.ex", Path.join([controller_pre, "#{singular}_controller.ex"])},
+      {:eex, "edit.html.heex", Path.join([controller_pre, "#{singular}_html", "edit.html.heex"])},
+      {:eex, "index.html.heex",
+       Path.join([controller_pre, "#{singular}_html", "index.html.heex"])},
+      {:eex, "new.html.heex", Path.join([controller_pre, "#{singular}_html", "new.html.heex"])},
+      {:eex, "show.html.heex", Path.join([controller_pre, "#{singular}_html", "show.html.heex"])},
+      {:eex, "resource_form.html.heex",
+       Path.join([controller_pre, "#{singular}_html", "#{singular}_form.html.heex"])},
+      {:eex, "html.ex", Path.join([controller_pre, "#{singular}_html.ex"])},
+      {:eex, "controller_test.exs", Path.join([test_pre, "#{singular}_controller_test.exs"])}
+    ]
+  end
+
+  @doc false
+  def copy_new_files(%Context{} = context, paths, binding) do
+    files = files_to_be_generated(context)
+    Mix.Phoenix.copy_from(paths, "priv/templates/phx.gen.html", binding, files)
+    if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
+    context
+  end
+
+  @doc false
+  def print_shell_instructions(%Context{schema: schema, context_app: ctx_app} = context) do
+    if schema.web_namespace do
+      Mix.shell().info("""
+
+      Add the resource to your #{schema.web_namespace} :browser scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+
+          scope "/#{schema.web_path}", #{inspect(Module.concat(context.web_module, schema.web_namespace))}, as: :#{schema.web_path} do
+            pipe_through :browser
+            ...
+            resources "/#{schema.plural}", #{inspect(schema.alias)}Controller
+          end
+      """)
+    else
+      Mix.shell().info("""
+
+      Add the resource to your browser scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+
+          resources "/#{schema.plural}", #{inspect(schema.alias)}Controller
+      """)
+    end
+
+    if context.generate?, do: Gen.Context.print_shell_instructions(context)
+  end
+
+  @doc false
+  def inputs(%Schema{} = schema) do
+    schema.attrs
+    |> Enum.reject(fn {_key, type} -> type == :map end)
+    |> Enum.map(fn
+      {key, :integer} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="number" label=#{label(key)} />)
+
+      {key, :float} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="number" label=#{label(key)} step="any" />)
+
+      {key, :decimal} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="number" label=#{label(key)} step="any" />)
+
+      {key, :boolean} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="checkbox" label=#{label(key)} />)
+
+      {key, :text} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="text" label=#{label(key)} />)
+
+      {key, :date} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="date" label=#{label(key)} />)
+
+      {key, :time} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="time" label=#{label(key)} />)
+
+      {key, :utc_datetime} ->
+        ~s(<.itsm_calendar
+  field={@form[#{inspect(key)}]}
+  label=#{label(key)}
+  show_time
+  default_selected_date_time={@form[:inserted_at].value}
+/>)
+
+      {key, :naive_datetime} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="datetime-local" label=#{label(key)} />)
+
+      {key, {:array, _} = type} ->
+        ~s"""
+        <.input
+          field={@form[#{inspect(key)}]}
+          type="select"
+          multiple
+          label=#{label(key)}
+          options={#{inspect(default_options(type))}}
+        />
+        """
+
+      {key, {:enum, _}} ->
+        ~s"""
+        <.input
+          field={@form[#{inspect(key)}]}
+          type="select"
+          label=#{label(key)}
+          prompt="Choose a value"
+          options={Ecto.Enum.values(#{inspect(schema.module)}, #{inspect(key)})}
+        />
+        """
+
+      {key, _} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="text" label=#{label(key)} />)
+    end)
+  end
+
+  defp default_options({:array, :string}),
+    do: Enum.map([1, 2], &{"Option #{&1}", "option#{&1}"})
+
+  defp default_options({:array, :integer}),
+    do: Enum.map([1, 2], &{"#{&1}", &1})
+
+  defp default_options({:array, _}), do: []
+
+  defp label(key) do
+    humanized = ItsmWeb.LiveUtils.titleize(key)
+    "{gettext(\"#{humanized}\")}"
+  end
+
+  @doc false
+  def indent_inputs(inputs, column_padding) do
+    columns = String.duplicate(" ", column_padding)
+
+    inputs
+    |> Enum.map(fn input ->
+      lines = input |> String.split("\n") |> Enum.reject(&(&1 == ""))
+
+      case lines do
+        [] ->
+          []
+
+        [line] ->
+          [columns, line]
+
+        [first_line | rest] ->
+          rest = Enum.map_join(rest, "\n", &(columns <> &1))
+          [columns, first_line, "\n", rest]
+      end
+    end)
+    |> Enum.intersperse("\n")
+  end
+end

--- a/lib/mix/tasks/gen.Itsm.admin_live.ex
+++ b/lib/mix/tasks/gen.Itsm.admin_live.ex
@@ -1,0 +1,283 @@
+defmodule Mix.Tasks.Phx.Gen.Itsm.AdminLive do
+  @shortdoc "Generates Admin LiveView, templates, and context for a resource"
+
+  @moduledoc """
+  Generates LiveView, templates, and context for a resource.
+
+      mix phx.gen.admin_live Accounts User users name:string age:integer
+
+  The first argument is the context module.  The context is an Elixir module
+  that serves as an API boundary for the given resource. A context often holds
+  many related resources.  Therefore, if the context already exists, it will be
+  augmented with functions for the given resource.
+
+  The second argument is the schema module.  The schema is responsible for
+  mapping the database fields into an Elixir struct.
+
+  The remaining arguments are the schema module plural name (used as the schema
+  table name), and an optional list of attributes as their respective names and
+  types.  See `mix help phx.gen.schema` for more information on attributes.
+
+  When this command is run for the first time, a `Components` module will be
+  created if it does not exist, along with the resource level LiveViews and
+  components, including `UserLive.Index`, `UserLive.Show`, and
+  `UserLive.FormComponent` modules for the new resource.
+
+  > Note: A resource may also be split
+  > over distinct contexts (such as `Accounts.User` and `Payments.User`).
+
+  Overall, this generator will add the following files:
+
+    * a context module in `lib/app/accounts.ex` for the accounts API
+    * a schema in `lib/app/accounts/user.ex`, with a `users` table
+    * a LiveView in `lib/app_web/live/user_live/show.ex`
+    * a LiveView in `lib/app_web/live/user_live/index.ex`
+    * a LiveComponent in `lib/app_web/live/user_live/form_component.ex`
+    * a helpers module in `lib/app_web/live/live_helpers.ex` with a modal
+
+  After file generation is complete, there will be output regarding required
+  updates to the `lib/app_web/router.ex` file.
+
+      Add the live routes to your browser scope in lib/app_web/router.ex:
+
+        live "/users", UserLive.Index, :index
+        live "/users/new", UserLive.Index, :new
+        live "/users/:id/edit", UserLive.Index, :edit
+
+        live "/users/:id", UserLive.Show, :show
+        live "/users/:id/show/edit", UserLive.Show, :edit
+
+  ## The context app
+
+  A migration file for the repository and test files for the context and
+  controller features will also be generated.
+
+  The location of the web files (LiveView's, views, templates, etc.) in an
+  umbrella application will vary based on the `:context_app` config located
+  in your applications `:generators` configuration. When set, the Phoenix
+  generators will generate web files directly in your lib and test folders
+  since the application is assumed to be isolated to web specific functionality.
+  If `:context_app` is not set, the generators will place web related lib
+  and test files in a `web/` directory since the application is assumed
+  to be handling both web and domain specific functionality.
+  Example configuration:
+
+      config :my_app_web, :generators, context_app: :my_app
+
+  Alternatively, the `--context-app` option may be supplied to the generator:
+
+      mix phx.gen.live Accounts User users --context-app warehouse
+
+  ## Web namespace
+
+  By default, the LiveView modules will be namespaced by the web module.
+  You can customize the web module namespace by passing the `--web` flag with a
+  module name, for example:
+
+      mix phx.gen.live Accounts User users --web Sales
+
+  Which would generate the LiveViews in `lib/app_web/live/sales/user_live/`,
+  namespaced `AppWeb.Sales.UserLive` instead of `AppWeb.UserLive`.
+
+  ## Customizing the context, schema, tables and migrations
+
+  In some cases, you may wish to bootstrap HTML templates, LiveViews,
+  and tests, but leave internal implementation of the context or schema
+  to yourself. You can use the `--no-context` and `--no-schema` flags
+  for file generation control.
+
+      mix phx.gen.live Accounts User users --no-context --no-schema
+
+  In the cases above, tests are still generated, but they will all fail.
+
+  You can also change the table name or configure the migrations to
+  use binary ids for primary keys, see `mix help phx.gen.schema` for more
+  information.
+  """
+  use Mix.Task
+
+  alias Mix.Phoenix.{Context, Schema}
+  alias Mix.Tasks.Phx.Gen
+
+  @doc false
+  def run(args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise(
+        "mix phx.gen.admin_live must be invoked from within your *_web application root directory"
+      )
+    end
+
+    Mix.Phoenix.ensure_live_view_compat!(__MODULE__)
+
+    {%Context{} = context, %Schema{} = schema} = Gen.Context.build(args)
+
+    context = %{context | schema: %{context.schema | generate?: false, migration?: false}}
+
+    Gen.Context.prompt_for_code_injection(context)
+
+    binding = [context: context, schema: context.schema]
+    paths = Mix.Phoenix.generator_paths()
+
+    if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
+
+    admin_context = %{
+      context
+      | module: Module.concat([Itsm.Admin, context.alias]),
+        schema: %{
+          schema
+          | web_path: "admin",
+            web_namespace: Admin,
+            route_prefix: "/admin" <> schema.route_prefix
+        },
+        file: Path.join(["lib", "itsm", "admin", "#{context.basename}.ex"]),
+        test_file: "test/itsm/admin/#{context.basename}_test.exs",
+        test_fixtures_file: "test/support/fixtures/admin/#{context.basename}_fixtures.ex"
+    }
+
+    Gen.Context.prompt_for_code_injection(admin_context)
+
+    admin_binding = [
+      context: admin_context,
+      schema: admin_context.schema,
+      inputs: Mix.Tasks.Phx.Gen.Itsm.AdminHtml.inputs(context.schema)
+    ]
+
+    admin_context
+    |> copy_new_files(admin_binding, paths)
+    |> maybe_inject_imports()
+    |> print_shell_instructions()
+  end
+
+  defp files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    test_prefix = Mix.Phoenix.web_test_path(context_app)
+    web_path = to_string(schema.web_path)
+    live_subdir = "#{schema.singular}_live"
+    web_live = Path.join([web_prefix, "live", web_path, live_subdir])
+    test_live = Path.join([test_prefix, "live", web_path])
+
+    [
+      {:eex, "show.ex.eex", Path.join(web_live, "show.ex")},
+      {:eex, "index.ex.eex", Path.join(web_live, "index.ex")},
+      {:eex, "form_component.ex.eex", Path.join(web_live, "form_component.ex")},
+      {:eex, "index.html.heex.eex", Path.join(web_live, "index.html.heex")},
+      {:eex, "show.html.heex.eex", Path.join(web_live, "show.html.heex")},
+      {:eex, "live_test.exs.eex", Path.join(test_live, "#{schema.singular}_live_test.exs")},
+      {:new_eex, "core_components.ex.eex",
+       Path.join([web_prefix, "components", "core_components.ex"])}
+    ]
+  end
+
+  defp copy_new_files(%Context{} = context, binding, paths) do
+    files = files_to_be_generated(context)
+
+    binding =
+      Keyword.merge(binding,
+        assigns: %{
+          web_namespace: inspect(context.web_module),
+          gettext: true
+        }
+      )
+
+    Mix.Phoenix.copy_from(paths, "priv/templates/phx.gen.itsm.admin_live", binding, files)
+    if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
+
+    context
+  end
+
+  defp maybe_inject_imports(%Context{context_app: ctx_app} = context) do
+    web_prefix = Mix.Phoenix.web_path(ctx_app)
+    [lib_prefix, web_dir] = Path.split(web_prefix)
+    file_path = Path.join(lib_prefix, "#{web_dir}.ex")
+    file = File.read!(file_path)
+    inject = "import #{inspect(context.web_module)}.CoreComponents"
+
+    if String.contains?(file, inject) do
+      :ok
+    else
+      do_inject_imports(context, file, file_path, inject)
+    end
+
+    context
+  end
+
+  defp do_inject_imports(context, file, file_path, inject) do
+    Mix.shell().info([:green, "* injecting ", :reset, Path.relative_to_cwd(file_path)])
+
+    new_file =
+      String.replace(
+        file,
+        "use Phoenix.Component",
+        "use Phoenix.Component\n      #{inject}"
+      )
+
+    if file != new_file do
+      File.write!(file_path, new_file)
+    else
+      Mix.shell().info("""
+
+      Could not find use Phoenix.Component in #{file_path}.
+
+      This typically happens because your application was not generated
+      with the --live flag:
+
+          mix phx.new my_app --live
+
+      Please make sure LiveView is installed and that #{inspect(context.web_module)}
+      defines both `live_view/0` and `live_component/0` functions,
+      and that both functions import #{inspect(context.web_module)}.CoreComponents.
+      """)
+    end
+  end
+
+  @doc false
+  def print_shell_instructions(%Context{schema: schema, context_app: ctx_app} = context) do
+    prefix = Module.concat(context.web_module, schema.web_namespace)
+    web_path = Mix.Phoenix.web_path(ctx_app)
+
+    if schema.web_namespace do
+      Mix.shell().info("""
+
+      Add the live routes to your #{schema.web_namespace} :browser scope in #{web_path}/router.ex:
+
+          scope "/#{schema.web_path}", #{inspect(prefix)}, as: :#{schema.web_path} do
+            pipe_through :browser
+            ...
+
+      #{for line <- live_route_instructions(schema), do: "      #{line}"}
+          end
+      """)
+    else
+      Mix.shell().info("""
+
+      Add the live routes to your browser scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+
+      #{for line <- live_route_instructions(schema), do: "    #{line}"}
+      """)
+    end
+
+    if context.generate?, do: Gen.Context.print_shell_instructions(context)
+    maybe_print_upgrade_info()
+  end
+
+  defp maybe_print_upgrade_info do
+    unless Code.ensure_loaded?(Phoenix.LiveView.JS) do
+      Mix.shell().info("""
+
+      You must update :phoenix_live_view to v0.18 or later and
+      :phoenix_live_dashboard to v0.7 or later to use the features
+      in this generator.
+      """)
+    end
+  end
+
+  defp live_route_instructions(schema) do
+    [
+      ~s|live "/#{schema.plural}", Admin.#{inspect(schema.alias)}Live.Index, :index\n|,
+      ~s|live "/#{schema.plural}/new", Admin.#{inspect(schema.alias)}Live.Index, :new\n|,
+      ~s|live "/#{schema.plural}/:id/edit", Admin.#{inspect(schema.alias)}Live.Index, :edit\n\n|,
+      ~s|live "/#{schema.plural}/:id", Admin.#{inspect(schema.alias)}Live.Show, :show\n|,
+      ~s|live "/#{schema.plural}/:id/show/edit", Admin.#{inspect(schema.alias)}Live.Show, :edit|
+    ]
+  end
+end

--- a/priv/templates/phx.gen.context/access_no_schema.ex
+++ b/priv/templates/phx.gen.context/access_no_schema.ex
@@ -1,0 +1,25 @@
+  alias <%= inspect schema.module %>
+
+  def get_<%= schema.singular %>!(id), do: Repo.get!(<%= inspect schema.alias %>, id)
+
+  def list_<%= schema.plural %>, do: Repo.all(<%= inspect schema.alias %>)
+
+  def create_<%= schema.singular %>(attrs \\ %{}) do
+    %<%= inspect schema.alias %>{}
+    |> <%= inspect schema.alias %>.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
+    <%= schema.singular %>
+    |> <%= inspect schema.alias %>.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
+    Repo.delete(<%= schema.singular %>)
+  end
+
+  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
+    <%= inspect schema.alias %>.changeset(<%= schema.singular %>, attrs)
+  end

--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -1,0 +1,21 @@
+  alias <%= inspect schema.module %>
+
+  defdelegate get_<%= schema.singular %>!(id), to: Itsm.<%= inspect context.alias %>
+
+  defdelegate list_<%= schema.plural %>, to: Itsm.<%= inspect context.alias %>
+
+  defdelegate create_<%= schema.singular %>(attrs \\ %{}), to: Itsm.<%= inspect context.alias %>
+
+  def update_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
+    <%= schema.singular %>
+    |> <%= inspect schema.alias %>.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
+    |> Repo.update()
+  end
+
+  defdelegate delete_<%= schema.singular %>(<%= schema.singular %>), to: Itsm.<%= inspect context.alias %>
+
+  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
+    <%= inspect schema.alias %>.changeset(<%= schema.singular %>, attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
+  end

--- a/priv/templates/phx.gen.itsm.admin_live/core_components.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/core_components.ex.eex
@@ -1,0 +1,690 @@
+defmodule <%= @web_namespace %>.CoreComponents do
+  @moduledoc """
+  Provides core UI components.
+
+  At first glance, this module may seem daunting, but its goal is to provide
+  core building blocks for your application, such as modals, tables, and
+  forms. The components consist mostly of markup and are well-documented
+  with doc strings and declarative assigns. You may customize and style
+  them in any way you want, based on your application growth and needs.
+
+  The default components use Tailwind CSS, a utility-first CSS framework.
+  See the [Tailwind CSS documentation](https://tailwindcss.com) to learn
+  how to customize them or feel free to swap in another framework altogether.
+
+  Icons are provided by [heroicons](https://heroicons.com). See `icon/1` for usage.
+  """
+  use Phoenix.Component<%= if @gettext do %>
+  use Gettext, backend: <%= @web_namespace %>.Gettext<% end %>
+
+  alias Phoenix.LiveView.JS
+
+  @doc """
+  Renders a modal.
+
+  ## Examples
+
+      <.modal id="confirm-modal">
+        This is a modal.
+      </.modal>
+
+  JS commands may be passed to the `:on_cancel` to configure
+  the closing/cancel event, for example:
+
+      <.modal id="confirm" on_cancel={JS.navigate(~p"/posts")}>
+        This is another modal.
+      </.modal>
+
+  """
+  attr :id, :string, required: true
+  attr :show, :boolean, default: false
+  attr :on_cancel, JS, default: %JS{}
+  slot :inner_block, required: true
+
+  def modal(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      phx-mounted={@show && show_modal(@id)}
+      phx-remove={hide_modal(@id)}
+      data-cancel={JS.exec(@on_cancel, "phx-remove")}
+      class="relative z-50 hidden"
+    >
+      <div id={"#{@id}-bg"} class="bg-zinc-50/90 fixed inset-0 transition-opacity" aria-hidden="true" />
+      <div
+        class="fixed inset-0 overflow-y-auto"
+        aria-labelledby={"#{@id}-title"}
+        aria-describedby={"#{@id}-description"}
+        role="dialog"
+        aria-modal="true"
+        tabindex="0"
+      >
+        <div class="flex min-h-full items-center justify-center">
+          <div class="w-full max-w-3xl p-4 sm:p-6 lg:py-8">
+            <.focus_wrap
+              id={"#{@id}-container"}
+              phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
+              phx-key="escape"
+              phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
+              class="shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-2xl bg-white p-14 shadow-lg ring-1 transition"
+            >
+              <div class="absolute top-6 right-5">
+                <button
+                  phx-click={JS.exec("data-cancel", to: "##{@id}")}
+                  type="button"
+                  class="-m-3 flex-none p-3 opacity-20 hover:opacity-40"
+                  aria-label=<%= maybe_heex_attr_gettext.("close", @gettext) %>
+                >
+                  <.icon name="hero-x-mark-solid" class="h-5 w-5" />
+                </button>
+              </div>
+              <div id={"#{@id}-content"}>
+                {render_slot(@inner_block)}
+              </div>
+            </.focus_wrap>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders flash notices.
+
+  ## Examples
+
+      <.flash kind={:info} flash={@flash} />
+      <.flash kind={:info} phx-mounted={show("#flash")}>Welcome Back!</.flash>
+  """
+  attr :id, :string, doc: "the optional id of flash container"
+  attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
+  attr :title, :string, default: nil
+  attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+  attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
+
+  slot :inner_block, doc: "the optional inner block that renders the flash message"
+
+  def flash(assigns) do
+    assigns = assign_new(assigns, :id, fn -> "flash-#{assigns.kind}" end)
+
+    ~H"""
+    <div
+      :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
+      id={@id}
+      phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
+      role="alert"
+      class={[
+        "fixed top-2 right-2 mr-2 w-80 sm:w-96 z-50 rounded-lg p-3 ring-1",
+        @kind == :info && "bg-emerald-50 text-emerald-800 ring-emerald-500 fill-cyan-900",
+        @kind == :error && "bg-rose-50 text-rose-900 shadow-md ring-rose-500 fill-rose-900"
+      ]}
+      {@rest}
+    >
+      <p :if={@title} class="flex items-center gap-1.5 text-sm font-semibold leading-6">
+        <.icon :if={@kind == :info} name="hero-information-circle-mini" class="h-4 w-4" />
+        <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="h-4 w-4" />
+        {@title}
+      </p>
+      <p class="mt-2 text-sm leading-5">{msg}</p>
+      <button type="button" class="group absolute top-1 right-1 p-2" aria-label=<%= maybe_heex_attr_gettext.("close", @gettext) %>>
+        <.icon name="hero-x-mark-solid" class="h-5 w-5 opacity-40 group-hover:opacity-70" />
+      </button>
+    </div>
+    """
+  end
+
+  @doc """
+  Shows the flash group with standard titles and content.
+
+  ## Examples
+
+      <.flash_group flash={@flash} />
+  """
+  attr :flash, :map, required: true, doc: "the map of flash messages"
+  attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
+
+  def flash_group(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.flash kind={:info} title=<%= maybe_heex_attr_gettext.("Success!", @gettext) %> flash={@flash} />
+      <.flash kind={:error} title=<%= maybe_heex_attr_gettext.("Error!", @gettext) %> flash={@flash} />
+      <.flash
+        id="client-error"
+        kind={:error}
+        title=<%= maybe_heex_attr_gettext.("We can't find the internet", @gettext) %>
+        phx-disconnected={show(".phx-client-error #client-error")}
+        phx-connected={hide("#client-error")}
+        hidden
+      >
+        <%= maybe_eex_gettext.("Attempting to reconnect", @gettext) %>
+        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+      </.flash>
+
+      <.flash
+        id="server-error"
+        kind={:error}
+        title=<%= maybe_heex_attr_gettext.("Something went wrong!", @gettext) %>
+        phx-disconnected={show(".phx-server-error #server-error")}
+        phx-connected={hide("#server-error")}
+        hidden
+      >
+        <%= maybe_eex_gettext.("Hang in there while we get back on track", @gettext) %>
+        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+      </.flash>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a simple form.
+
+  ## Examples
+
+      <.simple_form for={@form} phx-change="validate" phx-submit="save">
+        <.input field={@form[:email]} label="Email"/>
+        <.input field={@form[:username]} label="Username" />
+        <:actions>
+          <.button>Save</.button>
+        </:actions>
+      </.simple_form>
+  """
+  attr :for, :any, required: true, doc: "the data structure for the form"
+  attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+
+  attr :rest, :global,
+    include: ~w(autocomplete name rel action enctype method novalidate target multipart),
+    doc: "the arbitrary HTML attributes to apply to the form tag"
+
+  slot :inner_block, required: true
+  slot :actions, doc: "the slot for form actions, such as a submit button"
+
+  def simple_form(assigns) do
+    ~H"""
+    <.form :let={f} for={@for} as={@as} {@rest}>
+      <div class="mt-10 space-y-8 bg-white">
+        {render_slot(@inner_block, f)}
+        <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
+          {render_slot(action, f)}
+        </div>
+      </div>
+    </.form>
+    """
+  end
+
+  @doc """
+  Renders a button.
+
+  ## Examples
+
+      <.button>Send!</.button>
+      <.button phx-click="go" class="ml-2">Send!</.button>
+  """
+  attr :type, :string, default: nil
+  attr :class, :string, default: nil
+  attr :rest, :global, include: ~w(disabled form name value)
+
+  slot :inner_block, required: true
+
+  def button(assigns) do
+    ~H"""
+    <button
+      type={@type}
+      class={[
+        "phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
+        "text-sm font-semibold leading-6 text-white active:text-white/80",
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  @doc """
+  Renders an input with label and error messages.
+
+  A `Phoenix.HTML.FormField` may be passed as argument,
+  which is used to retrieve the input name, id, and values.
+  Otherwise all attributes may be passed explicitly.
+
+  ## Types
+
+  This function accepts all HTML input types, considering that:
+
+    * You may also set `type="select"` to render a `<select>` tag
+
+    * `type="checkbox"` is used exclusively to render boolean values
+
+    * For live file uploads, see `Phoenix.Component.live_file_input/1`
+
+  See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+  for more information. Unsupported types, such as hidden and radio,
+  are best written directly in your templates.
+
+  ## Examples
+
+      <.input field={@form[:email]} type="email" />
+      <.input name="my-input" errors={["oh no!"]} />
+  """
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+
+  attr :type, :string,
+    default: "text",
+    values: ~w(checkbox color date datetime-local email file month number password
+               range search select tel text textarea time url week)
+
+  attr :field, Phoenix.HTML.FormField,
+    doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
+  attr :errors, :list, default: []
+  attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
+  attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
+  attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+  attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+
+  attr :rest, :global,
+    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                multiple pattern placeholder readonly required rows size step)
+
+  def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(errors, &translate_error(&1)))
+    |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> input()
+  end
+
+  def input(%{type: "checkbox"} = assigns) do
+    assigns =
+      assign_new(assigns, :checked, fn ->
+        Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
+      end)
+
+    ~H"""
+    <div>
+      <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
+        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
+        <input
+          type="checkbox"
+          id={@id}
+          name={@name}
+          value="true"
+          checked={@checked}
+          class="rounded border-zinc-300 text-zinc-900 focus:ring-0"
+          {@rest}
+        />
+        {@label}
+      </label>
+      <.error :for={msg <- @errors}>{msg}</.error>
+    </div>
+    """
+  end
+
+  def input(%{type: "select"} = assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}>{@label}</.label>
+      <select
+        id={@id}
+        name={@name}
+        class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        multiple={@multiple}
+        {@rest}
+      >
+        <option :if={@prompt} value="">{@prompt}</option>
+        {Phoenix.HTML.Form.options_for_select(@options, @value)}
+      </select>
+      <.error :for={msg <- @errors}>{msg}</.error>
+    </div>
+    """
+  end
+
+  def input(%{type: "textarea"} = assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}>{@label}</.label>
+      <textarea
+        id={@id}
+        name={@name}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 min-h-[6rem]",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
+      <.error :for={msg <- @errors}>{msg}</.error>
+    </div>
+    """
+  end
+
+  # All other inputs text, datetime-local, url, password, etc. are handled here...
+  def input(assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}>{@label}</.label>
+      <input
+        type={@type}
+        name={@name}
+        id={@id}
+        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      />
+      <.error :for={msg <- @errors}>{msg}</.error>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a label.
+  """
+  attr :for, :string, default: nil
+  slot :inner_block, required: true
+
+  def label(assigns) do
+    ~H"""
+    <label for={@for} class="block text-sm font-semibold leading-6 text-zinc-800">
+      {render_slot(@inner_block)}
+    </label>
+    """
+  end
+
+  @doc """
+  Generates a generic error message.
+  """
+  slot :inner_block, required: true
+
+  def error(assigns) do
+    ~H"""
+    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600">
+      <.icon name="hero-exclamation-circle-mini" class="mt-0.5 h-5 w-5 flex-none" />
+      {render_slot(@inner_block)}
+    </p>
+    """
+  end
+
+  @doc """
+  Renders a header with title.
+  """
+  attr :class, :string, default: nil
+
+  slot :inner_block, required: true
+  slot :subtitle
+  slot :actions
+
+  def header(assigns) do
+    ~H"""
+    <header class={[@actions != [] && "flex items-center justify-between gap-6", @class]}>
+      <div>
+        <h1 class="text-lg font-semibold leading-8 text-zinc-800">
+          {render_slot(@inner_block)}
+        </h1>
+        <p :if={@subtitle != []} class="mt-2 text-sm leading-6 text-zinc-600">
+          {render_slot(@subtitle)}
+        </p>
+      </div>
+      <div class="flex-none">{render_slot(@actions)}</div>
+    </header>
+    """
+  end
+
+  @doc ~S"""
+  Renders a table with generic styling.
+
+  ## Examples
+
+      <.table id="users" rows={@users}>
+        <:col :let={user} label="id">{user.id}</:col>
+        <:col :let={user} label="username">{user.username}</:col>
+      </.table>
+  """
+  attr :id, :string, required: true
+  attr :rows, :list, required: true
+  attr :row_id, :any, default: nil, doc: "the function for generating the row id"
+  attr :row_click, :any, default: nil, doc: "the function for handling phx-click on each row"
+
+  attr :row_item, :any,
+    default: &Function.identity/1,
+    doc: "the function for mapping each row before calling the :col and :action slots"
+
+  slot :col, required: true do
+    attr :label, :string
+  end
+
+  slot :action, doc: "the slot for showing user actions in the last table column"
+
+  def table(assigns) do
+    assigns =
+      with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
+        assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
+      end
+
+    ~H"""
+    <div class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
+      <table class="w-[40rem] mt-11 sm:w-full">
+        <thead class="text-sm text-left leading-6 text-zinc-500">
+          <tr>
+            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal">{col[:label]}</th>
+            <th :if={@action != []} class="relative p-0 pb-4">
+              <span class="sr-only"><%= maybe_eex_gettext.("Actions", @gettext) %></span>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          id={@id}
+          phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
+          class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700"
+        >
+          <tr :for={row <- @rows} id={@row_id && @row_id.(row)} class="group hover:bg-zinc-50">
+            <td
+              :for={{col, i} <- Enum.with_index(@col)}
+              phx-click={@row_click && @row_click.(row)}
+              class={["relative p-0", @row_click && "hover:cursor-pointer"]}
+            >
+              <div class="block py-4 pr-6">
+                <span class="absolute -inset-y-px right-0 -left-4 group-hover:bg-zinc-50 sm:rounded-l-xl" />
+                <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
+                  {render_slot(col, @row_item.(row))}
+                </span>
+              </div>
+            </td>
+            <td :if={@action != []} class="relative w-14 p-0">
+              <div class="relative whitespace-nowrap py-4 text-right text-sm font-medium">
+                <span class="absolute -inset-y-px -right-4 left-0 group-hover:bg-zinc-50 sm:rounded-r-xl" />
+                <span
+                  :for={action <- @action}
+                  class="relative ml-4 font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
+                >
+                  {render_slot(action, @row_item.(row))}
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a data list.
+
+  ## Examples
+
+      <.list>
+        <:item title="Title">{@post.title}</:item>
+        <:item title="Views">{@post.views}</:item>
+      </.list>
+  """
+  slot :item, required: true do
+    attr :title, :string, required: true
+  end
+
+  def list(assigns) do
+    ~H"""
+    <div class="mt-14">
+      <dl class="-my-4 divide-y divide-zinc-100">
+        <div :for={item <- @item} class="flex gap-4 py-4 text-sm leading-6 sm:gap-8">
+          <dt class="w-1/4 flex-none text-zinc-500">{item.title}</dt>
+          <dd class="text-zinc-700">{render_slot(item)}</dd>
+        </div>
+      </dl>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a back navigation link.
+
+  ## Examples
+
+      <.back navigate={~p"/posts"}>Back to posts</.back>
+  """
+  attr :navigate, :any, required: true
+  slot :inner_block, required: true
+
+  def back(assigns) do
+    ~H"""
+    <div class="mt-16">
+      <.link
+        navigate={@navigate}
+        class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
+      >
+        <.icon name="hero-arrow-left-solid" class="h-3 w-3" />
+        {render_slot(@inner_block)}
+      </.link>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a [Heroicon](https://heroicons.com).
+
+  Heroicons come in three styles – outline, solid, and mini.
+  By default, the outline style is used, but solid and mini may
+  be applied by using the `-solid` and `-mini` suffix.
+
+  You can customize the size and colors of the icons by setting
+  width, height, and background color classes.
+
+  Icons are extracted from the `deps/heroicons` directory and bundled within
+  your compiled app.css by the plugin in your `assets/tailwind.config.js`.
+
+  ## Examples
+
+      <.icon name="hero-x-mark-solid" />
+      <.icon name="hero-arrow-path" class="ml-1 w-3 h-3 animate-spin" />
+  """
+  attr :name, :string, required: true
+  attr :class, :string, default: nil
+
+  def icon(%{name: "hero-" <> _} = assigns) do
+    ~H"""
+    <span class={[@name, @class]} />
+    """
+  end
+
+  ## JS Commands
+
+  def show(js \\ %JS{}, selector) do
+    JS.show(js,
+      to: selector,
+      time: 300,
+      transition:
+        {"transition-all transform ease-out duration-300",
+         "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
+         "opacity-100 translate-y-0 sm:scale-100"}
+    )
+  end
+
+  def hide(js \\ %JS{}, selector) do
+    JS.hide(js,
+      to: selector,
+      time: 200,
+      transition:
+        {"transition-all transform ease-in duration-200",
+         "opacity-100 translate-y-0 sm:scale-100",
+         "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"}
+    )
+  end
+
+  def show_modal(js \\ %JS{}, id) when is_binary(id) do
+    js
+    |> JS.show(to: "##{id}")
+    |> JS.show(
+      to: "##{id}-bg",
+      time: 300,
+      transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
+    )
+    |> show("##{id}-container")
+    |> JS.add_class("overflow-hidden", to: "body")
+    |> JS.focus_first(to: "##{id}-content")
+  end
+
+  def hide_modal(js \\ %JS{}, id) do
+    js
+    |> JS.hide(
+      to: "##{id}-bg",
+      transition: {"transition-all transform ease-in duration-200", "opacity-100", "opacity-0"}
+    )
+    |> hide("##{id}-container")
+    |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
+    |> JS.remove_class("overflow-hidden", to: "body")
+    |> JS.pop_focus()
+  end
+
+  @doc """
+  Translates an error message using gettext.
+  """<%= if @gettext do %>
+  def translate_error({msg, opts}) do
+    # When using gettext, we typically pass the strings we want
+    # to translate as a static argument:
+    #
+    #     # Translate the number of files with plural rules
+    #     dngettext("errors", "1 file", "%{count} files", count)
+    #
+    # However the error messages in our forms and APIs are generated
+    # dynamically, so we need to translate them by calling Gettext
+    # with our gettext backend as first argument. Translations are
+    # available in the errors.po file (as we use the "errors" domain).
+    if count = opts[:count] do
+      Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
+    end
+  end<% else %>
+  def translate_error({msg, opts}) do
+    # You can make use of gettext to translate error messages by
+    # uncommenting and adjusting the following code:
+
+    # if count = opts[:count] do
+    #   Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
+    # else
+    #   Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
+    # end
+
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end<% end %>
+
+  @doc """
+  Translates the errors for a field from a keyword list of errors.
+  """
+  def translate_errors(errors, field) when is_list(errors) do
+    for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
+  end
+end

--- a/priv/templates/phx.gen.itsm.admin_live/form_component.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/form_component.ex.eex
@@ -1,0 +1,85 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent do
+  use <%= inspect context.web_module %>, :live_component
+
+  alias <%= inspect context.module %>
+
+  @impl true
+  def update(%{<%= schema.singular %>: <%= schema.singular %>} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_new(:form, fn ->
+       to_form(<%= inspect context.alias %>.change_<%= schema.singular %>(<%= schema.singular %>))
+     end)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        {@title}
+        <:subtitle>Use this form to manage <%= schema.singular %> records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="<%= schema.singular %>-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+<%= Mix.Tasks.Phx.Gen.Itsm.AdminHtml.indent_inputs(inputs, 8) %>
+        <.itsm_calendar
+          :if={@action == :edit}
+          field={@form[:inserted_at]}
+          label={gettext("Inserted At")}
+          show_time
+          default_selected_date_time={@form[:inserted_at].value}
+        />
+        <:actions>
+          <.button phx-disable-with="Saving...">Save <%= schema.human_singular %></.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("validate", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
+    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>(socket.assigns.<%= schema.singular %>, <%= schema.singular %>_params)
+    {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
+  end
+
+  @impl true
+  def handle_event("save", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
+    save_<%= schema.singular %>(socket, socket.assigns.action, <%= schema.singular %>_params)
+  end
+
+  defp save_<%= schema.singular %>(socket, :edit, <%= schema.singular %>_params) do
+    case <%= inspect context.alias %>.update_<%= schema.singular %>(socket.assigns.<%= schema.singular %>, <%= schema.singular %>_params) do
+      {:ok, _<%= schema.singular %>} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "<%= schema.human_singular %> updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp save_<%= schema.singular %>(socket, :new, <%= schema.singular %>_params) do
+    case <%= inspect context.alias %>.create_<%= schema.singular %>(<%= schema.singular %>_params) do
+      {:ok, _<%= schema.singular %>} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "<%= schema.human_singular %> created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+end

--- a/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
@@ -1,0 +1,48 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.Index do
+  use <%= inspect context.web_module %>, :live_view
+
+  alias <%= inspect context.module %>
+  alias <%= inspect schema.module %>
+  alias <%= inspect context.base_module %>.Paging
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, stream(socket, :<%= schema.collection %>, [])}
+  end
+
+  @impl true
+  def handle_params(params, url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+    {:ok, _} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>)
+
+    {:noreply, stream_delete(socket, :<%= schema.collection %>, <%= schema.singular %>)}
+  end
+
+  defp apply_action(socket, :index, params, url) do
+    value =
+      Paging.search_and_pagination(params, url, <%= inspect schema.alias %>, <%= inspect Keyword.keys(schema.attrs) %>)
+
+    socket
+    |> assign(:results, value.results)
+    |> stream(:<%= schema.collection %>, value.entries, reset: true)
+    |> assign(:page_title, "Listing <%= schema.human_plural %>")
+    |> assign(:<%= schema.singular %>, nil)
+  end
+
+  defp apply_action(socket, :new, _params, _url) do
+    socket
+    |> assign(:page_title, "New <%= schema.human_singular %>")
+    |> assign(:<%= schema.singular %>, %<%= inspect schema.alias %>{})
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}, _url) do
+    socket
+    |> assign(:page_title, "Edit <%= schema.human_singular %>")
+    |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))
+  end
+end

--- a/priv/templates/phx.gen.itsm.admin_live/index.html.heex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/index.html.heex.eex
@@ -1,0 +1,46 @@
+<.header>
+  Listing <%= schema.human_plural %>
+  <:actions>
+    <.link patch={~p"<%= schema.route_prefix %>/new"}>
+      <.button>New <%= schema.human_singular %></.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.itsm_table_container results={assigns[:results]}>
+  <.table
+    id="<%= schema.plural %>"
+    rows={@streams.<%= schema.collection %>}
+    row_click={fn {_id, <%= schema.singular %>} -> JS.navigate(~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}") end}
+  >
+    <%= for {k, type} <- schema.attrs do %><%= if type == :utc_datetime do %><:col :let={{id, <%= schema.singular %>}} label={<%= "gettext(\"#{ItsmWeb.LiveUtils.titleize(k)}\")" %>}>
+      <div id={"<%= k %>_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={<%= schema.singular %>.<%= k %>} />
+    </:col><% else %><:col :let={{_id, <%= schema.singular %>}} label={<%= "gettext(\"#{ItsmWeb.LiveUtils.titleize(k)}\")" %>}>{<%= schema.singular %>.<%= k %>}</:col>
+    <% end %><% end %>
+    <:action :let={{_id, <%= schema.singular %>}}>
+      <div class="sr-only">
+        <.link navigate={~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}"}>Show</.link>
+      </div>
+      <.link patch={~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}/edit"}>Edit</.link>
+    </:action>
+    <:action :let={{id, <%= schema.singular %>}}>
+      <.link
+        phx-click={JS.push("delete", value: %{id: <%= schema.singular %>.id}) |> hide("##{id}")}
+        data-confirm="Are you sure?"
+      >
+        Delete
+      </.link>
+    </:action>
+  </.table>
+</.itsm_table_container>
+
+<.modal :if={@live_action in [:new, :edit]} id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>?#{assigns[:results][:params] || %{}}")}>
+  <.live_component
+    module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
+    id={@<%= schema.singular %>.id || :new}
+    title={@page_title}
+    action={@live_action}
+    <%= schema.singular %>={@<%= schema.singular %>}
+    patch={~p"<%= schema.route_prefix %>?#{assigns[:results][:params] || %{}}"}
+  />
+</.modal>

--- a/priv/templates/phx.gen.itsm.admin_live/live_test.exs.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/live_test.exs.eex
@@ -1,0 +1,113 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>LiveTest do
+  use <%= inspect context.web_module %>.ConnCase
+
+  import Phoenix.LiveViewTest
+  import <%= inspect context.module %>Fixtures
+
+  @create_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.create, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
+  @update_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.update, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
+  @invalid_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.create, into: %{}, do: {key, value |> Mix.Phoenix.Schema.live_form_value() |> Mix.Phoenix.Schema.invalid_form_value()} %>
+
+  defp create_<%= schema.singular %>(_) do
+    <%= schema.singular %> = <%= schema.singular %>_fixture()
+    %{<%= schema.singular %>: <%= schema.singular %>}
+  end
+
+  describe "Index" do
+    setup [:create_<%= schema.singular %>]
+
+    test "lists all <%= schema.plural %>", <%= if schema.string_attr do %>%{conn: conn, <%= schema.singular %>: <%= schema.singular %>}<% else %>%{conn: conn}<% end %> do
+      {:ok, _index_live, html} = live(conn, ~p"<%= schema.route_prefix %>")
+
+      assert html =~ "Listing <%= schema.human_plural %>"<%= if schema.string_attr do %>
+      assert html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+    end
+
+    test "saves new <%= schema.singular %>", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"<%= schema.route_prefix %>")
+
+      assert index_live |> element("a", "New <%= schema.human_singular %>") |> render_click() =~
+               "New <%= schema.human_singular %>"
+
+      assert_patch(index_live, ~p"<%= schema.route_prefix %>/new")
+
+      assert index_live
+             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @invalid_attrs)
+             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(schema) %>"
+
+      assert index_live
+             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"<%= schema.route_prefix %>")
+
+      html = render(index_live)
+      assert html =~ "<%= schema.human_singular %> created successfully"<%= if schema.string_attr do %>
+      assert html =~ "some <%= schema.string_attr %>"<% end %>
+    end
+
+    test "updates <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      {:ok, index_live, _html} = live(conn, ~p"<%= schema.route_prefix %>")
+
+      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.id} a", "Edit") |> render_click() =~
+               "Edit <%= schema.human_singular %>"
+
+      assert_patch(index_live, ~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}/edit")
+
+      assert index_live
+             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @invalid_attrs)
+             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(schema) %>"
+
+      assert index_live
+             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"<%= schema.route_prefix %>")
+
+      html = render(index_live)
+      assert html =~ "<%= schema.human_singular %> updated successfully"<%= if schema.string_attr do %>
+      assert html =~ "some updated <%= schema.string_attr %>"<% end %>
+    end
+
+    test "deletes <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      {:ok, index_live, _html} = live(conn, ~p"<%= schema.route_prefix %>")
+
+      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#<%= schema.plural %>-#{<%= schema.singular %>.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_<%= schema.singular %>]
+
+    test "displays <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      {:ok, _show_live, html} = live(conn, ~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}")
+
+      assert html =~ "Show <%= schema.human_singular %>"<%= if schema.string_attr do %>
+      assert html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+    end
+
+    test "updates <%= schema.singular %> within modal", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      {:ok, show_live, _html} = live(conn, ~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit <%= schema.human_singular %>"
+
+      assert_patch(show_live, ~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}/show/edit")
+
+      assert show_live
+             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @invalid_attrs)
+             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(schema) %>"
+
+      assert show_live
+             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}")
+
+      html = render(show_live)
+      assert html =~ "<%= schema.human_singular %> updated successfully"<%= if schema.string_attr do %>
+      assert html =~ "some updated <%= schema.string_attr %>"<% end %>
+    end
+  end
+end

--- a/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
@@ -1,0 +1,21 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.Show do
+  use <%= inspect context.web_module %>, :live_view
+
+  alias <%= inspect context.module %>
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))}
+  end
+
+  defp page_title(:show), do: "Show <%= schema.human_singular %>"
+  defp page_title(:edit), do: "Edit <%= schema.human_singular %>"
+end

--- a/priv/templates/phx.gen.itsm.admin_live/show.html.heex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/show.html.heex.eex
@@ -1,0 +1,42 @@
+<.header>
+  <%= schema.human_singular %> {@<%= schema.singular %>.id}
+  <:subtitle>This is a <%= schema.singular %> record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit <%= schema.singular %></.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list><%= for {k, type} <- schema.attrs do %>
+  <%= if type == :utc_datetime do %><:item title={<%= "gettext(\"#{ItsmWeb.LiveUtils.titleize(k)}\")" %>}>
+    <span id={"<%= schema.singular %>-<%= k %>_#{@<%= schema.singular %>.id}"} phx-hook="LocalTime.ToLocale" utc-value={@<%= schema.singular %>.<%= k %>} />
+  </:item><% else %><:item title={<%= "gettext(\"#{ItsmWeb.LiveUtils.titleize(k)}\")" %>}>{@<%= schema.singular %>.<%= k %>}</:item><% end %><% end %>
+  <:item title={gettext("Inserted At")}>
+    <span
+      id={"<%= schema.singular %>-inserted-at_#{@<%= schema.singular %>.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@<%= schema.singular %>.inserted_at}
+    />
+  </:item>
+  <:item title={gettext("Updated At")}>
+    <span
+      id={"<%= schema.singular %>-updated-at_#{@<%= schema.singular %>.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@<%= schema.singular %>.updated_at}
+    />
+  </:item>
+</.list>
+
+<.back navigate={~p"<%= schema.route_prefix %>"}>Back to <%= schema.plural %></.back>
+
+<.modal :if={@live_action == :edit} id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}")}>
+  <.live_component
+    module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
+    id={@<%= schema.singular %>.id}
+    title={@page_title}
+    action={@live_action}
+    <%= schema.singular %>={@<%= schema.singular %>}
+    patch={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}"}
+  />
+</.modal>


### PR DESCRIPTION
## 🚀 개요
반복되는 관리자(Admin) 기능 개발 효율을 높이기 위해, 프로젝트 커스텀 규칙이 적용된 **ITSM 전용 어드민 제너레이터**를 구현했습니다.

## ✨ 주요 변경 사항
- **Custom Mix Task 추가**: `mix phx.gen.itsm.admin_live` 명령어를 통해 ITSM 표준 규격에 맞는 코드 생성이 가능합니다.
- **폴더 구조 자동화**:
    - `lib/itsm/admin/`: 관리자 전용 비즈니스 로직(Admin Context) 생성
    - `lib/itsm_web/live/admin/`: 관리자 전용 LiveView 컴포넌트 및 페이지 생성
    - 스키마 및 기본 컨텍스트는 표준 위치에 생성하여 도메인 중심 설계 유지
- **커스텀 생성** utc_datetime 일 경우 itsm 전용 포맷 생성
- **파일 구성**: `form_component.ex`, `index.ex`, `index.html.heex`, `show.ex`, `show.html.heex` 자동 생성
- **생성 후 필수 행위** router.ex에 터미널에 출력된 라우트 기입 필요

## 🛠 사용 방법

### 1. 명령어 실행
터미널에서 아래와 같이 입력합니다 (예시: 상품 관리 기능 생성).
```bash
mix phx.gen.itsm.admin_live Products Product products name:string stock:integer due_date:utc_datetime
```

### 2. 커스텀 생성 (Customized)
Index/Show Page: due_date가 일반 텍스트가 아닌 ITSM 표준 포맷터로 감싸져 출력됩니다.

Form Component: due_date 입력란에 ItsmWeb.CalendarComponent가 자동으로 주입되어 일관된 사용자 경험을 제공합니다.

### 3. 생성되는 파일 위치
Schemas: lib/itsm/products/product.ex

Contexts: lib/itsm/products.ex

Admin Contexts: lib/itsm/admin/products_admin.ex

LiveViews: lib/itsm_web/live/admin/product_live/ 하위 파일들

### 4. 라우트 설정 (필수)
명령어 실행 후 터미널에 출력되는 라우트 정보를 router.ex의 :admin 파이프라인(또는 해당 스코프)에 수동으로 추가해야 합니다.

```elixir
# lib/itsm_web/router.ex 예시
scope "/admin", ItsmWeb.Admin do
  pipe_through [:browser, :admin_layout]

  live "/products", ProductLive.Index, :index
  live "/products/new", ProductLive.Index, :new
  # ... (터미널 출력 내용 붙여넣기)
end
```