### PR TITLE
[feat] Crew에 공통 pubsub 메소드 적용 및 수정한 사용자 이름 표출

### DIFF
--- a/lib/itsm/crews.ex
+++ b/lib/itsm/crews.ex
@@ -3,31 +3,12 @@ defmodule Itsm.Crews do
   alias Itsm.Repo
   alias Itsm.Crews.{Crew, CrewsUsers, CrewReference}
   alias Itsm.Accounts.User
+  alias Itsm.Utils
 
   @doc """
-  메소드 순서 subscribe->get->preload->read(select)->create->update->delete-> defp
+  메소드 순서 get->preload->read(select)->create->update->delete-> defp
   """
-  def subscribe_crew(crew_id) do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "crew:#{crew_id}")
-  end
-
-  def broadcast_crew(%Crew{id: crew_id}, message) do
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "crew:#{crew_id}", {:crew, message})
-  end
-
-  def subscribe_crews() do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "crews")
-  end
-
-  def broadcast_crews(message) do
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "crews", {:crews, message})
-  end
-
   def get_crew!(id), do: Repo.get!(Crew, id)
-
-  def preload_leader_and_users(%Crew{} = crew) do
-    Repo.preload(crew, [:leader, :users])
-  end
 
   def with_assoc(%Crew{} = crew, preloads) do
     Repo.preload(crew, preloads)
@@ -111,6 +92,7 @@ defmodule Itsm.Crews do
     |> case do
       {:ok, crew} ->
         crew = Repo.preload(crew, [:leader, :users])
+        Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_crew, {:crews, crew}})
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -136,7 +118,7 @@ defmodule Itsm.Crews do
 
   def sync_references(_resource_type, _resource_id, _), do: :ok
 
-  def add_users(%Crew{} = crew, add_users) when is_list(add_users) do
+  def add_users(%Crew{} = crew, add_users, %User{} = action_user) when is_list(add_users) do
     crew = Repo.preload(crew, :users)
 
     new_users =
@@ -148,8 +130,8 @@ defmodule Itsm.Crews do
     |> Repo.update()
     |> case do
       {:ok, crew} ->
-        Itsm.Utils.broadcast(Crew, {:add_users, add_users})
-        Itsm.Utils.broadcasts(Crew, {:add_users, crew})
+        Utils.broadcast(__MODULE__, crew, {action_user, :add_users, {:crew, add_users}})
+        Utils.broadcasts(__MODULE__, {action_user, :add_users, {:crews, crew}})
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -157,14 +139,15 @@ defmodule Itsm.Crews do
     end
   end
 
-  def switch_leader(%Crew{} = crew, %User{} = leader, %User{} = user) do
+  def switch_leader(%Crew{} = crew, %User{} = leader, %User{} = action_user) do
     changeset = Crew.leader_changeset(crew, leader)
 
