### PR TITLE
Added PubSub on Admin && refactoring

### DIFF
--- a/lib/itsm/admin/approvals.ex
+++ b/lib/itsm/admin/approvals.ex
@@ -10,17 +10,33 @@ defmodule Itsm.Admin.Approvals do
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
   end
 
-  defdelegate create_approval(attrs \\ %{}), to: Itsm.Approvals
-
   def update_approval(%Approval{} = approval, attrs) do
     approval
     |> Approval.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
+    |> case do
+      {:ok, approval} ->
+        Itsm.Utils.broadcast(:approval, {:update_approval, approval})
+        Itsm.Utils.broadcasts(:approvals, {:update_approval, approval})
+        {:ok, approval}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   def delete_approval(%Approval{} = approval) do
     Repo.delete(approval)
+    |> case do
+      {:ok, approval} ->
+        Itsm.Utils.broadcast(:approval, {:delete_approval, approval})
+        Itsm.Utils.broadcasts(:approvals, {:delete_approval, approval})
+        {:ok, approval}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   def preload_category(%Approval{} = approval) do

--- a/lib/itsm/admin/assets.ex
+++ b/lib/itsm/admin/assets.ex
@@ -18,9 +18,27 @@ defmodule Itsm.Admin.Assets do
     |> Asset.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
+    |> case do
+      {:ok, asset} ->
+        Itsm.Utils.broadcast(:asset, {:update_asset, asset})
+        Itsm.Utils.broadcasts(:assets, {:update_asset, asset})
+        {:ok, asset}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def delete_asset(%Asset{} = asset) do
     Repo.delete(asset)
+    |> case do
+      {:ok, asset} ->
+        Itsm.Utils.broadcast(:asset, {:update_asset, asset})
+        Itsm.Utils.broadcasts(:assets, {:update_asset, asset})
+        {:ok, asset}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 end

--- a/lib/itsm/admin/categories.ex
+++ b/lib/itsm/admin/categories.ex
@@ -14,6 +14,14 @@ defmodule Itsm.Admin.Categories do
     %Category{}
     |> Category.changeset(attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, category} ->
+        Itsm.Utils.broadcasts(:category, {:create_Category, category})
+        {:ok, category}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def update_category(%Category{} = category, attrs) do
@@ -21,10 +29,28 @@ defmodule Itsm.Admin.Categories do
     |> Category.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
+    |> case do
+      {:ok, category} ->
+        Itsm.Utils.broadcast(:category, {:update_category, category})
+        Itsm.Utils.broadcasts(:categories, {:update_category, category})
+        {:ok, category}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   def delete_category(%Category{} = category) do
     Repo.delete(category)
+    |> case do
+      {:ok, category} ->
+        Itsm.Utils.broadcast(:category, {:delete_category, category})
+        Itsm.Utils.broadcasts(:categories, {:delete_category, category})
+        {:ok, category}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   def get_category_options do

--- a/lib/itsm/admin/comments.ex
+++ b/lib/itsm/admin/comments.ex
@@ -17,10 +17,28 @@ defmodule Itsm.Admin.Comments do
     |> Comment.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
+    |> case do
+      {:ok, comment} ->
+        Itsm.Utils.broadcast(:comment, {:update_comment, comment})
+        Itsm.Utils.broadcasts(:comments, {:update_comment, comment})
+        {:ok, comment}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def delete_comment(%Comment{} = comment) do
     Repo.delete(comment)
+    |> case do
+      {:ok, comment} ->
+        Itsm.Utils.broadcast(:comment, {:delete_comment, comment})
+        Itsm.Utils.broadcasts(:comments, {:delete_comment, comment})
+        {:ok, comment}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def preload_user(%Comment{} = comment) do

--- a/lib/itsm/admin/common_codes.ex
+++ b/lib/itsm/admin/common_codes.ex
@@ -14,6 +14,14 @@ defmodule Itsm.Admin.CommonCodes do
     %CommonCode{}
     |> CommonCode.changeset(attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, common_code} ->
+        Itsm.Utils.broadcasts(:common_code, {:create_common_code, common_code})
+        {:ok, common_code}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def update_common_code(%CommonCode{} = common_code, attrs) do
@@ -21,10 +29,28 @@ defmodule Itsm.Admin.CommonCodes do
     |> CommonCode.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