-    with :ok <- ensure_leader(crew, user),
-         :ok <- ensure_crew(crew, user),
+    with :ok <- ensure_leader(crew, action_user),
+         :ok <- ensure_crew(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
-      Itsm.Utils.broadcast(Crew, {:leader_changed, crew})
-      Itsm.Utils.broadcasts(Crew, {:leader_changed, crew})
+      Utils.broadcast(__MODULE__, crew, {action_user, :switch_leader, {:crew, crew}})
+      Utils.broadcasts(__MODULE__, {action_user, :switch_leader, {:crews, crew}})
+
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -175,12 +158,13 @@ defmodule Itsm.Crews do
     end
   end
 
-  def update_crew(%Crew{} = crew, %User{} = user, attrs \\ %{}) do
+  def update_crew(%Crew{} = crew, %User{} = action_user, attrs \\ %{}) do
     crew = Repo.preload(crew, :leader)
     changeset = Crew.changeset(crew, attrs)
 
-    with :ok <- ensure_leader(crew, user),
+    with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
+      Utils.broadcasts(__MODULE__, {action_user, :update_crew, {:crews, crew}})
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -197,11 +181,14 @@ defmodule Itsm.Crews do
     |> Repo.insert()
   end
 
-  def delete_crew(%Crew{} = crew, %User{} = user) do
+  def delete_crew(%Crew{} = crew, %User{} = action_user) do
     crew = Repo.preload(crew, :leader)
 
-    with :ok <- ensure_leader(crew, user),
+    with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.delete(crew) do
+      Utils.broadcast(__MODULE__, crew, {action_user, :delete_crew, {:crew, crew}})
+      Utils.broadcasts(__MODULE__, {action_user, :delete_crew, {:crews, crew}})
+
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -212,12 +199,15 @@ defmodule Itsm.Crews do
     end
   end
 
-  def delete_user(%Crew{} = crew, %User{} = target_user, %User{} = user) do
+  def delete_user(%Crew{} = crew, %User{} = target_user, %User{} = action_user) do
     crews_users = Repo.get_by(CrewsUsers, crew_id: crew.id, user_id: target_user.id)
 
-    with :ok <- ensure_delete_auth(crew, target_user, user),
+    with :ok <- ensure_delete_auth(crew, target_user, action_user),
          {:ok, _} <- Repo.delete(crews_users) do
-      {:ok, crew}
+      Utils.broadcast(__MODULE__, crew, {action_user, :delete_user, {:crew, target_user}})
+      Utils.broadcasts(__MODULE__, {action_user, :delete_user, {:crews, crew, target_user}})
+
+      {:ok, target_user}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
         {:error, :delete_user}
@@ -255,7 +245,7 @@ defmodule Itsm.Crews do
   defp ensure_crew(%Crew{leader: leader}, _user) when leader in [nil, ""], do: :ok
 
   defp ensure_crew(%Crew{} = crew, %User{} = leader) do
-    if Enum.member?(crew.users, leader), do: :ok, else: {:error, :not_in_crew}
+    if Enum.any?(crew.users, &(&1.id == leader.id)), do: :ok, else: {:error, :not_in_crew}
   end
 
   defp ensure_delete_auth(crew, target_user, user)

--- a/lib/itsm/utils.ex
+++ b/lib/itsm/utils.ex
@@ -26,6 +26,11 @@ defmodule Itsm.Utils do
     Ecto.Changeset.put_change(changeset, field, value)
   end
 
+  def broadcast(domain, %{id: id}, message) do
+    topic = "#{get_topic(domain)}:#{id}"
+    Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), topic, {:pubsub, message})
+  end
+
   def broadcast(domain, message) do
     topic = "#{get_topic(domain)}:#{extract_id(message)}"
     Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), topic, {:pubsub, message})

--- a/lib/itsm_web/live/crew_live/all_index.ex
+++ b/lib/itsm_web/live/crew_live/all_index.ex
@@ -2,15 +2,14 @@ defmodule ItsmWeb.CrewLive.AllIndex do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
+  alias Itsm.Utils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
   import ItsmWeb.CrewLive.Components
 
   def mount(_params, _session, socket) do
-    if(connected?(socket)) do
-      Crews.subscribe_crews()
-    end
+    if connected?(socket), do: Utils.subscribes(Crews)
 
     {:ok, socket |> assign(:org_options, Itsm.CommonCodes.get_select_options("계열사"))}
   end
@@ -44,13 +43,20 @@ defmodule ItsmWeb.CrewLive.AllIndex do
     {:noreply, socket}
   end
 
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
 
-  defp handle_pubsub(_user, _event, _item, socket) do
+  defp handle_pubsub(_action_user, event, {:crews, _crew}, socket)
+       when event in [:create_crew, :update_crew, :delete_crew] do
+    %{filter_params: params} = socket.assigns
+
+    {:noreply, push_patch(socket, to: ~p"/crews/all?#{params}")}
+  end
+
+  defp handle_pubsub(_action_user, _event, _item, socket) do
     {:noreply, socket}
   end
 end

--- a/lib/itsm_web/live/crew_live/index.ex
+++ b/lib/itsm_web/live/crew_live/index.ex
@@ -5,6 +5,7 @@ defmodule ItsmWeb.CrewLive.Index do
   alias Itsm.Crews.Crew
   alias Itsm.Accounts.User
   alias ItsmWeb.LiveUtils
+  alias Itsm.Utils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
@@ -12,9 +13,7 @@ defmodule ItsmWeb.CrewLive.Index do
   def mount(_params, _session, socket) do
     %{current_user: user} = socket.assigns
 
-    if connected?(socket) do
-      Crews.subscribe_crews()
-    end
+    if connected?(socket), do: Utils.subscribes(Crews)
 
     {:ok, stream(socket, :crews, Crews.list_my_crews(user))}
   end
@@ -65,31 +64,67 @@ defmodule ItsmWeb.CrewLive.Index do
     {:noreply, stream_insert(socket, :crews, crew)}
   end
 