+    |> case do
+      {:ok, common_code} ->
+        Itsm.Utils.broadcast(:common_code, {:update_common_code, common_code})
+        Itsm.Utils.broadcasts(:common_codes, {:update_common_code, common_code})
+        {:ok, common_code}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def delete_common_code(%CommonCode{} = common_code) do
     Repo.delete(common_code)
+    |> case do
+      {:ok, common_code} ->
+        Itsm.Utils.broadcast(:common_code, {:delete_common_code, common_code})
+        Itsm.Utils.broadcasts(:common_codes, {:delete_common_code, common_code})
+        {:ok, common_code}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   defdelegate get_select_options(group_code), to: Itsm.CommonCodes

--- a/lib/itsm/admin/crews.ex
+++ b/lib/itsm/admin/crews.ex
@@ -22,10 +22,10 @@ defmodule Itsm.Admin.Crews do
     |> Repo.update()
     |> case do
       {:ok, crew} ->
-        # Preload 및 Broadcast
         crew = Repo.preload(crew, [:leader, :users])
-        broadcast_crew(crew.id, {:update_crew, crew})
-        broadcast_crews({:update_crew, crew})
+        Itsm.Utils.broadcast(:crew, {:update_crew, crew})
+        Itsm.Utils.broadcasts(:crews, {:update_crew, crew})
+
         {:ok, crew}
 
       {:error, _} = error ->
@@ -37,7 +37,8 @@ defmodule Itsm.Admin.Crews do
     Repo.delete(crew)
     |> case do
       {:ok, deleted_crew} ->
-        broadcast_crews({:delete_crew, deleted_crew})
+        Itsm.Utils.broadcast(:crew, {:update_crew, crew})
+        Itsm.Utils.broadcasts(:crews, {:update_crew, crew})
         {:ok, deleted_crew}
 
       {:error, _} = error ->

--- a/lib/itsm/admin/requests.ex
+++ b/lib/itsm/admin/requests.ex
@@ -17,8 +17,8 @@ defmodule Itsm.Admin.Requests do
     |> Repo.update()
     |> case do
       {:ok, request} ->
-        request = Repo.preload(request, :category)
-        Itsm.Requests.broadcast_request(request.id, {:request_updated, request})
+        Itsm.Utils.broadcast(:request, {:update_request, request})
+        Itsm.Utils.broadcasts(:requests, {:update_request, request})
         {:ok, request}
 
       {:error, _} = error ->
@@ -28,5 +28,14 @@ defmodule Itsm.Admin.Requests do
 
   def delete_request(%Request{} = request) do
     Repo.delete(request)
+    |> case do
+      {:ok, request} ->
+        Itsm.Utils.broadcast(:request, {:update_request, request})
+        Itsm.Utils.broadcasts(:requests, {:update_request, request})
+        {:ok, request}
+
+      {:error, _} = error ->
+        error
+    end
   end
 end

--- a/lib/itsm/assets.ex
+++ b/lib/itsm/assets.ex
@@ -98,6 +98,14 @@ defmodule Itsm.Assets do
     %Asset{}
     |> Asset.changeset(attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, asset} ->
+        Itsm.Utils.broadcasts(:assets, {:update_asset, asset})
+        {:ok, asset}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   @doc """

--- a/lib/itsm/comments.ex
+++ b/lib/itsm/comments.ex
@@ -9,6 +9,7 @@ defmodule Itsm.Comments do
 
   # 결과 처리
   def broadcast_result({:ok, %{comment: comment}}, topic_id) do
+    Itsm.Utils.broadcasts(:comments, {:create_comment, comment})
     comment = Repo.preload(comment, :attachments)
     # PubSub 방송 (토픽 ID로 전파)
     Requests.broadcast_request(topic_id, {:comment_created, comment})
@@ -52,6 +53,7 @@ defmodule Itsm.Comments do
 
         # 🌟 2. 여기서 직접 PubSub 방송을 쏩니다! (기존 로직 활용)
         Requests.broadcast_request(resource.id, {:comment_created, preloaded_comment})
+        Itsm.Utils.broadcasts(:comments, {:create_comment, comment})
 
         {:ok, preloaded_comment}
 

--- a/lib/itsm/requests.ex
+++ b/lib/itsm/requests.ex
@@ -70,8 +70,13 @@ defmodule Itsm.Requests do
     |> Ecto.Changeset.put_change(:requestor_name, user.display_name)
     |> Repo.insert()
     |> case do
-      {:ok, request} -> {:ok, Repo.preload(request, :category)}
-      {:error, _} = error -> error
+      {:ok, request} ->
+        request = Repo.preload(request, :category)
+        Itsm.Utils.broadcasts(:requests, {:update_request, request})
+        {:ok, request}
+
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -86,7 +91,8 @@ defmodule Itsm.Requests do
     |> case do
       {:ok, request} ->
         request = Repo.preload(request, :category)
-        broadcast_request(request.id, {:request_updated, request})
+        Itsm.Utils.broadcast(:request, {:update_request, request})
+        Itsm.Utils.broadcasts(:requests, {:update_request, request})
         {:ok, request}
 
       {:error, _} = error ->

--- a/lib/itsm/utils.ex
+++ b/lib/itsm/utils.ex
@@ -25,4 +25,20 @@ defmodule Itsm.Utils do
   defp parse_and_put(changeset, field, value, {:error, _reason}) do
     Ecto.Changeset.put_change(changeset, field, value)
   end
+
+  def broadcast(domain, {_event, item} = message) do
+    Phoenix.PubSub.broadcast(Itsm.PubSub, "#{domain}:#{item.id}", {:pubsub, message})
+  end
+
+  def broadcasts(domain, message) do
+    Phoenix.PubSub.broadcast(Itsm.PubSub, "#{domain}", {:pubsub, message})
+  end
+
+  def subscribe(domain, id) do
+    Phoenix.PubSub.subscribe(Itsm.PubSub, "#{domain}:#{id}")
+  end
+
+  def subscribes(domain) do
+    Phoenix.PubSub.subscribe(Itsm.PubSub, "#{domain}")
+  end
 end

--- a/lib/itsm_web/live/admin/approval_live/form_component.ex
+++ b/lib/itsm_web/live/admin/approval_live/form_component.ex
@@ -78,10 +78,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
   defp save_approval(socket, :edit, approval_params) do
     case Approvals.update_approval(socket.assigns.approval, approval_params) do
       {:ok, _approval} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Approval updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/approval_live/index.ex
+++ b/lib/itsm_web/live/admin/approval_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:approvals)
+    end
+
     {:ok, stream(socket, :approvals, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
 
     {:noreply, stream_delete(socket, :approvals, approval)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -54,5 +66,26 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
     socket
     |> assign(:page_title, "Edit Approval")
     |> assign(:approval, Approvals.get_approval!(id))
+  end
+
+  defp handle_pubsub(event, _approval, socket)
+       when event in [:create_approval, :update_approval] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_approval,
+         do: gettext("Created") <> " " <> gettext("Approval"),
+         else: gettext("Updated") <> " " <> gettext("Approval")
+       )
+     )
+     |> push_patch(to: ~p"/admin/approvals?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_approval, approval, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Approval"))
+     |> stream_delete(:approvals, approval)}
   end
 end

--- a/lib/itsm_web/live/admin/approval_live/show.ex
+++ b/lib/itsm_web/live/admin/approval_live/show.ex
@@ -10,12 +10,48 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:approval, id)
+      Itsm.Utils.subscribes(:approvals)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:approval, Approvals.get_approval!(id) |> Approvals.preload_category())}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Approval"
   defp page_title(:edit), do: "Edit Approval"
+
+  defp handle_pubsub(
+         :update_approval,
+         %{id: id} = approval,
+         %{assigns: %{approval: %{id: id}}} = socket
+       ) do
+    {:noreply,
+     socket
+     |> assign(:approval, Approvals.preload_category(approval))
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("Approval"))
+     |> push_patch(to: ~p"/admin/approvals/#{approval}")}
+  end
+
+  defp handle_pubsub(:delete_approval, %{id: id}, %{assigns: %{approval: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Approval"))
+     |> push_navigate(to: ~p"/admin/approvals")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/admin/asset_live/form_component.ex
+++ b/lib/itsm_web/live/admin/asset_live/form_component.ex
@@ -49,14 +49,14 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
         <.input
           field={@form[:region_type]}
           type="select"
-          label={gettext("Region type")}
+          label={gettext("Region Type")}
           prompt="Choose a value"
           options={@region_type_options}
         />
         <.input
           field={@form[:infra_type]}
           type="select"
-          label={gettext("Infra type")}
+          label={gettext("Infra Type")}
           prompt="Choose a value"
           options={@infra_type_options}
         />
@@ -74,7 +74,7 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
           prompt="Choose a value"
           options={@location_options}
         />
-        <.input field={@form[:is_dmz_zone]} type="checkbox" label={gettext("Is dmz zone")} />
+        <.input field={@form[:is_dmz_zone]} type="checkbox" label={gettext("Is Dmz Zone")} />
         <.itsm_calendar
           field={@form[:inserted_at]}
           label={gettext("Inserted At")}
@@ -112,10 +112,7 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
   defp save_asset(socket, :edit, asset_params) do
     case Assets.update_asset(socket.assigns.asset, asset_params) do
       {:ok, _asset} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Asset updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
@@ -125,10 +122,7 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
   defp save_asset(socket, :new, asset_params) do
     case Assets.create_asset(asset_params) do
       {:ok, _asset} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Asset created successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/asset_live/index.ex
+++ b/lib/itsm_web/live/admin/asset_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:assets)
+    end
+
     {:ok, stream(socket, :assets, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
 
     {:noreply, stream_delete(socket, :assets, asset)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -54,5 +66,26 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
     socket
     |> assign(:page_title, "Edit Asset")
     |> assign(:asset, Assets.get_asset!(id))
+  end
+
+  defp handle_pubsub(event, _asset, socket)
+       when event in [:create_asset, :update_asset] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_asset,
+         do: gettext("Created") <> " " <> gettext("Asset"),
+         else: gettext("Updated") <> " " <> gettext("Asset")
+       )
+     )
+     |> push_patch(to: ~p"/admin/assets?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_asset, asset, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Asset"))
+     |> stream_delete(:assets, asset)}
   end
 end

--- a/lib/itsm_web/live/admin/asset_live/show.ex
+++ b/lib/itsm_web/live/admin/asset_live/show.ex
@@ -10,12 +10,44 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:asset, id)
+      Itsm.Utils.subscribes(:assets)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:asset, Assets.get_asset!(id))}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Asset"
   defp page_title(:edit), do: "Edit Asset"
+
+  defp handle_pubsub(:update_asset, %{id: id} = asset, %{assigns: %{asset: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> assign(:asset, asset)
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("Asset"))
+     |> push_patch(to: ~p"/admin/assets/#{asset}")}
+  end
+
+  defp handle_pubsub(:delete_asset, %{id: id}, %{assigns: %{asset: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Asset"))
+     |> push_navigate(to: ~p"/admin/assets")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/admin/category_live/form_component.ex
+++ b/lib/itsm_web/live/admin/category_live/form_component.ex
@@ -94,10 +94,7 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
   defp save_category(socket, :edit, category_params) do
     case Categories.update_category(socket.assigns.category, category_params) do
       {:ok, _category} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Category updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
@@ -107,10 +104,7 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
   defp save_category(socket, :new, category_params) do
     case Categories.create_category(category_params) do
       {:ok, _category} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Category created successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/category_live/index.ex
+++ b/lib/itsm_web/live/admin/category_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:categories)
+    end
+
     {:ok, socket |> stream(:categories, []) |> assign_new_options()}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
 
     {:noreply, stream_delete(socket, :categories, category)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp assign_new_options(socket) do
     socket
@@ -57,5 +69,26 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
     socket
     |> assign(:page_title, "Edit Category")
     |> assign(:category, Categories.get_category!(id))
+  end
+
+  defp handle_pubsub(event, _category, socket)
+       when event in [:create_category, :update_category] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_category,
+         do: gettext("Created") <> " " <> gettext("Category"),
+         else: gettext("Updated") <> " " <> gettext("Category")
+       )
+     )
+     |> push_patch(to: ~p"/admin/categories?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_category, category, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Category"))
+     |> stream_delete(:categories, category)}
   end
 end

--- a/lib/itsm_web/live/admin/category_live/show.ex
+++ b/lib/itsm_web/live/admin/category_live/show.ex
@@ -10,12 +10,50 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:category, id)
+      Itsm.Utils.subscribes(:categories)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:category, Categories.get_category!(id))}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Category"
   defp page_title(:edit), do: "Edit Category"
+
+  defp handle_pubsub(
+         :update_category,
+         %{id: id} = category,
+         %{assigns: %{category: %{id: id}}} = socket
+       ) do
+    {
+      :noreply,
+      socket
+      |> assign(:category, category)
+      |> put_flash(:info, gettext("Updated") <> " " <> gettext("Category"))
+      |> push_patch(to: ~p"/admin/categories/#{category}")
+    }
+  end
+
+  defp handle_pubsub(:delete_category, %{id: id}, %{assigns: %{category: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Category"))
+     |> push_navigate(to: ~p"/admin/categories")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/admin/comment_live/form_component.ex
+++ b/lib/itsm_web/live/admin/comment_live/form_component.ex
@@ -57,10 +57,7 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
   defp save_comment(socket, :edit, comment_params) do
     case Comments.update_comment(socket.assigns.comment, comment_params) do
       {:ok, _comment} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Comment updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/comment_live/index.ex
+++ b/lib/itsm_web/live/admin/comment_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:comments)
+    end
+
     {:ok, stream(socket, :comments, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
 
     {:noreply, stream_delete(socket, :comments, comment)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -50,5 +62,26 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
     socket
     |> assign(:page_title, "Edit Comment")
     |> assign(:comment, Comments.get_comment!(id))
+  end
+
+  defp handle_pubsub(event, _comment, socket)
+       when event in [:create_comment, :update_comment] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_comment,
+         do: gettext("Created") <> " " <> gettext("Comment"),
+         else: gettext("Updated") <> " " <> gettext("Comment")
+       )
+     )
+     |> push_patch(to: ~p"/admin/comments?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_comment, comment, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Comment"))
+     |> stream_delete(:comments, comment)}
   end
 end

--- a/lib/itsm_web/live/admin/comment_live/show.ex
+++ b/lib/itsm_web/live/admin/comment_live/show.ex
@@ -10,12 +10,48 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:comment, id)
+      Itsm.Utils.subscribes(:comments)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:comment, Comments.get_comment!(id) |> Comments.preload_user())}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Comment"
   defp page_title(:edit), do: "Edit Comment"
+
+  defp handle_pubsub(
+         :update_comment,
+         %{id: id} = comment,
+         %{assigns: %{comment: %{id: id}}} = socket
+       ) do
+    {:noreply,
+     socket
+     |> assign(:comment, comment)
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("Comment"))
+     |> push_patch(to: ~p"/admin/comments/#{comment}")}
+  end
+
+  defp handle_pubsub(:delete_comment, %{id: id}, %{assigns: %{comment: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Comment"))
+     |> push_navigate(to: ~p"/admin/comments")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/admin/common_code_live/form_component.ex
+++ b/lib/itsm_web/live/admin/common_code_live/form_component.ex
@@ -29,12 +29,12 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:group_code]} type="text" label={gettext("Group code")} />
+        <.input field={@form[:group_code]} type="text" label={gettext("Group Code")} />
         <.input field={@form[:code]} type="text" label={gettext("Code")} />
         <.input field={@form[:label]} type="text" label={gettext("Label")} />
         <.input field={@form[:description]} type="text" label={gettext("Description")} />
-        <.input field={@form[:sort_order]} type="number" label={gettext("Sort order")} />
-        <.input field={@form[:is_active]} type="checkbox" label={gettext("Is active")} />
+        <.input field={@form[:sort_order]} type="number" label={gettext("Sort Order")} />
+        <.input field={@form[:is_active]} type="checkbox" label={gettext("Is Active")} />
         <.itsm_calendar
           :if={@action == :edit}
           field={@form[:inserted_at]}
@@ -64,10 +64,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
   defp save_common_code(socket, :edit, common_code_params) do
     case CommonCodes.update_common_code(socket.assigns.common_code, common_code_params) do
       {:ok, _common_code} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Common Code updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
@@ -77,10 +74,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
   defp save_common_code(socket, :new, common_code_params) do
     case CommonCodes.create_common_code(common_code_params) do
       {:ok, _common_code} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Common Code created successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/common_code_live/index.ex
+++ b/lib/itsm_web/live/admin/common_code_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:common_codes)
+    end
+
     {:ok, stream(socket, :common_codes, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
 
     {:noreply, stream_delete(socket, :common_codes, common_code)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -42,7 +54,28 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
 
   defp apply_action(socket, :edit, %{"id" => id}, _url) do
     socket
-    |> assign(:page_title, "Edit  Common Code")
+    |> assign(:page_title, "Edit Common Code")
     |> assign(:common_code, CommonCodes.get_common_code!(id))
+  end
+
+  defp handle_pubsub(event, _common_code, socket)
+       when event in [:create_common_code, :update_common_code] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_common_code,
+         do: gettext("Created") <> " " <> gettext("Common Code"),
+         else: gettext("Updated") <> " " <> gettext("Common Code")
+       )
+     )
+     |> push_patch(to: ~p"/admin/common_codes?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_common_code, common_code, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Common Code"))
+     |> stream_delete(:common_codes, common_code)}
   end
 end

--- a/lib/itsm_web/live/admin/common_code_live/show.ex
+++ b/lib/itsm_web/live/admin/common_code_live/show.ex
@@ -10,12 +10,52 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:common_code, id)
+      Itsm.Utils.subscribes(:common_codes)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:common_code, CommonCodes.get_common_code!(id))}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Common Code"
   defp page_title(:edit), do: "Edit Common Code"
+
+  defp handle_pubsub(
+         :update_common_code,
+         %{id: id} = common_code,
+         %{assigns: %{common_code: %{id: id}}} = socket
+       ) do
+    {:noreply,
+     socket
+     |> assign(:common_code, common_code)
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("Common Code"))
+     |> push_patch(to: ~p"/admin/common_codes/#{common_code}")}
+  end
+
+  defp handle_pubsub(
+         :delete_common_code,
+         %{id: id},
+         %{assigns: %{common_code: %{id: id}}} = socket
+       ) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Common Code"))
+     |> push_navigate(to: ~p"/admin/common_codes")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/admin/crew_live/form_component.ex
+++ b/lib/itsm_web/live/admin/crew_live/form_component.ex
@@ -58,10 +58,7 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
   defp save_crew(socket, :edit, crew_params) do
     case Crews.update_crew(socket.assigns.crew, crew_params) do
       {:ok, _crew} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Crew updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
@@ -73,10 +70,7 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
 
     case Crews.create_crew(current_user, crew_params) do
       {:ok, _crew} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Crew created successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, _step, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/crew_live/index.ex
+++ b/lib/itsm_web/live/admin/crew_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:crews)
+    end
+
     {:ok, stream(socket, :crews, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
 
     {:noreply, stream_delete(socket, :crews, crew)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -48,5 +60,26 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
     socket
     |> assign(:page_title, "Edit Crew")
     |> assign(:crew, Crews.get_crew!(id))
+  end
+
+  defp handle_pubsub(event, _crew, socket)
+       when event in [:create_crew, :update_crew] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_crew,
+         do: gettext("Created") <> " " <> gettext("Crew"),
+         else: gettext("Updated") <> " " <> gettext("Crew")
+       )
+     )
+     |> push_patch(to: ~p"/admin/crews?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_crew, crew, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Crew"))
+     |> stream_delete(:crews, crew)}
   end
 end

--- a/lib/itsm_web/live/admin/crew_live/show.ex
+++ b/lib/itsm_web/live/admin/crew_live/show.ex
@@ -10,12 +10,44 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:crew, id)
+      Itsm.Utils.subscribes(:crews)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:crew, Crews.get_crew!(id))}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Crew"
   defp page_title(:edit), do: "Edit Crew"
+
+  defp handle_pubsub(:update_crew, %{id: id} = crew, %{assigns: %{crew: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> assign(:crew, crew)
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("Crew"))
+     |> push_patch(to: ~p"/admin/crews/#{crew}")}
+  end
+
+  defp handle_pubsub(:delete_crew, %{id: id}, %{assigns: %{crew: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Crew"))
+     |> push_navigate(to: ~p"/admin/crews")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/admin/request_live/form_component.ex
+++ b/lib/itsm_web/live/admin/request_live/form_component.ex
@@ -80,10 +80,7 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
   defp save_request(socket, :edit, request_params) do
     case Requests.update_request(socket.assigns.request, request_params) do
       {:ok, _request} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Request updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
@@ -93,10 +90,7 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
   defp save_request(socket, :new, request_params) do
     case Requests.create_request(socket.assigns.current_user, request_params) do
       {:ok, _request} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Request created successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/lib/itsm_web/live/admin/request_live/index.ex
+++ b/lib/itsm_web/live/admin/request_live/index.ex
@@ -7,6 +7,10 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:requests)
+    end
+
     {:ok, stream(socket, :requests, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
 
     {:noreply, stream_delete(socket, :requests, request)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -55,5 +67,26 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
     socket
     |> assign(:page_title, "Edit Request")
     |> assign(:request, Requests.get_request!(id))
+  end
+
+  defp handle_pubsub(event, _request, socket)
+       when event in [:create_request, :update_request] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_request,
+         do: gettext("Created") <> " " <> gettext("Request"),
+         else: gettext("Updated") <> " " <> gettext("Request")
+       )
+     )
+     |> push_patch(to: ~p"/admin/requests?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_request, request, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Request"))
+     |> stream_delete(:requests, request)}
   end
 end

--- a/lib/itsm_web/live/admin/request_live/show.ex
+++ b/lib/itsm_web/live/admin/request_live/show.ex
@@ -10,12 +10,48 @@ defmodule ItsmWeb.Admin.RequestLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:request, id)
+      Itsm.Utils.subscribes(:requests)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:request, Requests.get_request!(id))}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show Request"
   defp page_title(:edit), do: "Edit Request"
+
+  defp handle_pubsub(
+         :update_request,
+         %{id: id} = request,
+         %{assigns: %{request: %{id: id}}} = socket
+       ) do
+    {:noreply,
+     socket
+     |> assign(:request, request)
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("Request"))
+     |> push_patch(to: ~p"/admin/requests/#{request}")}
+  end
+
+  defp handle_pubsub(:delete_request, %{id: id}, %{assigns: %{request: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("Request"))
+     |> push_navigate(to: ~p"/admin/requests")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -255,3 +255,6 @@ msgstr "작업명"
 
 msgid "Requests"
 msgstr "요청목록"
+
+msgid "Common Code"
+msgstr "공통 코드"

--- a/priv/templates/phx.gen.context/access_no_schema.ex
+++ b/priv/templates/phx.gen.context/access_no_schema.ex
@@ -8,16 +8,42 @@
     %<%= inspect schema.alias %>{}
     |> <%= inspect schema.alias %>.changeset(attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, <%= schema.singular %>} ->
+       Itsm.Utils.broadcasts(:<%= schema.plural %>, {:create_<%= schema.singular %>, <%= schema.singular %>})
+       {:ok, <%= schema.singular %>}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def update_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
     <%= schema.singular %>
     |> <%= inspect schema.alias %>.changeset(attrs)
     |> Repo.update()
+    |> case do
+      {:ok, <%= schema.singular %>} ->
+       Itsm.Utils.broadcast(:<%= schema.singular %>, {:update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcasts(:<%= schema.plural %>, {:update_<%= schema.singular %>, <%= schema.singular %>})
+       {:ok, <%= schema.singular %>}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def delete_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
     Repo.delete(<%= schema.singular %>)
+    |> case do
+      {:ok, <%= schema.singular %>} ->
+       Itsm.Utils.broadcast(:<%= schema.singular %>, {:update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcasts(:<%= schema.plural %>, {:update_<%= schema.singular %>, <%= schema.singular %>})
+       {:ok, <%= schema.singular %>}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do

--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -11,6 +11,15 @@
     |> <%= inspect schema.alias %>.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
+    |> case do
+      {:ok, <%= schema.singular %>} ->
+       Itsm.Utils.broadcast(:<%= schema.singular %>, {:update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcasts(:<%= schema.plural %>, {:update_<%= schema.singular %>, <%= schema.singular %>})
+       {:ok, <%= schema.singular %>}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   defdelegate delete_<%= schema.singular %>(<%= schema.singular %>), to: Itsm.<%= inspect context.alias %>

--- a/priv/templates/phx.gen.itsm.admin_live/form_component.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/form_component.ex.eex
@@ -59,10 +59,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   defp save_<%= schema.singular %>(socket, :edit, <%= schema.singular %>_params) do
     case <%= inspect context.alias %>.update_<%= schema.singular %>(socket.assigns.<%= schema.singular %>, <%= schema.singular %>_params) do
       {:ok, _<%= schema.singular %>} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "<%= schema.human_singular %> updated successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
@@ -72,10 +69,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   defp save_<%= schema.singular %>(socket, :new, <%= schema.singular %>_params) do
     case <%= inspect context.alias %>.create_<%= schema.singular %>(<%= schema.singular %>_params) do
       {:ok, _<%= schema.singular %>} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "<%= schema.human_singular %> created successfully")
-         |> push_patch(to: socket.assigns.patch)}
+        {:noreply, socket}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}

--- a/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
@@ -7,6 +7,10 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   @impl true
   def mount(_params, _session, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribes(:<%= schema.collection %>)
+    end
+
     {:ok, stream(socket, :<%= schema.collection %>, [])}
   end
 
@@ -22,6 +26,14 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
     {:noreply, stream_delete(socket, :<%= schema.collection %>, <%= schema.singular %>)}
   end
+
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
     value =
@@ -44,5 +56,26 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     socket
     |> assign(:page_title, "Edit <%= schema.human_singular %>")
     |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))
+  end
+
+  defp handle_pubsub(event, _<%= schema.singular %>, socket)
+       when event in [:create_<%= schema.singular %>, :update_<%= schema.singular %>] do
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       if(event == :create_<%= schema.singular %>,
+         do: gettext("Created") <> " " <> gettext("<%= schema.human_singular %>"),
+         else: gettext("Updated") <> " " <> gettext("<%= schema.human_singular %>")
+       )
+     )
+     |> push_patch(to: ~p"/admin/<%= schema.collection %>?#{socket.assigns[:results][:params] || %{}}")}
+  end
+
+  defp handle_pubsub(:delete_<%= schema.singular %>, <%= schema.singular %>, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("<%= schema.human_singular %>"))
+     |> stream_delete(:<%= schema.collection %>, <%= schema.singular %>)}
   end
 end

--- a/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
@@ -10,12 +10,44 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(:<%= schema.singular %>, id)
+      Itsm.Utils.subscribes(:<%= schema.collection %>)
+    end
+
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))}
   end
 
+  @impl true
+  def handle_info({:pubsub, {event, item}}, socket) do
+    handle_pubsub(event, item, socket)
+  end
+
+  @impl true
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   defp page_title(:show), do: "Show <%= schema.human_singular %>"
   defp page_title(:edit), do: "Edit <%= schema.human_singular %>"
+
+  defp handle_pubsub(:update_<%= schema.singular %>, %{id: id} = <%= schema.singular %>, %{assigns: %{<%= schema.singular %>: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> assign(:<%= schema.singular %>, <%= schema.singular %>)
+     |> put_flash(:info, gettext("Updated") <> " " <> gettext("<%= schema.human_singular %>"))
+     |> push_patch(to: ~p"/admin/<%= schema.collection %>/#{<%= schema.singular %>}")}
+  end
+
+  defp handle_pubsub(:delete_<%= schema.singular %>, %{id: id}, %{assigns: %{<%= schema.singular %>: %{id: id}}} = socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Deleted") <> " " <> gettext("<%= schema.human_singular %>"))
+     |> push_navigate(to: ~p"/admin/<%= schema.collection %>")}
+  end
+
+  defp handle_pubsub(_event, _item, socket) do
+    {:noreply, socket}
+  end
 end


### PR DESCRIPTION
## 📌 Description
관리자(Admin) 결재 도메인에 실시간 업데이트를 위한 PubSub 기능을 추가하고, 관련 로직을 리팩토링했습니다.

### ⚡ 주요 변경 사항
1. **Admin페이지 PubSub 도입**
   - `Itsm.Utils.broadcast/2` (단일 항목 전용: `approval:ID`) 및 `broadcasts/2` (도메인 전체: `approval`) 활용.
   - 결재 생성, 수정, 삭제 시 실시간 알림 이벤트 발생.

2. **LiveView 구독 전략 최적화**
   - **Index (목록):** `subscribes(:approval)`를 통해 도메인 전체 이벤트를 수신하며, 이벤트 발생 시 `push_patch`를 통해 목록을 효율적으로 갱신합니다.
   - **Show (상세):** `subscribe(:approval, id)`와 `subscribes(:approval)`를 병행하여, 개별 수정 사항뿐만 아니라 관리자의 일괄 처리(Bulk Update) 신호까지 놓치지 않도록 설계했습니다.

3. **공통 Utils에서 PubSub 관리**
   -  Itsm.Utils에 공통으로 사용할 PubSub생성

4. **코드 리팩토링**
   - `handle_pubsub/3` 내에서 `gettext` 매크로의 컴파일 타임 제약을 준수하도록 메시지 처리 로직 개선.
   - 불필요한 스트림(Stream) 조작 대신 `push_patch`를 활용하여 데이터 일관성 유지 및 코드 단순화.