-  def handle_info({:crews, {event, %Crew{} = crew}}, socket)
-      when event in [:create_crew, :update_crew, :add_users, :leader_changed] do
-    %{current_user: user} = socket.assigns
-    crew = Crews.with_assoc(crew, [:leader, :users])
-
-    if(Enum.member?(crew.users, user) || user == crew.leader) do
-      {:noreply, stream_insert(socket, :crews, crew)}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info({:crews, {:delete_crew, %Crew{} = crew}}, socket) do
-    {:noreply, stream_delete(socket, :crews, crew)}
-  end
-
-  def handle_info({:crews, {:delete_user, %Crew{} = crew, %User{} = deleted_user}}, socket) do
-    %{current_user: user} = socket.assigns
-
-    if(user == deleted_user) do
-      {:noreply, stream_delete(socket, :crews, crew)}
-    else
-      {:noreply, socket}
-    end
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp handle_pubsub(action_user, event, {:crews, %Crew{} = crew}, socket)
+       when event in [:update_crew, :add_users, :switch_leader] do
+    %{current_user: user} = socket.assigns
+    crew = Crews.with_assoc(crew, [:leader, :users])
+
+    if(Enum.any?(crew.users, &(&1.id == user.id)) || user == crew.leader) do
+      {:noreply,
+       stream_insert(socket, :crews, crew)
+       |> put_flash(
+         :info,
+         gettext("%{crew_name} added/updated by %{action_user}.",
+           crew_name: crew.name,
+           action_user: action_user.display_name
+         )
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp handle_pubsub(action_user, :delete_crew, {:crews, %Crew{} = crew}, socket) do
+    {:noreply,
+     stream_delete(socket, :crews, crew)
+     |> put_flash(
+       :info,
+       gettext("%{crew_name} deleted by %{action_user}.",
+         crew_name: crew.name,
+         action_user: action_user.display_name
+       )
+     )}
+  end
+
+  defp handle_pubsub(
+         action_user,
+         :delete_user,
+         {:crews, %Crew{} = crew, %User{} = deleted_user},
+         socket
+       ) do
+    %{current_user: user} = socket.assigns
+
+    if(user == deleted_user) do
+      {:noreply,
+       stream_delete(socket, :crews, crew)
+       |> put_flash(
+         :info,
+         gettext("You have been removed from the crew by %{action_user}.",
+           action_user: action_user.display_name
+         )
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp handle_pubsub(_action_user, _event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/crew_live/show.ex
+++ b/lib/itsm_web/live/crew_live/show.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.CrewLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
+  alias Itsm.Utils
   alias ItsmWeb.LiveUtils
 
   def mount(params, _session, socket) do
@@ -13,8 +14,8 @@ defmodule ItsmWeb.CrewLive.Show do
 
   def handle_params(%{"id" => id}, _params, socket) do
     if connected?(socket) do
-      Crews.subscribe_crew(id)
-      Crews.subscribe_crews()
+      Utils.subscribe(Crews, id)
+      Utils.subscribes(Crews)
     end
 
     crew =
@@ -43,13 +44,19 @@ defmodule ItsmWeb.CrewLive.Show do
     target_user = Accounts.get_user!(user_id)
 
     case Crews.delete_user(crew, target_user, current_user) do
-      {:ok, _crew} ->
+      {:ok, _target_user} ->
         msg =
           if current_user == target_user,
             do: "You have left the crew",
             else: "Member removed successfully"
 
-        {:noreply, put_flash(socket, :info, msg)}
+        socket =
+          socket
+          |> assign(:show_member_modal, false)
+          |> stream_delete(:users, target_user)
+          |> put_flash(:info, msg)
+
+        {:noreply, socket}
 
       {:error, step} ->
         {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
@@ -71,8 +78,41 @@ defmodule ItsmWeb.CrewLive.Show do
     {:noreply, socket}
   end
 
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
+  end
+
+  def handle_info({ItsmWeb.SearchUsersDialog, :users_selected, user_ids}, socket) do
+    %{crew: crew, current_user: action_user} = socket.assigns
+
+    crew =
+      Crews.get_crew!(crew.id)
+      |> Crews.with_assoc([:leader, :users])
+
+    users = Accounts.get_users(user_ids)
+
+    case Crews.add_users(crew, users, action_user) do
+      {:ok, _crew} ->
+        socket =
+          users
+          |> List.delete(crew.leader)
+          |> Enum.reduce(socket, fn user, acc ->
+            stream_insert(acc, :users, user, at: 0)
+          end)
+          |> assign(:show_member_modal, false)
+          |> put_flash(:info, "Members added successfully")
+
+        {:noreply, socket}
+
+      {:error, step} ->
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
+    end
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # 리더 변경시 각 버튼의 권한이 달라지므로 전체 stream 전체 reset 처리
-  def handle_info({:crew, {:leader_changed, %{id: crew_id}}}, socket) do
+  defp handle_pubsub(action_user, :switch_leader, {:crew, %{id: crew_id}}, socket) do
     crew =
       Crews.get_crew!(crew_id)
       |> Crews.with_assoc([:leader, :users])
@@ -82,11 +122,17 @@ defmodule ItsmWeb.CrewLive.Show do
       |> assign(:show_member_modal, false)
       |> assign(:crew, crew)
       |> stream(:users, Crews.list_regular_users(crew), reset: true)
+      |> put_flash(
+        :info,
+        gettext("Leader changed by %{action_user}",
+          action_user: action_user.display_name
+        )
+      )
 
     {:noreply, socket}
   end
 
-  def handle_info({:crew, {:add_users, add_users}}, socket) do
+  defp handle_pubsub(_action_user, :add_users, {:crew, add_users}, socket) do
     %{crew: crew} = socket.assigns
     crew = Crews.with_assoc(crew, :leader)
 
@@ -101,14 +147,14 @@ defmodule ItsmWeb.CrewLive.Show do
     {:noreply, socket}
   end
 
-  def handle_info({:crew, {:delete_user, removed_user}}, socket) do
+  defp handle_pubsub(_action_user, :delete_user, {:crew, removed_user}, socket) do
     {:noreply,
      socket
      |> assign(:show_member_modal, false)
      |> stream_delete(:users, removed_user)}
   end
 
-  def handle_info({:crews, {:update_crew, update_crew}}, socket) do
+  defp handle_pubsub(_action_user, :update_crew, {:crews, update_crew}, socket) do
     %{crew: crew} = socket.assigns
 
     if(crew.id == update_crew.id) do
@@ -119,43 +165,40 @@ defmodule ItsmWeb.CrewLive.Show do
     end
   end
 
-  def handle_info({:crews, {:delete_crew, deleted_crew}}, socket) do
-    %{crew: crew, back_path: back_path} = socket.assigns
+  defp handle_pubsub(action_user, :delete_crew, {:crew, deleted_crew}, socket) do
+    %{back_path: back_path} = socket.assigns
 
-    if(crew.id == deleted_crew.id) do
-      {:noreply,
-       socket
-       |> put_flash("info", "The crew has been deleted")
-       |> push_navigate(to: back_path)}
-    else
-      {:noreply, socket}
-    end
+    {:noreply,
+     socket
+     |> put_flash(
+       "info",
+       gettext("%{crew_name} has been deleted by %{action_user}.",
+         crew_name: deleted_crew.name,
+         action_user: action_user.display_name
+       )
+     )
+     |> push_navigate(to: back_path)}
   end
 
-  def handle_info({ItsmWeb.SearchUsersDialog, :users_selected, user_ids}, socket) do
-    %{crew: crew} = socket.assigns
-
-    crew =
-      Crews.get_crew!(crew.id)
-      |> Crews.with_assoc([:leader, :users])
-
-    users = Accounts.get_users(user_ids)
-
-    case Crews.add_users(crew, users) do
-      {:ok, _crew} ->
-        {:noreply, put_flash(socket, :info, "Members added successfully")}
-
-      {:error, step} ->
-        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
-    end
+  defp handle_pubsub(_user, _event, _item, socket) do
+    {:noreply, socket}
   end
-
-  def handle_info(_message, socket), do: {:noreply, socket}
 
   defp switch_leader(socket, crew, leader, current_user) do
     case Crews.switch_leader(crew, leader, current_user) do
-      {:ok, _crew} ->
-        {:noreply, put_flash(socket, :info, "Leader changed successfully")}
+      {:ok, crew} ->
+        crew =
+          Crews.get_crew!(crew.id)
+          |> Crews.with_assoc([:leader, :users])
+
+        socket =
+          socket
+          |> assign(:show_member_modal, false)
+          |> assign(:crew, crew)
+          |> stream(:users, Crews.list_regular_users(crew), reset: true)
+          |> put_flash(:info, "Leader changed successfully")
+
+        {:noreply, socket}
 
       {:error, step} ->
         {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}


### PR DESCRIPTION
## Crew에 공통 pubsub 메소드 적용 및 수정한 사용자 이름 표출
나의 Crew, 모든 Crew, Crew생성, Crew삭제, Crew멤버 추가, 리더 변경에 liveview에 적용을 함

이슈 번호 : #101