### PR TITLE
common code ets로 효율화 및 pubsub 수정

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -5,7 +5,7 @@ alias Itsm.Service.{Request, CommonKCreateVm}
 alias Itsm.Categories
 alias Itsm.Service.Category
 alias Itsm.Crews
-alias Itsm.Crews.{Crew, CrewsUsers, Reference}
+alias Itsm.Crews.{Crew, CrewsUsers, CrewReference}
 alias Itsm.Attachments
 alias Itsm.Attachments.Attachment
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -68,6 +68,32 @@ window.addEventListener("phx:page-loading-stop", (_info) => {
   }
 });
 
+window.addEventListener("phx:common_code_all_reloaded", (e) => {
+  const allData = e.detail;
+  const allElements = document.querySelectorAll("[data-common-code]");
+
+  allElements.forEach(el => {
+    const key = el.getAttribute("data-common-code");
+    if (allData[key]) {
+      const newLabel = allData[key];
+
+      if (el.innerText !== newLabel) {
+        el.innerText = newLabel;
+        el.classList.add("bg-yellow-200", "transition-all", "duration-0");
+
+        setTimeout(() => {
+          el.classList.replace("duration-0", "duration-1000");
+          el.classList.remove("bg-yellow-200");
+        }, 1000);
+
+        setTimeout(() => {
+          el.classList.remove("transition-all", "duration-1000");
+        }, 1200);
+      }
+    }
+  });
+});
+
 // connect if there are any LiveViews on the page
 liveSocket.connect();
 

--- a/lib/itsm/admin/approvals.ex
+++ b/lib/itsm/admin/approvals.ex
@@ -18,8 +18,8 @@ defmodule Itsm.Admin.Approvals do
     |> case do
       {:ok, approval} ->
         event = :update_approval
-        Itsm.Utils.broadcast(Approval, {attrs["current_user"], event, approval})
-        Itsm.Utils.broadcasts(Approval, {attrs["current_user"], event, approval})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, approval})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, approval})
         {:ok, approval}
 
       {:error, changeset} ->
@@ -32,8 +32,8 @@ defmodule Itsm.Admin.Approvals do
     |> case do
       {:ok, approval} ->
         event = :delete_approval
-        Itsm.Utils.broadcast(Approval, {attrs["current_user"], event, approval})
-        Itsm.Utils.broadcasts(Approval, {attrs["current_user"], event, approval})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, approval})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, approval})
         {:ok, approval}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/assets.ex
+++ b/lib/itsm/admin/assets.ex
@@ -21,8 +21,8 @@ defmodule Itsm.Admin.Assets do
     |> case do
       {:ok, asset} ->
         event = :update_asset
-        Itsm.Utils.broadcast(Asset, {attrs["current_user"], event, asset})
-        Itsm.Utils.broadcasts(Asset, {attrs["current_user"], event, asset})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, asset})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, asset})
         {:ok, asset}
 
       {:error, changeset} ->
@@ -35,8 +35,8 @@ defmodule Itsm.Admin.Assets do
     |> case do
       {:ok, asset} ->
         event = :delete_asset
-        Itsm.Utils.broadcast(Asset, {attrs["current_user"], event, asset})
-        Itsm.Utils.broadcasts(Asset, {attrs["current_user"], event, asset})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, asset})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, asset})
         {:ok, asset}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/categories.ex
+++ b/lib/itsm/admin/categories.ex
@@ -17,8 +17,8 @@ defmodule Itsm.Admin.Categories do
     |> case do
       {:ok, category} ->
         event = :create_category
-        Itsm.Utils.broadcast(Category, {attrs["current_user"], event, category})
-        Itsm.Utils.broadcasts(Category, {attrs["current_user"], event, category})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, category})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, category})
         {:ok, category}
 
       {:error, changeset} ->
@@ -34,8 +34,8 @@ defmodule Itsm.Admin.Categories do
     |> case do
       {:ok, category} ->
         event = :update_category
-        Itsm.Utils.broadcast(Category, {attrs["current_user"], event, category})
-        Itsm.Utils.broadcasts(Category, {attrs["current_user"], event, category})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, category})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, category})
         {:ok, category}
 
       {:error, changeset} ->
@@ -48,8 +48,8 @@ defmodule Itsm.Admin.Categories do
     |> case do
       {:ok, category} ->
         event = :delete_category
-        Itsm.Utils.broadcast(Category, {attrs["current_user"], event, category})
-        Itsm.Utils.broadcasts(Category, {attrs["current_user"], event, category})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, category})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, category})
         {:ok, category}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/comments.ex
+++ b/lib/itsm/admin/comments.ex
@@ -1,5 +1,6 @@
 defmodule Itsm.Admin.Comments do
   import Ecto.Query, warn: false
+  alias Itsm.Admin.Requests
   alias Itsm.Repo
   alias Itsm.Comments.Comment
 
@@ -20,8 +21,10 @@ defmodule Itsm.Admin.Comments do
     |> case do
       {:ok, comment} ->
         event = :update_comment
-        Itsm.Utils.broadcast(Comment, {attrs["current_user"], event, comment})
-        Itsm.Utils.broadcasts(Comment, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcast(Requests, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcasts(Requests, {attrs["current_user"], event, comment})
         {:ok, comment}
 
       {:error, changeset} ->
@@ -34,8 +37,10 @@ defmodule Itsm.Admin.Comments do
     |> case do
       {:ok, comment} ->
         event = :delete_comment
-        Itsm.Utils.broadcast(Comment, {attrs["current_user"], event, comment})
-        Itsm.Utils.broadcasts(Comment, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcast(Requests, {attrs["current_user"], event, comment})
+        Itsm.Utils.broadcasts(Requests, {attrs["current_user"], event, comment})
         {:ok, comment}
 
       {:error, changeset} ->
@@ -43,7 +48,5 @@ defmodule Itsm.Admin.Comments do
     end
   end
 
-  def preload_user(%Comment{} = comment) do
-    comment |> Repo.preload([:user])
-  end
+  defdelegate with_assoc(comment, preloads), to: Itsm.Comments
 end

--- a/lib/itsm/admin/common_codes.ex
+++ b/lib/itsm/admin/common_codes.ex
@@ -17,7 +17,7 @@ defmodule Itsm.Admin.CommonCodes do
     |> case do
       {:ok, common_code} ->
         event = :create_common_code
-        Itsm.Utils.broadcasts(CommonCode, {attrs["current_user"], event, common_code})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, common_code})
         {:ok, common_code}
 
       {:error, changeset} ->
@@ -33,8 +33,8 @@ defmodule Itsm.Admin.CommonCodes do
     |> case do
       {:ok, common_code} ->
         event = :update_common_code
-        Itsm.Utils.broadcast(CommonCode, {attrs["current_user"], event, common_code})
-        Itsm.Utils.broadcasts(CommonCode, {attrs["current_user"], event, common_code})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, common_code})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, common_code})
         {:ok, common_code}
 
       {:error, changeset} ->
@@ -47,8 +47,8 @@ defmodule Itsm.Admin.CommonCodes do
     |> case do
       {:ok, common_code} ->
         event = :delete_common_code
-        Itsm.Utils.broadcast(CommonCode, {attrs["current_user"], event, common_code})
-        Itsm.Utils.broadcasts(CommonCode, {attrs["current_user"], event, common_code})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, common_code})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, common_code})
         {:ok, common_code}
 
       {:error, changeset} ->
@@ -56,5 +56,7 @@ defmodule Itsm.Admin.CommonCodes do
     end
   end
 
-  defdelegate get_select_options(group_code), to: Itsm.CommonCodes
+  defdelegate get_select_options(group_code), to: Itsm.CommonCodeCache
+
+  defdelegate get_label(group_code, code), to: Itsm.CommonCodeCache
 end

--- a/lib/itsm/admin/crews.ex
+++ b/lib/itsm/admin/crews.ex
@@ -21,8 +21,8 @@ defmodule Itsm.Admin.Crews do
       {:ok, crew} ->
         crew = Repo.preload(crew, [:leader])
         event = :update_crew
-        Itsm.Utils.broadcast(Crew, {attrs["current_user"], event, crew})
-        Itsm.Utils.broadcasts(Crew, {attrs["current_user"], event, crew})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, crew})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, crew})
         {:ok, crew}
 
       {:error, changeset} ->
@@ -35,8 +35,8 @@ defmodule Itsm.Admin.Crews do
     |> case do
       {:ok, crew} ->
         event = :delete_crew
-        Itsm.Utils.broadcast(Crew, {attrs["current_user"], event, crew})
-        Itsm.Utils.broadcasts(Crew, {attrs["current_user"], event, crew})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, crew})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, crew})
         {:ok, crew}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/requests.ex
+++ b/lib/itsm/admin/requests.ex
@@ -18,8 +18,8 @@ defmodule Itsm.Admin.Requests do
     |> case do
       {:ok, request} ->
         event = :update_request
-        Itsm.Utils.broadcast(Request, {attrs["current_user"], event, request})
-        Itsm.Utils.broadcasts(Request, {attrs["current_user"], event, request})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, request})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, request})
         {:ok, request}
 
       {:error, changeset} ->
@@ -32,8 +32,8 @@ defmodule Itsm.Admin.Requests do
     |> case do
       {:ok, request} ->
         event = :delete_request
-        Itsm.Utils.broadcast(Request, {attrs["current_user"], event, request})
-        Itsm.Utils.broadcasts(Request, {attrs["current_user"], event, request})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], event, request})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], event, request})
         {:ok, request}
 
       {:error, changeset} ->

--- a/lib/itsm/application.ex
+++ b/lib/itsm/application.ex
@@ -5,7 +5,6 @@ defmodule Itsm.Application do
 
   use Application
 
-  @impl true
   def start(_type, _args) do
     children = [
       ItsmWeb.Telemetry,
@@ -17,7 +16,8 @@ defmodule Itsm.Application do
       # Start a worker by calling: Itsm.Worker.start_link(arg)
       # {Itsm.Worker, arg},
       # Start to serve requests, typically the last entry
-      ItsmWeb.Endpoint
+      ItsmWeb.Endpoint,
+      Itsm.CommonCodeCache
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -28,7 +28,6 @@ defmodule Itsm.Application do
 
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.
-  @impl true
   def config_change(changed, _new, removed) do
     ItsmWeb.Endpoint.config_change(changed, removed)
     :ok

--- a/lib/itsm/approvals.ex
+++ b/lib/itsm/approvals.ex
@@ -116,7 +116,7 @@ defmodule Itsm.Approvals do
         end
 
         broadcast_approvals_list({:request_updated, preloaded_request})
-        Itsm.Utils.broadcast(Request, {:request_updated, preloaded_request})
+        Itsm.Utils.broadcast(__MODULE__, {:request_updated, preloaded_request})
         # Requests.broadcast_request(preloaded_request.id, {:request_updated, preloaded_request})
         result
 
@@ -135,11 +135,10 @@ defmodule Itsm.Approvals do
       request: request,
       status: :request
     }
-    |> Approval.changeset(%{approver_id: user.id, request_id: request.id})
     |> repo.insert()
     |> case do
       {:ok, approval} ->
-        Itsm.Utils.broadcasts(Approval, {attrs["current_user"], :create_approval, approval})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_approval, approval})
         {:ok, approval}
 
       {:error, changeset} ->
@@ -153,7 +152,7 @@ defmodule Itsm.Approvals do
     |> Repo.insert()
     |> case do
       {:ok, approval} ->
-        Itsm.Utils.broadcasts(Approval, {attrs["current_user"], :create_approval, approval})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_approval, approval})
         {:ok, approval}
 
       {:error, changeset} ->

--- a/lib/itsm/assets.ex
+++ b/lib/itsm/assets.ex
@@ -100,8 +100,8 @@ defmodule Itsm.Assets do
     |> Repo.insert()
     |> case do
       {:ok, asset} ->
-        Itsm.Utils.broadcast(Asset, {attrs["current_user"], :create_asset, asset})
-        Itsm.Utils.broadcasts(Asset, {attrs["current_user"], :create_asset, asset})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :create_asset, asset})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_asset, asset})
         {:ok, asset}
 
       {:error, changeset} ->
@@ -127,8 +127,8 @@ defmodule Itsm.Assets do
     |> Repo.update()
     |> case do
       {:ok, asset} ->
-        Itsm.Utils.broadcast(Asset, {attrs["current_user"], :update_asset, asset})
-        Itsm.Utils.broadcasts(Asset, {attrs["current_user"], :update_asset, asset})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_asset, asset})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_asset, asset})
         {:ok, asset}
 
       {:error, changeset} ->
@@ -152,8 +152,8 @@ defmodule Itsm.Assets do
     Repo.delete(get_asset!(id))
     |> case do
       {:ok, asset} ->
-        Itsm.Utils.broadcast(Asset, {attrs["current_user"], :delete_asset, asset})
-        Itsm.Utils.broadcasts(Asset, {attrs["current_user"], :delete_asset, asset})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :delete_asset, asset})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :delete_asset, asset})
         {:ok, asset}
 
       {:error, changeset} ->

--- a/lib/itsm/attachments.ex
+++ b/lib/itsm/attachments.ex
@@ -17,7 +17,7 @@ defmodule Itsm.Attachments do
     |> case do
       {:ok, attachment} ->
         Itsm.Utils.broadcasts(
-          Attachment,
+          __MODULE__,
           {attrs["curremt_user"], :create_attachments, attachment}
         )
 
@@ -38,7 +38,7 @@ defmodule Itsm.Attachments do
       |> case do
         {:ok, attachment} ->
           Itsm.Utils.broadcasts(
-            Attachment,
+            __MODULE__,
             {attachments_attrs["curremt_user"], :create_attachments, attachment}
           )
 

--- a/lib/itsm/cache/common_code_cache.ex
+++ b/lib/itsm/cache/common_code_cache.ex
@@ -1,0 +1,84 @@
+defmodule Itsm.CommonCodeCache do
+  use GenServer
+
+  alias Itsm.Repo
+  alias Itsm.Common.CommonCode
+  alias Itsm.CommonCodes
+
+  @table :common_code_cache
+
+  def init(_) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+
+    Itsm.Utils.subscribes(CommonCodes)
+
+    send(self(), :load_from_db)
+    {:ok, %{}}
+  end
+
+  def handle_info(:load_from_db, state) do
+    do_load()
+    {:noreply, state}
+  end
+
+  def handle_info({:pubsub, {_acction_user, _event, _item}}, state) do
+    do_load()
+    {:noreply, state}
+  end
+
+  def handle_info(_event, state) do
+    {:noreply, state}
+  end
+
+  def handle_cast(:load_from_db, state) do
+    do_load()
+    {:noreply, state}
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def reload, do: GenServer.cast(__MODULE__, :load_from_db)
+
+  def get_by_group(group_code) do
+    @table
+    |> :ets.match_object({{group_code, :_}, :_})
+    |> Enum.filter(fn {_, data} -> data.is_active end)
+    |> Enum.map(fn {_, data} -> data end)
+    |> Enum.sort_by(& &1.sort_order)
+  end
+
+  def get_label(group_code, code) do
+    case :ets.lookup(@table, {group_code, code}) do
+      [{_, data}] -> data.label
+      [] -> code
+    end
+  end
+
+  def get_select_options(group_code) do
+    get_by_group(group_code)
+    |> Enum.map(fn item ->
+      {item.label, item.code}
+    end)
+  end
+
+  defp do_load do
+    data_list =
+      CommonCode
+      |> Repo.all()
+      |> Enum.map(fn item -> {{item.group_code, item.code}, item} end)
+
+    :ets.delete_all_objects(@table)
+
+    :ets.insert(@table, data_list)
+
+    update_map =
+      data_list
+      |> Enum.into(%{}, fn {{group, code}, item} -> {"#{group}:#{code}", item.label} end)
+
+    ItsmWeb.Endpoint.broadcast_from(self(), "common_code:updates", "all_codes_reload", update_map)
+
+    IO.puts("✅ [CodeCache] #{DateTime.utc_now()} - 공통코드 로드 완료 (Count: #{length(data_list)})")
+  end
+end

--- a/lib/itsm/comments.ex
+++ b/lib/itsm/comments.ex
@@ -1,5 +1,6 @@
 defmodule Itsm.Comments do
   import Ecto.Query, warn: false
+  alias Itsm.Requests
   alias Itsm.Repo
 
   alias Itsm.Comments.Comment
@@ -7,15 +8,9 @@ defmodule Itsm.Comments do
   alias Itsm.Utils
 
   # 결과 처리
-  def broadcast_result({:ok, %{comment: comment}}, action_user, resource) do
-    Itsm.Utils.broadcasts(Comment, {action_user, :create_comment, comment})
-    comment = Repo.preload(comment, :attachments)
-    # PubSub 방송 (토픽 ID로 전파)
-    # Requests.broadcast_request(topic_id, {:comment_created, comment})
-    Itsm.Utils.broadcast(
-      resource,
-      {action_user, :create_comment, {resource, comment}}
-    )
+  def broadcast_result({:ok, %{comment: comment}}, action_user) do
+    Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_comment, comment})
+    Itsm.Utils.broadcast(Requests, {action_user, :create_comment, comment})
 
     {:ok, comment}
   end
@@ -57,13 +52,21 @@ defmodule Itsm.Comments do
 
         # 🌟 2. 여기서 직접 PubSub 방송을 쏩니다! (기존 로직 활용)
         # Requests.broadcast_request(resource.id, {:comment_created, preloaded_comment})
-        Itsm.Utils.broadcast(Request, {attrs["current_user"], :create_comment, preloaded_comment})
-        Itsm.Utils.broadcasts(Comment, {attrs["current_user"], :create_comment, comment})
+        Itsm.Utils.broadcast(
+          Requests,
+          {attrs["current_user"], :create_comment, preloaded_comment}
+        )
+
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_comment, comment})
 
         {:ok, preloaded_comment}
 
       {:error, changeset} ->
         {:error, changeset}
     end
+  end
+
+  def with_assoc(%Comment{} = comment, preloads) do
+    Repo.preload(comment, preloads)
   end
 end

--- a/lib/itsm/common/common_code.ex
+++ b/lib/itsm/common/common_code.ex
@@ -1,8 +1,6 @@
 defmodule Itsm.Common.CommonCode do
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query
-  alias Itsm.Repo
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -21,42 +19,5 @@ defmodule Itsm.Common.CommonCode do
     codes
     |> cast(attrs, [:group_code, :code, :label, :description, :sort_order, :is_active])
     |> validate_required([:group_code, :code, :label, :is_active])
-  end
-
-  def validate_common_codes(changeset, group_field_map) do
-    to_check =
-      Enum.reduce(group_field_map, [], fn {field, group_code}, acc ->
-        if value = get_change(changeset, field) do
-          [{group_code, value, field} | acc]
-        else
-          acc
-        end
-      end)
-
-    if to_check == [], do: changeset, else: do_batch_validate(changeset, to_check)
-  end
-
-  defp do_batch_validate(changeset, to_check) do
-    conditions =
-      Enum.reduce(to_check, false, fn {g, c, _f}, acc ->
-        dynamic([c], (c.group_code == ^g and c.code == ^c) or ^acc)
-      end)
-
-    existing_set =
-      from(c in __MODULE__,
-        where: ^conditions,
-        where: c.is_active == true,
-        select: {c.group_code, c.code}
-      )
-      |> Repo.all()
-      |> MapSet.new()
-
-    Enum.reduce(to_check, changeset, fn {g, c, f}, acc_changeset ->
-      if MapSet.member?(existing_set, {g, c}) do
-        acc_changeset
-      else
-        add_error(acc_changeset, f, "is invalid (code '#{c}' not found in group '#{g}')")
-      end
-    end)
   end
 end

--- a/lib/itsm/common_codes.ex
+++ b/lib/itsm/common_codes.ex
@@ -11,24 +11,9 @@ defmodule Itsm.CommonCodes do
     |> Repo.all()
   end
 
-  def get_select_options(group_code) when is_nil(group_code) or group_code == "", do: []
+  defdelegate get_select_options(group_code), to: Itsm.CommonCodeCache
 
-  def get_select_options(group_code) do
-    CommonCode
-    |> with_type(group_code)
-    |> where([c], c.is_active == true)
-    |> order_by([c], asc: c.sort_order)
-    |> select([c], {c.label, c.code})
-    |> Repo.all()
-  end
-
-  def get_label(group_code, code) do
-    CommonCode
-    |> where([c], c.code == ^code)
-    |> with_type(group_code)
-    |> select([c], c.label)
-    |> Repo.one()
-  end
+  defdelegate get_label(group_code, code), to: Itsm.CommonCodeCache
 
   defp with_type(query, group_code) when group_code in [nil, ""], do: query
 

--- a/lib/itsm/crews.ex
+++ b/lib/itsm/crews.ex
@@ -3,30 +3,17 @@ defmodule Itsm.Crews do
   alias Itsm.Repo
   alias Itsm.Crews.{Crew, CrewsUsers, CrewReference}
   alias Itsm.Accounts.User
+  alias Itsm.Utils
 
   @doc """
-  메소드 순서 subscribe->get->preload->read(select)->create->update->delete-> defp
+  메소드 순서 get->preload->read(select)->create->update->delete-> defp
   """
-  def subscribe_crew(crew_id) do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "crew:#{crew_id}")
-  end
-
-  def broadcast_crew(%Crew{id: crew_id}, message) do
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "crew:#{crew_id}", {:crew, message})
-  end
-
-  def subscribe_crews() do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "crews")
-  end
-
-  def broadcast_crews(message) do
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "crews", {:crews, message})
-  end
-
   def get_crew!(id), do: Repo.get!(Crew, id)
 
-  def preload_leader_and_users(%Crew{} = crew) do
-    Repo.preload(crew, [:leader, :users])
+  def get_crews(ids) when is_list(ids) do
+    Crew
+    |> where([u], u.id in ^ids)
+    |> Repo.all()
   end
 
   def with_assoc(%Crew{} = crew, preloads) do
@@ -63,10 +50,10 @@ defmodule Itsm.Crews do
     List.delete(crew.users, crew.leader)
   end
 
-  def live_select_by_name_user_name(name, %User{id: user_id}) do
+  def search_live_select_crews(name, %User{} = exclude_user) do
     user_crew_ids =
       CrewsUsers
-      |> where([m], m.user_id == ^user_id)
+      |> where([m], m.user_id == ^exclude_user.id)
       |> select([m], m.crew_id)
 
     Crew
@@ -101,6 +88,15 @@ defmodule Itsm.Crews do
     |> Repo.all()
   end
 
+  def list_live_select_crews(%_{id: resource_id} = resource) do
+    CrewReference
+    |> join(:inner, [r], c in assoc(r, :crew))
+    |> where([r], r.resource_type == ^Utils.resource_name(resource))
+    |> where([r], r.resource_id == ^resource_id)
+    |> select([r, c], %{label: c.name, tag_label: c.name, value: c.id})
+    |> Repo.all()
+  end
+
   def change_crew(%Crew{} = crew, attrs \\ %{}) do
     Crew.changeset(crew, attrs)
   end
@@ -111,11 +107,40 @@ defmodule Itsm.Crews do
     |> case do
       {:ok, crew} ->
         crew = Repo.preload(crew, [:leader, :users])
+        Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_crew, {:crews, crew}})
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, :create_crew, changeset}
     end
+  end
+
+  def create_crew_reference(attrs) do
+    %CrewReference{}
+    |> CrewReference.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def create_crew_reference(repo, %_{id: resource_id} = module, %Crew{} = crew) do
+    %CrewReference{
+      resource_type: Utils.resource_name(module),
+      resource_id: resource_id,
+      crew: crew
+    }
+    |> repo.insert()
+  end
+
+  def create_crew_references(repo, %_{} = resource, crews) when is_list(crews) do
+    Enum.reduce_while(crews, {:ok, []}, fn crew, {:ok, acc} ->
+      create_crew_reference(repo, resource, crew)
+      |> case do
+        {:ok, crew_reference} ->
+          {:cont, {:ok, [crew_reference | acc]}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
   end
 
   def sync_crew_references(resource_type, resource_id, crews_id) when is_list(crews_id) do
@@ -136,7 +161,7 @@ defmodule Itsm.Crews do
 
   def sync_references(_resource_type, _resource_id, _), do: :ok
 
-  def add_users(%Crew{} = crew, add_users) when is_list(add_users) do
+  def add_users(%Crew{} = crew, add_users, %User{} = action_user) when is_list(add_users) do
     crew = Repo.preload(crew, :users)
 
     new_users =
@@ -148,8 +173,8 @@ defmodule Itsm.Crews do
     |> Repo.update()
     |> case do
       {:ok, crew} ->
-        Itsm.Utils.broadcast(Crew, {:add_users, add_users})
-        Itsm.Utils.broadcasts(Crew, {:add_users, crew})
+        Utils.broadcast(__MODULE__, crew, {action_user, :add_users, {:crew, add_users}})
+        Utils.broadcasts(__MODULE__, {action_user, :add_users, {:crews, crew}})
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -157,14 +182,15 @@ defmodule Itsm.Crews do
     end
   end
 
-  def switch_leader(%Crew{} = crew, %User{} = leader, %User{} = user) do
+  def switch_leader(%Crew{} = crew, %User{} = leader, %User{} = action_user) do
     changeset = Crew.leader_changeset(crew, leader)
 
-    with :ok <- ensure_leader(crew, user),
-         :ok <- ensure_crew(crew, user),
+    with :ok <- ensure_leader(crew, action_user),
+         :ok <- ensure_crew(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
-      Itsm.Utils.broadcast(Crew, {:leader_changed, crew})
-      Itsm.Utils.broadcasts(Crew, {:leader_changed, crew})
+      Utils.broadcast(__MODULE__, crew, {action_user, :switch_leader, {:crew, crew}})
+      Utils.broadcasts(__MODULE__, {action_user, :switch_leader, {:crews, crew}})
+
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -175,12 +201,13 @@ defmodule Itsm.Crews do
     end
   end
 
-  def update_crew(%Crew{} = crew, %User{} = user, attrs \\ %{}) do
+  def update_crew(%Crew{} = crew, %User{} = action_user, attrs \\ %{}) do
     crew = Repo.preload(crew, :leader)
     changeset = Crew.changeset(crew, attrs)
 
-    with :ok <- ensure_leader(crew, user),
+    with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
+      Utils.broadcasts(__MODULE__, {action_user, :update_crew, {:crews, crew}})
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -191,17 +218,14 @@ defmodule Itsm.Crews do
     end
   end
 
-  def create_crew_reference(attrs) do
-    %CrewReference{}
-    |> CrewReference.changeset(attrs)
-    |> Repo.insert()
-  end
-
-  def delete_crew(%Crew{} = crew, %User{} = user) do
+  def delete_crew(%Crew{} = crew, %User{} = action_user) do
     crew = Repo.preload(crew, :leader)
 
-    with :ok <- ensure_leader(crew, user),
+    with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.delete(crew) do
+      Utils.broadcast(__MODULE__, crew, {action_user, :delete_crew, {:crew, crew}})
+      Utils.broadcasts(__MODULE__, {action_user, :delete_crew, {:crews, crew}})
+
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -212,12 +236,15 @@ defmodule Itsm.Crews do
     end
   end
 
-  def delete_user(%Crew{} = crew, %User{} = target_user, %User{} = user) do
+  def delete_user(%Crew{} = crew, %User{} = target_user, %User{} = action_user) do
     crews_users = Repo.get_by(CrewsUsers, crew_id: crew.id, user_id: target_user.id)
 
-    with :ok <- ensure_delete_auth(crew, target_user, user),
+    with :ok <- ensure_delete_auth(crew, target_user, action_user),
          {:ok, _} <- Repo.delete(crews_users) do
-      {:ok, crew}
+      Utils.broadcast(__MODULE__, crew, {action_user, :delete_user, {:crew, target_user}})
+      Utils.broadcasts(__MODULE__, {action_user, :delete_user, {:crews, crew, target_user}})
+
+      {:ok, target_user}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
         {:error, :delete_user}
@@ -255,7 +282,7 @@ defmodule Itsm.Crews do
   defp ensure_crew(%Crew{leader: leader}, _user) when leader in [nil, ""], do: :ok
 
   defp ensure_crew(%Crew{} = crew, %User{} = leader) do
-    if Enum.member?(crew.users, leader), do: :ok, else: {:error, :not_in_crew}
+    if Enum.any?(crew.users, &(&1.id == leader.id)), do: :ok, else: {:error, :not_in_crew}
   end
 
   defp ensure_delete_auth(crew, target_user, user)

--- a/lib/itsm/delegations.ex
+++ b/lib/itsm/delegations.ex
@@ -106,7 +106,7 @@ defmodule Itsm.Delegations do
     |> Repo.insert()
     |> case do
       {:ok, delegation} ->
-        Itsm.Utils.broadcasts(Delegation, {attrs["current_user"], :create_delegation, delegation})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_delegation, delegation})
 
         {:ok, delegation}
 
@@ -211,12 +211,12 @@ defmodule Itsm.Delegations do
       |> case do
         {:ok, delegation} ->
           Itsm.Utils.broadcast(
-            Delegation,
+            __MODULE__,
             {attrs["current_user"], :delete_delegation, delegation}
           )
 
           Itsm.Utils.broadcasts(
-            Delegation,
+            __MODULE__,
             {attrs["current_user"], :delete_delegation, delegation}
           )
 

--- a/lib/itsm/evaluations.ex
+++ b/lib/itsm/evaluations.ex
@@ -55,7 +55,7 @@ defmodule Itsm.Evaluations do
     |> Repo.insert()
     |> case do
       {:ok, evaluation} ->
-        Itsm.Utils.broadcasts(Evaluation, {attrs["current_user"], :create_evaluation, evaluation})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_evaluation, evaluation})
         {:ok, evaluation}
 
       {:error, changeset} ->
@@ -81,8 +81,8 @@ defmodule Itsm.Evaluations do
     |> Repo.update()
     |> case do
       {:ok, evaluation} ->
-        Itsm.Utils.broadcast(Evaluation, {attrs["current_user"], :update_evaluation, evaluation})
-        Itsm.Utils.broadcasts(Evaluation, {attrs["current_user"], :update_evaluation, evaluation})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_evaluation, evaluation})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_evaluation, evaluation})
         {:ok, evaluation}
 
       {:error, changeset} ->
@@ -106,8 +106,8 @@ defmodule Itsm.Evaluations do
     Repo.delete(get_evaluation!(id))
     |> case do
       {:ok, evaluation} ->
-        Itsm.Utils.broadcast(Evaluation, {attrs["current_user"], :delete_evaluation, evaluation})
-        Itsm.Utils.broadcasts(Evaluation, {attrs["current_user"], :delete_evaluation, evaluation})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :delete_evaluation, evaluation})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :delete_evaluation, evaluation})
         {:ok, evaluation}
 
       {:error, changeset} ->

--- a/lib/itsm/os_instances.ex
+++ b/lib/itsm/os_instances.ex
@@ -56,7 +56,7 @@ defmodule Itsm.OsInstances do
     |> case do
       {:ok, os_istance} ->
         Itsm.Utils.broadcasts(
-          OsInstance,
+          __MODULE__,
           {attrs["current_user"], :create_os_instance, os_istance}
         )
 
@@ -86,12 +86,12 @@ defmodule Itsm.OsInstances do
     |> case do
       {:ok, os_istance} ->
         Itsm.Utils.broadcast(
-          OsInstance,
+          __MODULE__,
           {attrs["current_user"], :update_os_instance, os_istance}
         )
 
         Itsm.Utils.broadcasts(
-          OsInstance,
+          __MODULE__,
           {attrs["current_user"], :update_os_instance, os_istance}
         )
 
@@ -119,12 +119,12 @@ defmodule Itsm.OsInstances do
     |> case do
       {:ok, os_istance} ->
         Itsm.Utils.broadcast(
-          OsInstance,
+          __MODULE__,
           {attrs["current_user"], :delete_os_instance, os_istance}
         )
 
         Itsm.Utils.broadcasts(
-          OsInstance,
+          __MODULE__,
           {attrs["current_user"], :delete_os_instance, os_istance}
         )
 

--- a/lib/itsm/requests.ex
+++ b/lib/itsm/requests.ex
@@ -28,6 +28,10 @@ defmodule Itsm.Requests do
     |> Repo.preload(:category)
   end
 
+  def with_assoc(%Request{} = request, preloads) when is_list(preloads) do
+    Repo.preload(request, preloads)
+  end
+
   # ==================================================
   # Changeset
   # ==================================================
@@ -60,7 +64,7 @@ defmodule Itsm.Requests do
     |> case do
       {:ok, request} ->
         request = Repo.preload(request, :category)
-        Itsm.Utils.broadcasts(Request, {attrs["current_user"], :create_request, request})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_request, request})
         {:ok, request}
 
       {:error, _} = error ->
@@ -79,8 +83,8 @@ defmodule Itsm.Requests do
     |> case do
       {:ok, request} ->
         request = Repo.preload(request, :category)
-        Itsm.Utils.broadcast(Request, {attrs["current_user"], :update_request, request})
-        Itsm.Utils.broadcasts(Request, {attrs["current_user"], :update_request, request})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_request, request})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_request, request})
         {:ok, request}
 
       {:error, _} = error ->
@@ -96,8 +100,8 @@ defmodule Itsm.Requests do
     Repo.delete(get_request!(id))
     |> case do
       {:ok, request} ->
-        Itsm.Utils.broadcast(Request, {attrs["current_user"], :delete_request, request})
-        Itsm.Utils.broadcasts(Request, {attrs["current_user"], :delete_request, request})
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :delete_request, request})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :delete_request, request})
         {:ok, request}
 
       {:error, _} = error ->

--- a/lib/itsm/service.ex
+++ b/lib/itsm/service.ex
@@ -10,30 +10,35 @@ defmodule Itsm.Service do
   alias Itsm.Accounts.User
   alias Itsm.Attachments
   alias Itsm.Requests
-  alias Itsm.Service.Request
   alias Itsm.Approvals
   alias Itsm.Comments
+  alias Itsm.Crews
 
   def create_request(
         %User{} = user,
         %Category{} = category,
+        crews,
         handle_attachments,
-        request_params \\ %{}
-      ) do
+        attrs \\ %{}
+      )
+      when is_list(crews) and is_function(handle_attachments) do
     Multi.new()
-    |> Multi.insert(:request, Requests.change_request(user, category, request_params))
+    |> Multi.insert(:request, Requests.change_request(user, category, attrs))
     |> Multi.run(:approval, fn repo, %{request: request} ->
-      Approvals.create_approval(repo, request, user, request_params)
+      Approvals.create_approval(repo, request, user, attrs)
     end)
     |> Multi.run(:attachment, fn repo, %{request: request} ->
-      Attachments.create_attachments(repo, request, handle_attachments, request_params)
+      Attachments.create_attachments(repo, request, handle_attachments, attrs)
+    end)
+    |> Multi.run(:crew_reference, fn repo, %{request: request} ->
+      Crews.create_crew_references(repo, request, crews)
     end)
     |> Repo.transaction()
     |> case do
       {:ok, %{request: request}} ->
         request = Repo.preload(request, [:category, :attachments])
         Approvals.broadcast_approvals_list({:request_created, request})
-        Itsm.Utils.broadcasts(Request, {user, :created_request, request})
+        Itsm.Utils.broadcasts(Requests, {user, :created_request, request})
         {:ok, request}
 
       error ->
@@ -41,13 +46,27 @@ defmodule Itsm.Service do
     end
   end
 
-  def create_comment(resource, %User{} = user, handle_attachments, attrs \\ %{}) do
+  def create_comment(
+        resource,
+        %User{} = user,
+        handle_attachments,
+        attrs \\ %{}
+      ) do
     Multi.new()
     |> Multi.insert(:comment, Comments.changeset_comment(resource, user, attrs))
     |> Multi.run(:attachments, fn repo, %{comment: comment} ->
       Attachments.create_attachments(repo, comment, handle_attachments, attrs)
     end)
     |> Repo.transaction()
-    |> Comments.broadcast_result(attrs["current_user"], resource)
+    |> case do
+      {:ok, %{comment: comment, attachments: attachments}} ->
+        Itsm.Utils.broadcasts(Comments, {user, :create_comment, comment})
+        Itsm.Utils.broadcast(Requests, resource, {user, :create_comment, comment})
+        Itsm.Utils.broadcasts(Attachments, {user, :create_attachments, attachments})
+        {:ok, comment}
+
+      {:error, _} = error ->
+        error
+    end
   end
 end

--- a/lib/itsm/utils.ex
+++ b/lib/itsm/utils.ex
@@ -26,6 +26,11 @@ defmodule Itsm.Utils do
     Ecto.Changeset.put_change(changeset, field, value)
   end
 
+  def broadcast(domain, %{id: id}, message) do
+    topic = "#{get_topic(domain)}:#{id}"
+    Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), topic, {:pubsub, message})
+  end
+
   def broadcast(domain, message) do
     topic = "#{get_topic(domain)}:#{extract_id(message)}"
     Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), topic, {:pubsub, message})

--- a/lib/itsm_web.ex
+++ b/lib/itsm_web.ex
@@ -65,7 +65,7 @@ defmodule ItsmWeb do
     quote do
       use Phoenix.LiveComponent
 
-      use ItsmWeb.LiveHelpers
+      use ItsmWeb.LiveHelpers, only_common: true
 
       unquote(html_helpers())
     end

--- a/lib/itsm_web/components/calendar/calendar_component.ex
+++ b/lib/itsm_web/components/calendar/calendar_component.ex
@@ -11,7 +11,6 @@ defmodule ItsmWeb.CalendarComponent do
     7 => "col-start-7"
   }
 
-  @impl true
   def update(assigns, socket) do
     errors =
       if Phoenix.Component.used_input?(assigns[:field]), do: assigns[:field].errors, else: []
@@ -24,7 +23,6 @@ defmodule ItsmWeb.CalendarComponent do
      |> update_calendar_grid()}
   end
 
-  @impl true
   def handle_event("shift", %{"unit" => unit, "amount" => amount}, socket) do
     new_date =
       socket.assigns.view_date
@@ -35,7 +33,6 @@ defmodule ItsmWeb.CalendarComponent do
     {:noreply, socket |> assign(view_date: new_date) |> update_calendar_grid()}
   end
 
-  @impl true
   def handle_event("selected_date_time", %{"datetime" => datetime}, socket) do
     {:noreply,
      socket

--- a/lib/itsm_web/components/create_comment_dialog.ex
+++ b/lib/itsm_web/components/create_comment_dialog.ex
@@ -4,7 +4,6 @@ defmodule ItsmWeb.CreateCommentDialog do
   alias Itsm.Comments.Comment
   alias Itsm.Approvals
 
-  @impl true
   def update(assigns, socket) do
     {:ok,
      socket
@@ -14,7 +13,6 @@ defmodule ItsmWeb.CreateCommentDialog do
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -22,7 +20,7 @@ defmodule ItsmWeb.CreateCommentDialog do
         {@title} Request
         <:subtitle>Add a comment for this approval</:subtitle>
       </.header>
-      
+
       <.simple_form
         for={@form}
         id="approval-comment-form"
@@ -37,7 +35,6 @@ defmodule ItsmWeb.CreateCommentDialog do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"comment" => comment_params}, socket) do
     changeset = Comments.change_comment(%Comment{}, comment_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}

--- a/lib/itsm_web/components/itsm_components.ex
+++ b/lib/itsm_web/components/itsm_components.ex
@@ -411,6 +411,17 @@ defmodule ItsmWeb.ItsmComponents do
     """
   end
 
+  attr :group, :string
+  attr :code, :string
+
+  def common_code_label(assigns) do
+    ~H"""
+    <span data-common-code={"#{@group}:#{@code}"}>
+      {Itsm.CommonCodes.get_label(@group, @code)}
+    </span>
+    """
+  end
+
   @doc """
   Renders a time element that displays a localized time using a LiveView hook.
   yyyy.mm.dd hh:mm

--- a/lib/itsm_web/components/layouts/admin.html.heex
+++ b/lib/itsm_web/components/layouts/admin.html.heex
@@ -1,6 +1,6 @@
 <header class="w-full bg-white shadow-sm z-50 h-20 flex items-center">
   <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-start">
       <div class="flex items-center">
         <a href="/" class="flex items-center">
           <img src={~p"/images/itsm_banner.svg"} alt="KB ITSM" class="h-12 w-auto" />
@@ -12,9 +12,9 @@
 
       <div
         :if={@current_user}
-        class="w-full flex items-center justify-between"
+        class="flex-1 flex items-center justify-end"
       >
-        <nav class="w-full flex items-center justify-between">
+        <nav class="w-full flex items-center justify-around">
           <.link
             :for={menu <- ItsmWeb.RouterUtils.admin_menu_items()}
             href={menu.path}

--- a/lib/itsm_web/components/table_container/table_component.ex
+++ b/lib/itsm_web/components/table_container/table_component.ex
@@ -1,12 +1,10 @@
 defmodule ItsmWeb.TableContainerComponent do
   use ItsmWeb, :live_component
 
-  @impl true
   def update(assigns, socket) do
     {:ok, socket |> assign(assigns) |> init_default_value()}
   end
 
-  @impl true
   def handle_event("update-filters", params, socket) do
     query_params = %{
       "search" => params["search"],

--- a/lib/itsm_web/live/admin/approval_live/form_component.ex
+++ b/lib/itsm_web/live/admin/approval_live/form_component.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
 
   alias Itsm.Admin.Approvals
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{approval: approval} = assigns, socket) do
     {:ok,
      socket
@@ -25,7 +23,6 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
      |> assign_new_options()}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -81,13 +78,11 @@ defmodule ItsmWeb.Admin.ApprovalLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"approval" => approval_params}, socket) do
     changeset = Approvals.change_approval(socket.assigns.approval, approval_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"approval" => approval_params}, socket) do
     save_approval(socket, socket.assigns.action, approval_params)
   end

--- a/lib/itsm_web/live/admin/approval_live/index.ex
+++ b/lib/itsm_web/live/admin/approval_live/index.ex
@@ -5,31 +5,26 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
   alias Itsm.Service.Approval
   alias Itsm.Paging
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Approval)
+    if connected?(socket), do: Itsm.Utils.subscribes(Approvals)
 
     {:ok, stream(socket, :approvals, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = approval_params, socket) do
     {:ok, approval} = Approvals.delete_approval(approval_params)
 
     {:noreply, stream_delete(socket, :approvals, approval)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -65,7 +60,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
     |> assign(:approval, Approvals.get_approval!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :approval,
       resource_name: gettext("Approval"),
@@ -73,6 +68,6 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
       push_patch: [to: ~p"/admin/approvals?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/approval_live/show.ex
+++ b/lib/itsm_web/live/admin/approval_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Approvals
-  alias Itsm.Service.Approval
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Approval, id)
-      Itsm.Utils.subscribes(Approval)
+      Itsm.Utils.subscribe(Approvals, id)
+      Itsm.Utils.subscribes(Approvals)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
      |> assign(:approval, Approvals.get_approval!(id) |> Approvals.preload_category())}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Approval"
   defp page_title(:edit), do: "Edit Approval"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{approval: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/asset_live/form_component.ex
+++ b/lib/itsm_web/live/admin/asset_live/form_component.ex
@@ -3,8 +3,8 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
 
   alias Itsm.Admin.Assets
   alias Itsm.Assets.Asset
+  alias Itsm.Admin.CommonCodes
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -14,7 +14,6 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{asset: asset} = assigns, socket) do
     {:ok,
      socket
@@ -26,7 +25,6 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
      |> assign_new_options()}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -137,22 +135,21 @@ defmodule ItsmWeb.Admin.AssetLive.FormComponent do
      |> assign(form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"asset" => asset_params}, socket) do
     save_asset(socket, socket.assigns.action, asset_params)
   end
 
   defp assign_new_options(socket) do
-    crew_options = Itsm.Crews.options_excluding_user(socket.assigns[:current_user])
-
     socket
-    |> assign_new(:affiliate_options, fn -> Itsm.CommonCodes.get_select_options("계열사") end)
-    |> assign_new(:category_options, fn -> Itsm.CommonCodes.get_select_options("카테고리") end)
-    |> assign_new(:region_type_options, fn -> Itsm.CommonCodes.get_select_options("지역_유형") end)
-    |> assign_new(:infra_type_options, fn -> Itsm.CommonCodes.get_select_options("인프라_유형") end)
-    |> assign_new(:env_options, fn -> Itsm.CommonCodes.get_select_options("운영_구분") end)
-    |> assign_new(:location_options, fn -> Itsm.CommonCodes.get_select_options("장소") end)
-    |> assign(:crew_options, crew_options)
+    |> assign_new(:affiliate_options, fn -> CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:category_options, fn -> CommonCodes.get_select_options("카테고리") end)
+    |> assign_new(:region_type_options, fn -> CommonCodes.get_select_options("지역_유형") end)
+    |> assign_new(:infra_type_options, fn -> CommonCodes.get_select_options("인프라_유형") end)
+    |> assign_new(:env_options, fn -> CommonCodes.get_select_options("운영_구분") end)
+    |> assign_new(:location_options, fn -> CommonCodes.get_select_options("장소") end)
+    |> assign_new(:crew_options, fn ->
+      Itsm.Crews.options_excluding_user(socket.assigns[:current_user])
+    end)
   end
 
   defp save_asset(socket, :edit, asset_params) do

--- a/lib/itsm_web/live/admin/asset_live/index.ex
+++ b/lib/itsm_web/live/admin/asset_live/index.ex
@@ -5,31 +5,26 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
   alias Itsm.Assets.Asset
   alias Itsm.Paging
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Asset)
+    if connected?(socket), do: Itsm.Utils.subscribes(Assets)
 
     {:ok, stream(socket, :assets, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = asset_params, socket) do
     {:ok, asset} = Assets.delete_asset(asset_params)
 
     {:noreply, stream_delete(socket, :assets, asset)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -74,7 +69,7 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
     |> assign(:asset, Assets.get_asset!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :asset,
       resource_name: gettext("Asset"),
@@ -82,6 +77,6 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
       push_patch: [to: ~p"/admin/assets?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/asset_live/index.html.heex
+++ b/lib/itsm_web/live/admin/asset_live/index.html.heex
@@ -15,12 +15,24 @@
   >
     <:col :let={{_id, asset}} label={gettext("Name")}>{asset.name}</:col>
     <:col :let={{_id, asset}} label={gettext("Description")}>{asset.description}</:col>
-    <:col :let={{_id, asset}} label={gettext("Affiliate")}>{asset.affiliate}</:col>
-    <:col :let={{_id, asset}} label={gettext("Category")}>{asset.category}</:col>
-    <:col :let={{_id, asset}} label={gettext("Region Type")}>{asset.region_type}</:col>
-    <:col :let={{_id, asset}} label={gettext("Infra Type")}>{asset.infra_type}</:col>
-    <:col :let={{_id, asset}} label={gettext("Environment")}>{asset.env}</:col>
-    <:col :let={{_id, asset}} label={gettext("Location")}>{asset.location}</:col>
+    <:col :let={{_id, asset}} label={gettext("Affiliate")}>
+      <.common_code_label group="계열사" code={asset.affiliate} />
+    </:col>
+    <:col :let={{_id, asset}} label={gettext("Category")}>
+      <.common_code_label group="카테고리" code={asset.category} />
+    </:col>
+    <:col :let={{_id, asset}} label={gettext("Region Type")}>
+      <.common_code_label group="지역_유형" code={asset.region_type} />
+    </:col>
+    <:col :let={{_id, asset}} label={gettext("Infra Type")}>
+      <.common_code_label group="인프라_유형" code={asset.infra_type} />
+    </:col>
+    <:col :let={{_id, asset}} label={gettext("Environment")}>
+      <.common_code_label group="운영_구분" code={asset.env} />
+    </:col>
+    <:col :let={{_id, asset}} label={gettext("Location")}>
+      <.common_code_label group="장소" code={asset.location} />
+    </:col>
     <:col :let={{_id, asset}} label={gettext("Is Dmz Zone")}>{asset.is_dmz_zone}</:col>
     <:col :let={{_id, asset}} label={gettext("Service Crew")}>{asset.service_crew.name}</:col>
     <:col :let={{_id, asset}} label={gettext("System Crew")}>{asset.system_crew.name}</:col>

--- a/lib/itsm_web/live/admin/asset_live/show.ex
+++ b/lib/itsm_web/live/admin/asset_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Assets
-  alias Itsm.Assets.Asset
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Asset, id)
-      Itsm.Utils.subscribes(Asset)
+      Itsm.Utils.subscribe(Assets, id)
+      Itsm.Utils.subscribes(Assets)
     end
 
     {:noreply,
@@ -22,31 +19,28 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
      |> assign(:asset, Assets.get_asset!(id))}
   end
 
-  @impl true
   def handle_event("live_select_change", %{"text" => text, "id" => live_select_id}, socket) do
     %{current_user: user} = socket.assigns
 
     send_update(LiveSelect.Component,
       id: live_select_id,
-      options: Itsm.Crews.live_select_by_name_user_name(text, user)
+      options: Itsm.Crews.search_live_select_crews(text, user)
     )
 
     {:noreply, socket}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Asset"
   defp page_title(:edit), do: "Edit Asset"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{asset: %{id: id}}} = socket
@@ -57,7 +51,7 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/asset_live/show.html.heex
+++ b/lib/itsm_web/live/admin/asset_live/show.html.heex
@@ -11,12 +11,24 @@
 <.list>
   <:item title={gettext("Name")}>{@asset.name}</:item>
   <:item title={gettext("Description")}>{@asset.description}</:item>
-  <:item title={gettext("Affiliate")}>{@asset.affiliate}</:item>
-  <:item title={gettext("Category")}>{@asset.category}</:item>
-  <:item title={gettext("Region Type")}>{@asset.region_type}</:item>
-  <:item title={gettext("Infra Type")}>{@asset.infra_type}</:item>
-  <:item title={gettext("Environment")}>{@asset.env}</:item>
-  <:item title={gettext("Location")}>{@asset.location}</:item>
+  <:item title={gettext("Affiliate")}>
+    <.common_code_label group="계열사" code={@asset.affiliate} />
+  </:item>
+  <:item title={gettext("Category")}>
+    <.common_code_label group="카테고리" code={@asset.category} />
+  </:item>
+  <:item title={gettext("Region Type")}>
+    <.common_code_label group="지역_유형" code={@asset.region_type} />
+  </:item>
+  <:item title={gettext("Infra Type")}>
+    <.common_code_label group="인프라_유형" code={@asset.infra_type} />
+  </:item>
+  <:item title={gettext("Environment")}>
+    <.common_code_label group="운영_구분" code={@asset.env} />
+  </:item>
+  <:item title={gettext("Location")}>
+    <.common_code_label group="장소" code={@asset.location} />
+  </:item>
   <:item title={gettext("Is Dmz Zone")}>{@asset.is_dmz_zone}</:item>
   <:item title={gettext("Inserted At")}>
     <span

--- a/lib/itsm_web/live/admin/category_live/form_component.ex
+++ b/lib/itsm_web/live/admin/category_live/form_component.ex
@@ -2,8 +2,9 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
   use ItsmWeb, :live_component
 
   alias Itsm.Admin.Categories
+  alias Itsm.Admin.CommonCodes
+  alias Itsm.Admin.Crews
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +14,6 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{category: category} = assigns, socket) do
     {:ok,
      socket
@@ -25,7 +25,6 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
      |> assign_new_options()}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -97,22 +96,20 @@ defmodule ItsmWeb.Admin.CategoryLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"category" => category_params}, socket) do
     changeset = Categories.change_category(socket.assigns.category, category_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"category" => category_params}, socket) do
     save_category(socket, socket.assigns.action, category_params)
   end
 
   defp assign_new_options(socket) do
     socket
-    |> assign_new(:assignee_crews_options, fn -> Itsm.Admin.Crews.get_crew_options() end)
-    |> assign_new(:affiliate_options, fn -> Itsm.CommonCodes.get_select_options("계열사") end)
-    |> assign_new(:region_type_options, fn -> Itsm.CommonCodes.get_select_options("지역_유형") end)
+    |> assign_new(:assignee_crews_options, fn -> Crews.get_crew_options() end)
+    |> assign_new(:affiliate_options, fn -> CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:region_type_options, fn -> CommonCodes.get_select_options("지역_유형") end)
   end
 
   defp save_category(socket, :edit, category_params) do

--- a/lib/itsm_web/live/admin/category_live/index.ex
+++ b/lib/itsm_web/live/admin/category_live/index.ex
@@ -4,38 +4,34 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
   alias Itsm.Admin.Categories
   alias Itsm.Service.Category
   alias Itsm.Paging
+  alias Itsm.Admin.CommonCodes
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Category)
+    if connected?(socket), do: Itsm.Utils.subscribes(Categories)
 
     {:ok, socket |> stream(:categories, []) |> assign_new_options()}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = category_params, socket) do
     {:ok, category} = Categories.delete_category(category_params)
 
     {:noreply, stream_delete(socket, :categories, category)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp assign_new_options(socket) do
     socket
-    |> assign_new(:affiliate_options, fn -> Itsm.CommonCodes.get_select_options("계열사") end)
-    |> assign_new(:group_options, fn -> Itsm.CommonCodes.get_select_options("지역_유형") end)
+    |> assign_new(:affiliate_options, fn -> CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:group_options, fn -> CommonCodes.get_select_options("지역_유형") end)
   end
 
   defp apply_action(socket, :index, params, url) do
@@ -68,7 +64,7 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
     |> assign(:category, Categories.get_category!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :category,
       resource_name: gettext("Category"),
@@ -76,6 +72,6 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
       push_patch: [to: ~p"/admin/categories?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/category_live/index.html.heex
+++ b/lib/itsm_web/live/admin/category_live/index.html.heex
@@ -15,13 +15,15 @@
     <:col :let={{_id, category}} label={gettext("Name")}>{category.name}</:col>
     <:col :let={{_id, category}} label={gettext("Description")}>{category.description}</:col>
     <:col :let={{_id, category}} label={gettext("Affiliate")}>
-      {ItsmWeb.LiveUtils.find_label(@affiliate_options, category.affiliate)}
+      <.common_code_label group="계열사" code={category.affiliate} />
     </:col>
     <:col :let={{_id, category}} label={gettext("Request name")}>{category.request_name}</:col>
     <:col :let={{_id, category}} label={gettext("Group")}>
-      {ItsmWeb.LiveUtils.find_label(@group_options, category.group)}
+      <.common_code_label group="그룹" code={category.group} />
     </:col>
-    <:col :let={{_id, category}} label={gettext("Category")}>{category.category}</:col>
+    <:col :let={{_id, category}} label={gettext("Category")}>
+      <.common_code_label group="카테고리" code={category.category} />
+    </:col>
     <:col :let={{_id, category}} label={gettext("Duration")}>{category.duration}</:col>
     <:col :let={{_id, category}} label={gettext("Active")}>{category.active}</:col>
     <:action :let={{_id, category}}>

--- a/lib/itsm_web/live/admin/category_live/show.ex
+++ b/lib/itsm_web/live/admin/category_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Categories
-  alias Itsm.Service.Category
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Category, id)
-      Itsm.Utils.subscribes(Category)
+      Itsm.Utils.subscribe(Categories, id)
+      Itsm.Utils.subscribes(Categories)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
      |> assign(:category, Categories.get_category!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Category"
   defp page_title(:edit), do: "Edit Category"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{category: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/category_live/show.html.heex
+++ b/lib/itsm_web/live/admin/category_live/show.html.heex
@@ -11,10 +11,16 @@
 <.list>
   <:item title={gettext("Name")}>{@category.name}</:item>
   <:item title={gettext("Description")}>{@category.description}</:item>
-  <:item title={gettext("Affiliate")}>{@category.affiliate}</:item>
+  <:item title={gettext("Affiliate")}>
+    <.common_code_label group="계열사" code={@category.affiliate} />
+  </:item>
   <:item title={gettext("Request Name")}>{@category.request_name}</:item>
-  <:item title={gettext("Group")}>{@category.group}</:item>
-  <:item title={gettext("Category")}>{@category.category}</:item>
+  <:item title={gettext("Group")}>
+    <.common_code_label group="그룹" code={@category.group} />
+  </:item>
+  <:item title={gettext("Category")}>
+    <.common_code_label group="카테고리" code={@category.category} />
+  </:item>
   <:item title={gettext("Duration")}>{@category.duration}</:item>
   <:item title={gettext("Active")}>{@category.active}</:item>
   <:item title={gettext("Inserted At")}>

--- a/lib/itsm_web/live/admin/comment_live/form_component.ex
+++ b/lib/itsm_web/live/admin/comment_live/form_component.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
 
   alias Itsm.Admin.Comments
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{comment: comment} = assigns, socket) do
     {:ok,
      socket
@@ -24,7 +22,6 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -67,13 +64,11 @@ defmodule ItsmWeb.Admin.CommentLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"comment" => comment_params}, socket) do
     changeset = Comments.change_comment(socket.assigns.comment, comment_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"comment" => comment_params}, socket) do
     save_comment(socket, socket.assigns.action, comment_params)
   end

--- a/lib/itsm_web/live/admin/comment_live/index.ex
+++ b/lib/itsm_web/live/admin/comment_live/index.ex
@@ -5,31 +5,26 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
   alias Itsm.Comments.Comment
   alias Itsm.Paging
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Comment)
+    if connected?(socket), do: Itsm.Utils.subscribes(Comments)
 
     {:ok, stream(socket, :comments, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = comment_params, socket) do
     {:ok, comment} = Comments.delete_comment(comment_params)
 
     {:noreply, stream_delete(socket, :comments, comment)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -61,7 +56,7 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
     |> assign(:comment, Comments.get_comment!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :comment,
       resource_name: gettext("Comment"),
@@ -69,6 +64,6 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
       push_patch: [to: ~p"/admin/comments?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/comment_live/show.ex
+++ b/lib/itsm_web/live/admin/comment_live/show.ex
@@ -2,39 +2,34 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Comments
-  alias Itsm.Comments.Comment
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Comment, id)
-      Itsm.Utils.subscribes(Comment)
+      Itsm.Utils.subscribe(Comments, id)
+      Itsm.Utils.subscribes(Comments)
     end
 
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:comment, Comments.get_comment!(id) |> Comments.preload_user())}
+     |> assign(:comment, Comments.get_comment!(id) |> Comments.with_assoc(:user))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Comment"
   defp page_title(:edit), do: "Edit Comment"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{comment: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/common_code_live/form_component.ex
+++ b/lib/itsm_web/live/admin/common_code_live/form_component.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
 
   alias Itsm.Admin.CommonCodes
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{common_code: common_code} = assigns, socket) do
     {:ok,
      socket
@@ -24,7 +22,6 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -72,13 +69,11 @@ defmodule ItsmWeb.Admin.CommonCodeLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"common_code" => common_code_params}, socket) do
     changeset = CommonCodes.change_common_code(socket.assigns.common_code, common_code_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"common_code" => common_code_params}, socket) do
     save_common_code(socket, socket.assigns.action, common_code_params)
   end

--- a/lib/itsm_web/live/admin/common_code_live/index.ex
+++ b/lib/itsm_web/live/admin/common_code_live/index.ex
@@ -5,31 +5,26 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
   alias Itsm.Common.CommonCode
   alias Itsm.Paging
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(CommonCode)
+    if connected?(socket), do: Itsm.Utils.subscribes(CommonCodes)
 
     {:ok, stream(socket, :common_codes, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = common_code_params, socket) do
     {:ok, common_code} = CommonCodes.delete_common_code(common_code_params)
 
     {:noreply, stream_delete(socket, :common_codes, common_code)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -55,7 +50,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
     |> assign(:common_code, CommonCodes.get_common_code!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :common_code,
       resource_name: gettext("Common Code"),
@@ -63,6 +58,6 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
       push_patch: [to: ~p"/admin/common_codes?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/common_code_live/show.ex
+++ b/lib/itsm_web/live/admin/common_code_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.CommonCodes
-  alias Itsm.Common.CommonCode
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(CommonCode, id)
-      Itsm.Utils.subscribes(CommonCode)
+      Itsm.Utils.subscribe(CommonCodes, id)
+      Itsm.Utils.subscribes(CommonCodes)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
      |> assign(:common_code, CommonCodes.get_common_code!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Common Code"
   defp page_title(:edit), do: "Edit Common Code"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{common_code: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/crew_live/form_component.ex
+++ b/lib/itsm_web/live/admin/crew_live/form_component.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
 
   alias Itsm.Admin.Crews
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{crew: crew} = assigns, socket) do
     {:ok,
      socket
@@ -24,7 +22,6 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -68,13 +65,11 @@ defmodule ItsmWeb.Admin.CrewLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"crew" => crew_params}, socket) do
     changeset = Crews.change_crew(socket.assigns.crew, crew_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"crew" => crew_params}, socket) do
     save_crew(socket, socket.assigns.action, crew_params)
   end

--- a/lib/itsm_web/live/admin/crew_live/index.ex
+++ b/lib/itsm_web/live/admin/crew_live/index.ex
@@ -5,31 +5,26 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
   alias Itsm.Crews.Crew
   alias Itsm.Paging
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Crew)
+    if connected?(socket), do: Itsm.Utils.subscribes(Crews)
 
     {:ok, stream(socket, :crews, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = crew_params, socket) do
     {:ok, crew} = Crews.delete_crew(crew_params)
 
     {:noreply, stream_delete(socket, :crews, crew)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -59,7 +54,7 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
     |> assign(:crew, Crews.get_crew!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :crew,
       resource_name: gettext("Crew"),
@@ -67,6 +62,6 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
       push_patch: [to: ~p"/admin/crews?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/crew_live/show.ex
+++ b/lib/itsm_web/live/admin/crew_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Crews
-  alias Itsm.Crews.Crew
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Crew, id)
-      Itsm.Utils.subscribes(Crew)
+      Itsm.Utils.subscribe(Crews, id)
+      Itsm.Utils.subscribes(Crews)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
      |> assign(:crew, Crews.get_crew!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Crew"
   defp page_title(:edit), do: "Edit Crew"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{crew: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/request_live/form_component.ex
+++ b/lib/itsm_web/live/admin/request_live/form_component.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
 
   alias Itsm.Admin.Requests
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{request: request} = assigns, socket) do
     {:ok,
      socket
@@ -25,7 +23,6 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
      |> assign_new_options()}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -83,13 +80,11 @@ defmodule ItsmWeb.Admin.RequestLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"request" => request_params}, socket) do
     changeset = Requests.change_request(socket.assigns.request, request_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"request" => request_params}, socket) do
     save_request(socket, socket.assigns.action, request_params)
   end

--- a/lib/itsm_web/live/admin/request_live/index.ex
+++ b/lib/itsm_web/live/admin/request_live/index.ex
@@ -5,31 +5,26 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
   alias Itsm.Paging
   alias Itsm.Service.Request
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Request)
+    if connected?(socket), do: Itsm.Utils.subscribes(Requests)
 
     {:ok, stream(socket, :requests, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = request_params, socket) do
     {:ok, request} = Requests.delete_request(request_params)
 
     {:noreply, stream_delete(socket, :requests, request)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -66,7 +61,7 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
     |> assign(:request, Requests.get_request!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :request,
       resource_name: gettext("Request"),
@@ -74,6 +69,6 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
       push_patch: [to: ~p"/admin/requests?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/admin/request_live/index.html.heex
+++ b/lib/itsm_web/live/admin/request_live/index.html.heex
@@ -11,7 +11,9 @@
     <:col :let={{_id, request}} label={gettext("Description")}>
       <div class="w-[90px] truncate">{request.description}</div>
     </:col>
-    <:col :let={{_id, request}} label={gettext("Environment")}>{request.env}</:col>
+    <:col :let={{_id, request}} label={gettext("Environment")}>
+      <.common_code_label group="운영_구분" code={request.env} />
+    </:col>
     <:col :let={{id, request}} label={gettext("Due Date")}>
       <div id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date} />
     </:col>

--- a/lib/itsm_web/live/admin/request_live/show.ex
+++ b/lib/itsm_web/live/admin/request_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.Admin.RequestLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Requests
-  alias Itsm.Service.Request
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Request, id)
-      Itsm.Utils.subscribes(Request)
+      Itsm.Utils.subscribe(Requests, id)
+      Itsm.Utils.subscribes(Requests)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.Admin.RequestLive.Show do
      |> assign(:request, Requests.get_request!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Request"
   defp page_title(:edit), do: "Edit Request"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{request: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.Admin.RequestLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/admin/request_live/show.html.heex
+++ b/lib/itsm_web/live/admin/request_live/show.html.heex
@@ -13,7 +13,9 @@
   <:item title={gettext("Description")}>
     <div class="w-[90px] truncate">{@request.description}</div>
   </:item>
-  <:item title={gettext("Environment")}>{@request.env}</:item>
+  <:item title={gettext("Environment")}>
+    <.common_code_label group="운영_구분" code={@request.env} />
+  </:item>
   <:item title={gettext("Due Date")}>
     <span
       id={"due-date-#{@request.id}"}

--- a/lib/itsm_web/live/approval_live/index.ex
+++ b/lib/itsm_web/live/approval_live/index.ex
@@ -6,27 +6,22 @@ defmodule ItsmWeb.ApprovalLive.Index do
   alias Phoenix.LiveView.JS
   alias Itsm.Requests
   alias Itsm.Approvals
-  alias Itsm.Service.Approval
   alias Itsm.Workflow
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Approval)
+    if connected?(socket), do: Itsm.Utils.subscribes(Approvals)
 
     {:ok, stream(socket, :requests, [])}
   end
 
-  @impl true
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :approve, %{"request_id" => id}) do
@@ -57,7 +52,7 @@ defmodule ItsmWeb.ApprovalLive.Index do
     )
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :request,
       resource_name: gettext("Approval"),
@@ -67,6 +62,6 @@ defmodule ItsmWeb.ApprovalLive.Index do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/approval_live/index.html.heex
+++ b/lib/itsm_web/live/approval_live/index.html.heex
@@ -44,7 +44,9 @@
     <div class="w-[90px] truncate">{request.title}</div>
   </:col>
 
-  <:col :let={{_id, request}} label={gettext("Environment")}>{request.env}</:col>
+  <:col :let={{_id, request}} label={gettext("Environment")}>
+    <.common_code_label group="운영_구분" code={request.env} />
+  </:col>
 
   <:col :let={{id, request}} label={gettext("Due Date")}>
     <span id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date}></span>

--- a/lib/itsm_web/live/asset_live/form_component.ex
+++ b/lib/itsm_web/live/asset_live/form_component.ex
@@ -2,8 +2,8 @@ defmodule ItsmWeb.AssetLive.FormComponent do
   use ItsmWeb, :live_component
 
   alias Itsm.Assets
+  alias Itsm.CommonCodes
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +13,6 @@ defmodule ItsmWeb.AssetLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{asset: asset} = assigns, socket) do
     {:ok,
      socket
@@ -25,7 +24,6 @@ defmodule ItsmWeb.AssetLive.FormComponent do
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -105,7 +103,6 @@ defmodule ItsmWeb.AssetLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"asset" => asset_params}, socket) do
     changeset = Assets.change_asset(socket.assigns.asset, asset_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
@@ -117,12 +114,12 @@ defmodule ItsmWeb.AssetLive.FormComponent do
 
   defp assign_new_options(socket) do
     socket
-    |> assign_new(:affiliate_options, fn -> Itsm.CommonCodes.get_select_options("계열사") end)
-    |> assign_new(:category_options, fn -> Itsm.CommonCodes.get_select_options("카테고리") end)
-    |> assign_new(:region_type_options, fn -> Itsm.CommonCodes.get_select_options("지역_유형") end)
-    |> assign_new(:infra_type_options, fn -> Itsm.CommonCodes.get_select_options("인프라_유형") end)
-    |> assign_new(:env_options, fn -> Itsm.CommonCodes.get_select_options("운영_구분") end)
-    |> assign_new(:location_options, fn -> Itsm.CommonCodes.get_select_options("장소") end)
+    |> assign_new(:affiliate_options, fn -> CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:category_options, fn -> CommonCodes.get_select_options("카테고리") end)
+    |> assign_new(:region_type_options, fn -> CommonCodes.get_select_options("지역_유형") end)
+    |> assign_new(:infra_type_options, fn -> CommonCodes.get_select_options("인프라_유형") end)
+    |> assign_new(:env_options, fn -> CommonCodes.get_select_options("운영_구분") end)
+    |> assign_new(:location_options, fn -> CommonCodes.get_select_options("장소") end)
   end
 
   defp save_asset(socket, :new, asset_params) do

--- a/lib/itsm_web/live/asset_live/index.ex
+++ b/lib/itsm_web/live/asset_live/index.ex
@@ -4,36 +4,30 @@ defmodule ItsmWeb.AssetLive.Index do
   alias Itsm.Assets
   alias Itsm.Assets.Asset
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Asset)
+    if connected?(socket), do: Itsm.Utils.subscribes(Assets)
 
     {:ok, stream(socket, :assets, [])}
   end
 
-  @impl true
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = asset_params, socket) do
     {:ok, asset} = Assets.delete_asset(asset_params)
 
     {:noreply, stream_delete(socket, :assets, asset)}
   end
 
-  @impl true
   def handle_info({ItsmWeb.AssetLive.FormComponent, {:saved, asset}}, socket) do
     {:noreply, stream_insert(socket, :assets, asset)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :edit, %{"id" => id}) do
@@ -54,7 +48,7 @@ defmodule ItsmWeb.AssetLive.Index do
     |> stream(:assets, Assets.list_assets())
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :asset,
       resource_name: gettext("Asset"),
@@ -62,6 +56,6 @@ defmodule ItsmWeb.AssetLive.Index do
       push_patch: [to: ~p"/assets"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/asset_live/index.html.heex
+++ b/lib/itsm_web/live/asset_live/index.html.heex
@@ -14,12 +14,24 @@
 >
   <:col :let={{_id, asset}} label={gettext("Name")}>{asset.name}</:col>
   <:col :let={{_id, asset}} label={gettext("Description")}>{asset.description}</:col>
-  <:col :let={{_id, asset}} label={gettext("Affiliate")}>{asset.affiliate}</:col>
-  <:col :let={{_id, asset}} label={gettext("Category")}>{asset.category}</:col>
-  <:col :let={{_id, asset}} label={gettext("Region type")}>{asset.region_type}</:col>
-  <:col :let={{_id, asset}} label={gettext("Infra type")}>{asset.infra_type}</:col>
-  <:col :let={{_id, asset}} label={gettext("Environment")}>{asset.env}</:col>
-  <:col :let={{_id, asset}} label={gettext("Location")}>{asset.location}</:col>
+  <:col :let={{_id, asset}} label={gettext("Affiliate")}>
+    <.common_code_label group="계열사" code={asset.affiliate} />
+  </:col>
+  <:col :let={{_id, asset}} label={gettext("Category")}>
+    <.common_code_label group="카테고리" code={asset.category} />
+  </:col>
+  <:col :let={{_id, asset}} label={gettext("Region type")}>
+    <.common_code_label group="지역_유형" code={asset.region_type} />
+  </:col>
+  <:col :let={{_id, asset}} label={gettext("Infra type")}>
+    <.common_code_label group="인프라_유형" code={asset.infra_type} />
+  </:col>
+  <:col :let={{_id, asset}} label={gettext("Environment")}>
+    <.common_code_label group="운영_구분" code={asset.env} />
+  </:col>
+  <:col :let={{_id, asset}} label={gettext("Location")}>
+    <.common_code_label group="장소" code={asset.location} />
+  </:col>
   <:col :let={{_id, asset}} label={gettext("Is dmz zone")}>{asset.is_dmz_zone}</:col>
   <:action :let={{_id, asset}}>
     <div class="sr-only">

--- a/lib/itsm_web/live/asset_live/show.ex
+++ b/lib/itsm_web/live/asset_live/show.ex
@@ -3,19 +3,17 @@ defmodule ItsmWeb.AssetLive.Show do
 
   import ItsmWeb.ResourceComponents
   alias Itsm.Assets
-  alias Itsm.Assets.Asset
   alias Itsm.Assets.ResourceCardData
+  alias Itsm.CommonCodes
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if connected?(socket) do
-      Itsm.Utils.subscribe(Asset, id)
-      Itsm.Utils.subscribes(Asset)
+      Itsm.Utils.subscribe(Assets, id)
+      Itsm.Utils.subscribes(Assets)
     end
 
     {:noreply,
@@ -25,16 +23,14 @@ defmodule ItsmWeb.AssetLive.Show do
      |> assign_new_options()}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp assign_new_options(socket) do
-    socket |> assign_new(:affiliate_optios, Itsm.CommonCodes.get_select_options("계열사"))
+    socket |> assign_new(:affiliate_options, fn -> CommonCodes.get_select_options("계열사") end)
   end
 
   # 리소스 섹션 정의 — 새 인스턴스 타입 추가 시 여기에 항목만 추가
@@ -78,7 +74,7 @@ defmodule ItsmWeb.AssetLive.Show do
   defp page_title(:edit), do: "Edit Asset"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{asset: %{id: id}}} = socket
@@ -87,9 +83,11 @@ defmodule ItsmWeb.AssetLive.Show do
       [context_key: :asset, resource_name: gettext("Asset")]
       |> Keyword.merge(push_event_action(event))
 
+    item = Itsm.Assets.with_assoc(item, service_crew: [:users], system_crew: [:users])
+
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/asset_live/show.html.heex
+++ b/lib/itsm_web/live/asset_live/show.html.heex
@@ -25,13 +25,13 @@
 
           <div class="mt-3 flex flex-wrap gap-2">
             <span class="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700">
-              {@asset.category}
+              <.common_code_label group="카테고리" code={@asset.category} />
             </span>
             <span class="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-medium text-zinc-700">
-              {@asset.env}
+              <.common_code_label group="운영_구분" code={@asset.env} />
             </span>
             <span class="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-medium text-zinc-700">
-              {Map.filter(@affiliate_optios, fn option -> @asset.affiliate.code == option end).label}
+              <.common_code_label group="계열사" code={@asset.affiliate} />
             </span>
             <%= if @asset.is_dmz_zone do %>
               <span class="inline-flex items-center gap-1 rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs font-medium text-red-700">
@@ -50,7 +50,9 @@
           <div>
             <p class="text-xs text-zinc-500 mb-0.5">Location</p>
 
-            <p class="text-sm font-medium text-zinc-900">{@asset.location}</p>
+            <p class="text-sm font-medium text-zinc-900">
+              <.common_code_label group="장소" code={@asset.location} />
+            </p>
           </div>
         </div>
 
@@ -59,7 +61,9 @@
           <div>
             <p class="text-xs text-zinc-500 mb-0.5">Region</p>
 
-            <p class="text-sm font-medium text-zinc-900">{@asset.region_type}</p>
+            <p class="text-sm font-medium text-zinc-900">
+              <.common_code_label group="지역_유형" code={@asset.region_type} />
+            </p>
           </div>
         </div>
 
@@ -68,7 +72,9 @@
           <div>
             <p class="text-xs text-zinc-500 mb-0.5">Infrastructure</p>
 
-            <p class="text-sm font-medium text-zinc-900">{@asset.infra_type}</p>
+            <p class="text-sm font-medium text-zinc-900">
+              <.common_code_label group="인프라_유형" code={@asset.infra_type} />
+            </p>
           </div>
         </div>
 

--- a/lib/itsm_web/live/category_live/index.ex
+++ b/lib/itsm_web/live/category_live/index.ex
@@ -4,30 +4,24 @@ defmodule ItsmWeb.CategoryLive.Index do
   import ItsmWeb.CategoryLive.Components
 
   alias Itsm.Categories
-  alias Itsm.Service.Category
+  alias Itsm.CommonCodes
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Category)
+    if connected?(socket), do: Itsm.Utils.subscribes(Categories)
 
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(params, _uri, socket) do
     {:noreply,
      socket
      |> stream(:categories, Categories.filter_categories(params), reset: true)
      |> assign(:current_params, params)
      |> assign(:filtered_category_groups, Categories.get_category_groups(params))
-     |> assign(
-       :group_select_options,
-       [{"그룹", ""}] ++ Itsm.CommonCodes.get_select_options("지역_유형")
-     )
+     |> assign(:group_select_options, [{"그룹", ""}] ++ CommonCodes.get_select_options("지역_유형"))
      |> assign(:form, to_form(params))}
   end
 
-  @impl true
   def handle_event("filter", params, socket) do
     params =
       params
@@ -39,15 +33,13 @@ defmodule ItsmWeb.CategoryLive.Index do
     {:noreply, socket}
   end
 
-  @impl true
-  def handle_info({:pusbusb, user, event, item}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pusbusb, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :category,
       resource_name: gettext("Category"),
@@ -55,6 +47,6 @@ defmodule ItsmWeb.CategoryLive.Index do
       push_patch: [to: ~p"/categories?#{socket.assigns[:current_params] || %{}}"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/common_k_create_vm_live/components.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/components.ex
@@ -31,7 +31,9 @@ defmodule ItsmWeb.CommonKCreateVmLive.Components do
 
       <:item title={gettext("Description")}>{@request.description}</:item>
 
-      <:item title={gettext("Environment")}>{@request.env}</:item>
+      <:item title={gettext("Environment")}>
+        <.common_code_label group="운영_구분" code={@request.env} />
+      </:item>
 
       <:item title={gettext("Status")}>{Workflow.status_label(:service_request, @request)}</:item>
 

--- a/lib/itsm_web/live/common_k_create_vm_live/form.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/form.ex
@@ -8,6 +8,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   alias Itsm.Service.Request
   alias Itsm.Crews
   alias ItsmWeb.LiveUtils
+  alias Itsm.CommonCodes
 
   def mount(_params, _session, socket) do
     {:ok,
@@ -20,8 +21,8 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
 
   def handle_params(%{"id" => id} = params, _uri, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Request, id)
-      Itsm.Utils.subscribes(Request)
+      Itsm.Utils.subscribe(Requests, id)
+      Itsm.Utils.subscribes(Requests)
     end
 
     {:noreply, socket |> apply_action(socket.assigns.live_action, params)}
@@ -79,18 +80,19 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
 
     send_update(LiveSelect.Component,
       id: live_select_id,
-      options: Crews.live_select_by_name_user_name(text, user)
+      options: Crews.search_live_select_crews(text, user)
     )
 
     {:noreply, socket}
   end
 
-  def handle_event("save", %{"request" => request_params}, socket) do
-    save_request(socket, socket.assigns.live_action, request_params)
+  def handle_event("save", %{"request" => params}, socket) do
+    params = LiveUtils.live_select_params(params, ["referenced_crews"], :tags)
+    save_request(socket, socket.assigns.live_action, params)
   end
 
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
@@ -98,13 +100,13 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   defp assign_new_options(socket) do
     socket
     |> assign_new(:crew_options, fn -> Accounts.crew_ids_names(socket.assigns.current_user) end)
-    |> assign_new(:env_options, fn -> Itsm.CommonCodes.get_select_options("운영_구분") end)
-    |> assign_new(:group_code_options, fn -> Itsm.CommonCodes.get_select_options("운영체제") end)
-    |> assign_new(:location_options, fn -> Itsm.CommonCodes.get_select_options("장소") end)
+    |> assign_new(:env_options, fn -> CommonCodes.get_select_options("운영_구분") end)
+    |> assign_new(:group_code_options, fn -> CommonCodes.get_select_options("운영체제") end)
+    |> assign_new(:location_options, fn -> CommonCodes.get_select_options("장소") end)
     |> assign_new(:os_version_options, fn ->
       %{
-        "리눅스" => Itsm.CommonCodes.get_select_options("리눅스"),
-        "윈도우" => Itsm.CommonCodes.get_select_options("윈도우")
+        "리눅스" => CommonCodes.get_select_options("리눅스"),
+        "윈도우" => CommonCodes.get_select_options("윈도우")
       }
     end)
   end
@@ -124,12 +126,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
     request = Requests.get_request!(id)
 
     # 기존 referenced crews를 옵션 맵으로 로드 (label 유지를 위해)
-    referenced_crews_options =
-      Crews.list_crew_reference("Request", id)
-      |> Enum.map(fn ref ->
-        crew = Crews.get_crew!(ref.crew_id)
-        %{label: crew.name, tag_label: crew.name, value: crew.id}
-      end)
+    referenced_crews_options = Crews.list_live_select_crews(request)
 
     socket
     |> assign(:page_title, "Edit Request")
@@ -141,12 +138,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   defp apply_action(socket, :copy, %{"id" => id}) do
     request = Requests.get_request!(id)
 
-    referenced_crews_options =
-      Crews.list_crew_reference("Request", id)
-      |> Enum.map(fn ref ->
-        crew = Crews.get_crew!(ref.crew_id)
-        %{label: crew.name, tag_label: crew.name, value: crew.id}
-      end)
+    referenced_crews_options = Crews.list_live_select_crews(request)
 
     socket
     |> assign(:page_title, "New Request")
@@ -155,15 +147,13 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
     |> assign(:form, to_form(Requests.change_request(request)))
   end
 
-  defp save_request(socket, :edit, request_params) do
+  defp save_request(socket, :edit, params) do
     %{current_user: user, request: request} = socket.assigns
 
-    crews_id = Map.get(request_params, "referenced_crews", [])
-
-    case Requests.update_request(user, request, request_params) do
+    case Requests.update_request(user, request, params) do
       {:ok, updated_request} ->
         # reference 동기화 (기존 삭제 → 새로 생성)
-        Crews.sync_crew_references("Request", updated_request.id, crews_id)
+        Crews.sync_crew_references("Request", updated_request.id, params["referenced_crews"])
 
         {:noreply,
          socket
@@ -175,22 +165,19 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
     end
   end
 
-  defp save_request(socket, :new, request_params) do
+  defp save_request(socket, :new, params) do
     %{current_user: user, category: category} = socket.assigns
 
-    # LiveSelect tags 값 추출
-    crews_id = Map.get(request_params, "referenced_crews", [])
+    crews = Crews.get_crews(params["referenced_crews"])
 
     case Service.create_request(
            user,
            category,
+           crews,
            fn -> LiveUtils.consume_attachments(socket) end,
-           request_params
+           params
          ) do
       {:ok, request} ->
-        # reference 생성
-        Crews.sync_crew_references("Request", request.id, crews_id)
-
         {:noreply,
          socket
          |> put_flash(:info, "Request created successfully")
@@ -202,8 +189,9 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
       {:error, step, _changeset, _so_far_changeset} ->
         changeset =
           socket.assigns.form.source
+          |> Map.update!(:errors, &Enum.reject(&1, fn {k, _} -> k == :base end))
           |> Ecto.Changeset.add_error(:base, LiveUtils.translate_step_error(step))
-          |> Map.put(:action, :insert)
+          |> Map.put(:action, :validate)
 
         {:noreply,
          socket
@@ -215,12 +203,12 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   defp format_file_size(bytes) when bytes < 1024 * 1024, do: "#{round(bytes / 1024)} KB"
   defp format_file_size(bytes), do: "#{round(bytes / (1024 * 1024))} MB"
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [context_key: :request]
-    {:noreply, socket |> check_conflict(user, event, item, opts)}
+    {:noreply, socket |> check_conflict(action_user, event, item, opts)}
   end
 
-  defp check_conflict(socket, user, event, item, opts) do
+  defp check_conflict(socket, action_user, event, item, opts) do
     resource = socket.assigns[opts[:context_key]]
     current_id = if resource, do: to_string(resource.id), else: nil
 
@@ -229,7 +217,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
 
       socket
       |> assign(:conflict, true)
-      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")
+      |> assign(:conflict_msg, "#{action_user.display_name}님이 데이터를 #{msg}했습니다.")
     else
       socket
     end

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -7,7 +7,6 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
   alias Itsm.Comments
   alias Itsm.Comments.Comment
   alias Itsm.Requests
-  alias Itsm.Service.Request
   alias ItsmWeb.LiveUtils
   alias Itsm.Service
 
@@ -20,8 +19,8 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
 
   def handle_params(%{"id" => id}, _uri, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(Request, id)
-      Itsm.Utils.subscribes(Request)
+      Itsm.Utils.subscribe(Requests, id)
+      Itsm.Utils.subscribes(Requests)
     end
 
     {:noreply,
@@ -29,7 +28,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
      |> assign(:page_title, "Show Request")
      |> assign(:request, Requests.get_request!(id))
      |> assign(:selected_attachment, nil)
-     |> stream(:comments, Comments.list_comments(Requests.get_request!(id)))}
+     |> stream(:comments, Comments.list_comments(Requests.get_request!(id)), reset: true)}
   end
 
   def handle_event("view_attachment", %{"id" => id, "filename" => filename}, socket) do
@@ -56,6 +55,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
          ) do
       {:ok, comment} ->
         changeset = Comments.change_comment(%Comment{})
+        comment = Comments.with_assoc(comment, :attachments)
 
         {:noreply,
          socket
@@ -71,14 +71,14 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     {:noreply, cancel_upload(socket, :attachment, ref)}
   end
 
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{request: %{id: id}}} = socket
@@ -89,7 +89,30 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
+
+  defp handle_pubsub(
+         action_user,
+         event,
+         %Comment{} = item,
+         socket
+       ) do
+    opts =
+      [
+        context_key: [:streams, :comments],
+        stream_name: :comments,
+        resource_name: gettext("Comment")
+      ]
+      |> Keyword.merge(push_event_action(event))
+
+    item = Comments.with_assoc(item, [:user, :attachments])
+
+    {:noreply,
+     socket
+     |> assign(:live_action, :index)
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)
+     |> handle_pubsub_comment(Atom.to_string(event), item)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do
@@ -100,4 +123,9 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     do: [push_navigate: [to: ~p"/requests"]]
 
   defp push_event_action(_), do: []
+
+  defp handle_pubsub_comment(socket, "update" <> _action, item),
+    do: stream_insert(socket, :comments, item)
+
+  defp handle_pubsub_comment(socket, _other_event, _item), do: socket
 end

--- a/lib/itsm_web/live/crew_live/all_index.ex
+++ b/lib/itsm_web/live/crew_live/all_index.ex
@@ -2,15 +2,14 @@ defmodule ItsmWeb.CrewLive.AllIndex do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
+  alias Itsm.Utils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
   import ItsmWeb.CrewLive.Components
 
   def mount(_params, _session, socket) do
-    if(connected?(socket)) do
-      Crews.subscribe_crews()
-    end
+    if connected?(socket), do: Utils.subscribes(Crews)
 
     {:ok, socket |> assign(:org_options, Itsm.CommonCodes.get_select_options("계열사"))}
   end
@@ -44,13 +43,20 @@ defmodule ItsmWeb.CrewLive.AllIndex do
     {:noreply, socket}
   end
 
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
 
-  defp handle_pubsub(_user, _event, _item, socket) do
+  defp handle_pubsub(_action_user, event, {:crews, _crew}, socket)
+       when event in [:create_crew, :update_crew, :delete_crew] do
+    %{filter_params: params} = socket.assigns
+
+    {:noreply, push_patch(socket, to: ~p"/crews/all?#{params}")}
+  end
+
+  defp handle_pubsub(_action_user, _event, _item, socket) do
     {:noreply, socket}
   end
 end

--- a/lib/itsm_web/live/crew_live/index.ex
+++ b/lib/itsm_web/live/crew_live/index.ex
@@ -5,6 +5,7 @@ defmodule ItsmWeb.CrewLive.Index do
   alias Itsm.Crews.Crew
   alias Itsm.Accounts.User
   alias ItsmWeb.LiveUtils
+  alias Itsm.Utils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
@@ -12,9 +13,7 @@ defmodule ItsmWeb.CrewLive.Index do
   def mount(_params, _session, socket) do
     %{current_user: user} = socket.assigns
 
-    if connected?(socket) do
-      Crews.subscribe_crews()
-    end
+    if connected?(socket), do: Utils.subscribes(Crews)
 
     {:ok, stream(socket, :crews, Crews.list_my_crews(user))}
   end
@@ -65,31 +64,67 @@ defmodule ItsmWeb.CrewLive.Index do
     {:noreply, stream_insert(socket, :crews, crew)}
   end
 
-  def handle_info({:crews, {event, %Crew{} = crew}}, socket)
-      when event in [:create_crew, :update_crew, :add_users, :leader_changed] do
-    %{current_user: user} = socket.assigns
-    crew = Crews.with_assoc(crew, [:leader, :users])
-
-    if(Enum.member?(crew.users, user) || user == crew.leader) do
-      {:noreply, stream_insert(socket, :crews, crew)}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info({:crews, {:delete_crew, %Crew{} = crew}}, socket) do
-    {:noreply, stream_delete(socket, :crews, crew)}
-  end
-
-  def handle_info({:crews, {:delete_user, %Crew{} = crew, %User{} = deleted_user}}, socket) do
-    %{current_user: user} = socket.assigns
-
-    if(user == deleted_user) do
-      {:noreply, stream_delete(socket, :crews, crew)}
-    else
-      {:noreply, socket}
-    end
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp handle_pubsub(action_user, event, {:crews, %Crew{} = crew}, socket)
+       when event in [:update_crew, :add_users, :switch_leader] do
+    %{current_user: user} = socket.assigns
+    crew = Crews.with_assoc(crew, [:leader, :users])
+
+    if(Enum.any?(crew.users, &(&1.id == user.id)) || user == crew.leader) do
+      {:noreply,
+       stream_insert(socket, :crews, crew)
+       |> put_flash(
+         :info,
+         gettext("%{crew_name} added/updated by %{action_user}.",
+           crew_name: crew.name,
+           action_user: action_user.display_name
+         )
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp handle_pubsub(action_user, :delete_crew, {:crews, %Crew{} = crew}, socket) do
+    {:noreply,
+     stream_delete(socket, :crews, crew)
+     |> put_flash(
+       :info,
+       gettext("%{crew_name} deleted by %{action_user}.",
+         crew_name: crew.name,
+         action_user: action_user.display_name
+       )
+     )}
+  end
+
+  defp handle_pubsub(
+         action_user,
+         :delete_user,
+         {:crews, %Crew{} = crew, %User{} = deleted_user},
+         socket
+       ) do
+    %{current_user: user} = socket.assigns
+
+    if(user == deleted_user) do
+      {:noreply,
+       stream_delete(socket, :crews, crew)
+       |> put_flash(
+         :info,
+         gettext("You have been removed from the crew by %{action_user}.",
+           action_user: action_user.display_name
+         )
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp handle_pubsub(_action_user, _event, _item, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/itsm_web/live/crew_live/show.ex
+++ b/lib/itsm_web/live/crew_live/show.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.CrewLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
+  alias Itsm.Utils
   alias ItsmWeb.LiveUtils
 
   def mount(params, _session, socket) do
@@ -13,8 +14,8 @@ defmodule ItsmWeb.CrewLive.Show do
 
   def handle_params(%{"id" => id}, _params, socket) do
     if connected?(socket) do
-      Crews.subscribe_crew(id)
-      Crews.subscribe_crews()
+      Utils.subscribe(Crews, id)
+      Utils.subscribes(Crews)
     end
 
     crew =
@@ -43,13 +44,19 @@ defmodule ItsmWeb.CrewLive.Show do
     target_user = Accounts.get_user!(user_id)
 
     case Crews.delete_user(crew, target_user, current_user) do
-      {:ok, _crew} ->
+      {:ok, _target_user} ->
         msg =
           if current_user == target_user,
             do: "You have left the crew",
             else: "Member removed successfully"
 
-        {:noreply, put_flash(socket, :info, msg)}
+        socket =
+          socket
+          |> assign(:show_member_modal, false)
+          |> stream_delete(:users, target_user)
+          |> put_flash(:info, msg)
+
+        {:noreply, socket}
 
       {:error, step} ->
         {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
@@ -71,8 +78,41 @@ defmodule ItsmWeb.CrewLive.Show do
     {:noreply, socket}
   end
 
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
+  end
+
+  def handle_info({ItsmWeb.SearchUsersDialog, :users_selected, user_ids}, socket) do
+    %{crew: crew, current_user: action_user} = socket.assigns
+
+    crew =
+      Crews.get_crew!(crew.id)
+      |> Crews.with_assoc([:leader, :users])
+
+    users = Accounts.get_users(user_ids)
+
+    case Crews.add_users(crew, users, action_user) do
+      {:ok, _crew} ->
+        socket =
+          users
+          |> List.delete(crew.leader)
+          |> Enum.reduce(socket, fn user, acc ->
+            stream_insert(acc, :users, user, at: 0)
+          end)
+          |> assign(:show_member_modal, false)
+          |> put_flash(:info, "Members added successfully")
+
+        {:noreply, socket}
+
+      {:error, step} ->
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
+    end
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # 리더 변경시 각 버튼의 권한이 달라지므로 전체 stream 전체 reset 처리
-  def handle_info({:crew, {:leader_changed, %{id: crew_id}}}, socket) do
+  defp handle_pubsub(action_user, :switch_leader, {:crew, %{id: crew_id}}, socket) do
     crew =
       Crews.get_crew!(crew_id)
       |> Crews.with_assoc([:leader, :users])
@@ -82,11 +122,17 @@ defmodule ItsmWeb.CrewLive.Show do
       |> assign(:show_member_modal, false)
       |> assign(:crew, crew)
       |> stream(:users, Crews.list_regular_users(crew), reset: true)
+      |> put_flash(
+        :info,
+        gettext("Leader changed by %{action_user}",
+          action_user: action_user.display_name
+        )
+      )
 
     {:noreply, socket}
   end
 
-  def handle_info({:crew, {:add_users, add_users}}, socket) do
+  defp handle_pubsub(_action_user, :add_users, {:crew, add_users}, socket) do
     %{crew: crew} = socket.assigns
     crew = Crews.with_assoc(crew, :leader)
 
@@ -101,14 +147,14 @@ defmodule ItsmWeb.CrewLive.Show do
     {:noreply, socket}
   end
 
-  def handle_info({:crew, {:delete_user, removed_user}}, socket) do
+  defp handle_pubsub(_action_user, :delete_user, {:crew, removed_user}, socket) do
     {:noreply,
      socket
      |> assign(:show_member_modal, false)
      |> stream_delete(:users, removed_user)}
   end
 
-  def handle_info({:crews, {:update_crew, update_crew}}, socket) do
+  defp handle_pubsub(_action_user, :update_crew, {:crews, update_crew}, socket) do
     %{crew: crew} = socket.assigns
 
     if(crew.id == update_crew.id) do
@@ -119,43 +165,40 @@ defmodule ItsmWeb.CrewLive.Show do
     end
   end
 
-  def handle_info({:crews, {:delete_crew, deleted_crew}}, socket) do
-    %{crew: crew, back_path: back_path} = socket.assigns
+  defp handle_pubsub(action_user, :delete_crew, {:crew, deleted_crew}, socket) do
+    %{back_path: back_path} = socket.assigns
 
-    if(crew.id == deleted_crew.id) do
-      {:noreply,
-       socket
-       |> put_flash("info", "The crew has been deleted")
-       |> push_navigate(to: back_path)}
-    else
-      {:noreply, socket}
-    end
+    {:noreply,
+     socket
+     |> put_flash(
+       "info",
+       gettext("%{crew_name} has been deleted by %{action_user}.",
+         crew_name: deleted_crew.name,
+         action_user: action_user.display_name
+       )
+     )
+     |> push_navigate(to: back_path)}
   end
 
-  def handle_info({ItsmWeb.SearchUsersDialog, :users_selected, user_ids}, socket) do
-    %{crew: crew} = socket.assigns
-
-    crew =
-      Crews.get_crew!(crew.id)
-      |> Crews.with_assoc([:leader, :users])
-
-    users = Accounts.get_users(user_ids)
-
-    case Crews.add_users(crew, users) do
-      {:ok, _crew} ->
-        {:noreply, put_flash(socket, :info, "Members added successfully")}
-
-      {:error, step} ->
-        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
-    end
+  defp handle_pubsub(_user, _event, _item, socket) do
+    {:noreply, socket}
   end
-
-  def handle_info(_message, socket), do: {:noreply, socket}
 
   defp switch_leader(socket, crew, leader, current_user) do
     case Crews.switch_leader(crew, leader, current_user) do
-      {:ok, _crew} ->
-        {:noreply, put_flash(socket, :info, "Leader changed successfully")}
+      {:ok, crew} ->
+        crew =
+          Crews.get_crew!(crew.id)
+          |> Crews.with_assoc([:leader, :users])
+
+        socket =
+          socket
+          |> assign(:show_member_modal, false)
+          |> assign(:crew, crew)
+          |> stream(:users, Crews.list_regular_users(crew), reset: true)
+          |> put_flash(:info, "Leader changed successfully")
+
+        {:noreply, socket}
 
       {:error, step} ->
         {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}

--- a/lib/itsm_web/live/crew_live/table_components.ex
+++ b/lib/itsm_web/live/crew_live/table_components.ex
@@ -9,21 +9,24 @@ defmodule ItsmWeb.CrewLive.TableComponents do
     ~H"""
     <.table id="crews" rows={@crews} row_click={@row_click}>
       <:col :let={{_id, crew}} label={gettext("Name")}>{crew.name}</:col>
-      
+
       <:col :let={{_id, crew}} label={gettext("Description")}>{crew.description}</:col>
-      
+
       <:col :let={{_id, crew}} label={gettext("Organization")}>
-        {Itsm.CommonCodes.get_label("계열사", LiveUtils.fetch_safe(crew.leader, :organization_code))}
+        <.common_code_label
+          group="계열사"
+          code={LiveUtils.fetch_safe(crew.leader, :organization_code)}
+        />
       </:col>
-      
+
       <:col :let={{_id, crew}} label={gettext("Department")}>
         {LiveUtils.fetch_safe(crew.leader, :department)}
       </:col>
-      
+
       <:col :let={{_id, crew}} label={gettext("Leader")}>
         {LiveUtils.fetch_safe(crew.leader, :display_name)}
       </:col>
-      
+
       <%!--
          [수정된 부분]
          render_slot(@action, crew) -> render_slot(@action, {_id, crew})

--- a/lib/itsm_web/live/delegation_live/form_component.ex
+++ b/lib/itsm_web/live/delegation_live/form_component.ex
@@ -3,8 +3,8 @@ defmodule ItsmWeb.DelegationLive.FormComponent do
 
   alias Itsm.Delegations
   alias Itsm.Accounts
+  alias Itsm.CommonCodes
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -14,7 +14,6 @@ defmodule ItsmWeb.DelegationLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{delegation: delegation} = assigns, socket) do
     # 새 delegation이면 start_date를 오늘로 기본 설정
     delegation =
@@ -34,7 +33,6 @@ defmodule ItsmWeb.DelegationLive.FormComponent do
      |> assign_new_options()}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -135,7 +133,6 @@ defmodule ItsmWeb.DelegationLive.FormComponent do
     {:noreply, socket}
   end
 
-  @impl true
   def handle_event("validate", %{"delegation" => delegation_params}, socket) do
     changeset =
       socket.assigns.delegation
@@ -151,7 +148,7 @@ defmodule ItsmWeb.DelegationLive.FormComponent do
 
   defp assign_new_options(socket) do
     socket
-    |> assign_new(:reason_options, fn -> Itsm.CommonCodes.get_select_options("사유") end)
+    |> assign_new(:reason_options, fn -> CommonCodes.get_select_options("사유") end)
   end
 
   defp save_delegation(socket, :new, delegation_params) do

--- a/lib/itsm_web/live/delegation_live/index.ex
+++ b/lib/itsm_web/live/delegation_live/index.ex
@@ -5,19 +5,16 @@ defmodule ItsmWeb.DelegationLive.Index do
   alias Itsm.Delegations.Delegation
   alias Itsm.Accounts.User
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Delegation)
+    if connected?(socket), do: Itsm.Utils.subscribes(Delegations)
 
     {:ok, stream(socket, :delegations, [])}
   end
 
-  @impl true
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = delegation_params, socket) do
     case Delegations.delete_delegation(delegation_params) do
       {:ok, delegation} ->
@@ -38,17 +35,14 @@ defmodule ItsmWeb.DelegationLive.Index do
   end
 
   # Delegation이 저장되었을 때 스트림에 추가
-  @impl true
   def handle_info({ItsmWeb.DelegationLive.FormComponent, {:saved, delegation}}, socket) do
     {:noreply, stream_insert(socket, :delegations, delegation)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket) do
     {:noreply, socket}
   end
@@ -79,7 +73,7 @@ defmodule ItsmWeb.DelegationLive.Index do
   # 3. 그 외에는 모두 false (버튼 숨김)
   defp can_delete?(_user, _delegation), do: false
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :delegation,
       resource_name: gettext("Delegation"),
@@ -87,6 +81,6 @@ defmodule ItsmWeb.DelegationLive.Index do
       push_patch: [to: ~p"/delegations"]
     ]
 
-    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/delegation_live/show.ex
+++ b/lib/itsm_web/live/delegation_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.DelegationLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Delegations
-  alias Itsm.Delegations.Delegation
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if connected?(socket) do
-      Itsm.Utils.subscribe(Delegation, id)
-      Itsm.Utils.subscribes(Delegation)
+      Itsm.Utils.subscribe(Delegations, id)
+      Itsm.Utils.subscribes(Delegations)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.DelegationLive.Show do
      |> assign(:delegation, Delegations.get_delegation!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Delegation"
   defp page_title(:edit), do: "Edit Delegation"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{delegation: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.DelegationLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/evaluation_live/form_component.ex
+++ b/lib/itsm_web/live/evaluation_live/form_component.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.EvaluationLive.FormComponent do
 
   alias Itsm.Evaluations
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule ItsmWeb.EvaluationLive.FormComponent do
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{evaluation: evaluation} = assigns, socket) do
     {:ok,
      socket
@@ -24,7 +22,6 @@ defmodule ItsmWeb.EvaluationLive.FormComponent do
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -74,7 +71,6 @@ defmodule ItsmWeb.EvaluationLive.FormComponent do
     """
   end
 
-  @impl true
   def handle_event("validate", %{"evaluation" => evaluation_params}, socket) do
     changeset = Evaluations.change_evaluation(socket.assigns.evaluation, evaluation_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}

--- a/lib/itsm_web/live/evaluation_live/index.ex
+++ b/lib/itsm_web/live/evaluation_live/index.ex
@@ -4,36 +4,30 @@ defmodule ItsmWeb.EvaluationLive.Index do
   alias Itsm.Evaluations
   alias Itsm.Evaluations.Evaluation
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Evaluation)
+    if connected?(socket), do: Itsm.Utils.subscribes(Evaluations)
 
     {:ok, stream(socket, :evaluations, [])}
   end
 
-  @impl true
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = evaluation_params, socket) do
     {:ok, evaluation} = Evaluations.delete_evaluation(evaluation_params)
 
     {:noreply, stream_delete(socket, :evaluations, evaluation)}
   end
 
-  @impl true
   def handle_info({ItsmWeb.EvaluationLive.FormComponent, {:saved, evaluation}}, socket) do
     {:noreply, stream_insert(socket, :evaluations, evaluation)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket) do
     {:noreply, socket}
   end
@@ -56,7 +50,7 @@ defmodule ItsmWeb.EvaluationLive.Index do
     |> stream(:evaluation, Evaluations.list_evaluations(), reset: true)
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :evaluation,
       resource_name: gettext("Evaluation"),
@@ -66,6 +60,6 @@ defmodule ItsmWeb.EvaluationLive.Index do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/evaluation_live/show.ex
+++ b/lib/itsm_web/live/evaluation_live/show.ex
@@ -2,18 +2,15 @@ defmodule ItsmWeb.EvaluationLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Evaluations
-  alias Itsm.Evaluations.Evaluation
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if connected?(socket) do
-      Itsm.Utils.subscribe(Evaluation, id)
-      Itsm.Utils.subscribes(Evaluation)
+      Itsm.Utils.subscribe(Evaluations, id)
+      Itsm.Utils.subscribes(Evaluations)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule ItsmWeb.EvaluationLive.Show do
      |> assign(:evaluation, Evaluations.get_evaluation!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show Evaluation"
   defp page_title(:edit), do: "Edit Evaluation"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{evaluation: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule ItsmWeb.EvaluationLive.Show do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do

--- a/lib/itsm_web/live/live_helpers.ex
+++ b/lib/itsm_web/live/live_helpers.ex
@@ -1,5 +1,7 @@
 defmodule ItsmWeb.LiveHelpers do
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
+    only_common = Keyword.get(opts, :only_common, false)
+
     quote do
       def handle_event(event, params, socket)
           when event in ["save", "update", "delete"] and
@@ -11,6 +13,17 @@ defmodule ItsmWeb.LiveHelpers do
           |> Map.put("use_help", true)
 
         handle_event(event, new_params, socket)
+      end
+
+      if !unquote(only_common) do
+        on_mount {ItsmWeb.LiveHelpers, :default}
+
+        def handle_info(
+              %Phoenix.Socket.Broadcast{event: "all_codes_reload", payload: all_map},
+              socket
+            ) do
+          {:noreply, push_event(socket, "common_code_all_reloaded", all_map)}
+        end
       end
 
       defp inject_current_user(params, nil), do: params
@@ -25,5 +38,13 @@ defmodule ItsmWeb.LiveHelpers do
         end
       end
     end
+  end
+
+  def on_mount(:default, _params, _session, socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      ItsmWeb.Endpoint.subscribe("common_code:updates")
+    end
+
+    {:cont, socket}
   end
 end

--- a/lib/itsm_web/live/request_live/index.ex
+++ b/lib/itsm_web/live/request_live/index.ex
@@ -4,19 +4,16 @@ defmodule ItsmWeb.RequestLive.Index do
   alias Itsm.Requests
   alias Itsm.Service.Request
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Request)
+    if connected?(socket), do: Itsm.Utils.subscribes(Requests)
 
     {:ok, stream(socket, :requests, [])}
   end
 
-  @impl true
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = request_params, socket) do
     %{current_user: user, request: request} = socket.assigns
 
@@ -25,12 +22,10 @@ defmodule ItsmWeb.RequestLive.Index do
     {:noreply, stream_delete(socket, :requests, request)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket) do
     {:noreply, socket}
   end
@@ -53,7 +48,7 @@ defmodule ItsmWeb.RequestLive.Index do
     |> assign(:request, Requests.get_request!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :request,
       resource_name: gettext("Request"),
@@ -63,6 +58,6 @@ defmodule ItsmWeb.RequestLive.Index do
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 end

--- a/lib/itsm_web/live/request_live/index.html.heex
+++ b/lib/itsm_web/live/request_live/index.html.heex
@@ -16,7 +16,9 @@
     <div class="w-[90px] truncate">{request.description}</div>
   </:col>
 
-  <:col :let={{_id, request}} label={gettext("Environment")}>{request.env}</:col>
+  <:col :let={{_id, request}} label={gettext("Environment")}>
+    <.common_code_label group="운영_구분" code={request.env} />
+  </:col>
 
   <:col :let={{id, request}} label={gettext("Due Date")}>
     <div id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date} />

--- a/lib/itsm_web/live_utils.ex
+++ b/lib/itsm_web/live_utils.ex
@@ -79,17 +79,19 @@ defmodule ItsmWeb.LiveUtils do
     end)
   end
 
-  def handle_standard_pubsub(socket, user, event, item, opts) do
+  def handle_standard_pubsub(socket, action_user, event, item, opts) do
     [action_type | _] = event |> Atom.to_string() |> String.split("_")
 
     socket
-    |> put_flash_by_event(user, action_type, opts)
+    |> put_flash_by_event(action_user, action_type, opts)
     |> apply_action_type(action_type, item, opts)
-    |> send_update_by_conflict(user, event, item, opts)
+    |> send_update_by_conflict(action_user, event, item, opts)
   end
 
-  defp put_flash_by_event(socket, user, action_type, opts) do
-    message = opts[:flash_message] || build_message(user, action_type, opts[:resource_name])
+  defp put_flash_by_event(socket, action_user, action_type, opts) do
+    message =
+      opts[:flash_message] || build_message(action_user, action_type, opts[:resource_name])
+
     Phoenix.LiveView.put_flash(socket, :info, message)
   end
 
@@ -113,28 +115,29 @@ defmodule ItsmWeb.LiveUtils do
     end
   end
 
-  defp send_update_by_conflict(socket, user, event, item, opts) do
+  defp send_update_by_conflict(socket, action_user, event, item, opts) do
     resource = socket.assigns[opts[:context_key]]
     current_id = if resource, do: to_string(resource.id), else: nil
 
     if current_id == to_string(item.id) and socket.assigns.live_action == :edit do
       form_module = get_form_module(socket, opts)
-      Phoenix.LiveView.send_update(form_module, id: item.id, conflict: {event, user})
+      Phoenix.LiveView.send_update(form_module, id: item.id, conflict: {event, action_user})
     end
 
     socket
   end
 
-  defp build_message(user, "create", name),
-    do: "#{user.display_name} #{gettext("Created")} #{name}"
+  defp build_message(action_user, "create", name),
+    do: "#{action_user.display_name} #{gettext("Created")} #{name}"
 
-  defp build_message(user, "update", name),
-    do: "#{user.display_name} #{gettext("Updated")} #{name}"
+  defp build_message(action_user, "update", name),
+    do: "#{action_user.display_name} #{gettext("Updated")} #{name}"
 
-  defp build_message(user, "delete", name),
-    do: "#{user.display_name} #{gettext("Deleted")} #{name}"
+  defp build_message(action_user, "delete", name),
+    do: "#{action_user.display_name} #{gettext("Deleted")} #{name}"
 
-  defp build_message(user, _, name), do: "#{user.display_name} #{gettext("Processed")} #{name}"
+  defp build_message(action_user, _, name),
+    do: "#{action_user.display_name} #{gettext("Processed")} #{name}"
 
   defp get_form_module(socket, opts) do
     case opts[:form_module] do
@@ -163,6 +166,27 @@ defmodule ItsmWeb.LiveUtils do
       Phoenix.Component.assign(socket, context_key, item)
     else
       socket
+    end
+  end
+
+  def live_select_params(attrs, fields, :single) when is_list(fields) do
+    Enum.reduce(fields, attrs, fn field, acc ->
+      process_empty_selection(acc, field, nil)
+    end)
+  end
+
+  def live_select_params(attrs, fields, :tags) when is_list(fields) do
+    Enum.reduce(fields, attrs, fn field, acc ->
+      process_empty_selection(acc, field, [])
+    end)
+  end
+
+  defp process_empty_selection(acc, field, default_value) do
+    empty_key = "#{field}_empty_selection"
+
+    case {Map.has_key?(acc, field), Map.has_key?(acc, empty_key)} do
+      {false, true} -> Map.put(acc, field, default_value)
+      _ -> acc
     end
   end
 end

--- a/lib/itsm_web/telemetry.ex
+++ b/lib/itsm_web/telemetry.ex
@@ -6,7 +6,6 @@ defmodule ItsmWeb.Telemetry do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
-  @impl true
   def init(_arg) do
     children = [
       # Telemetry poller will execute the given period measurements

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -138,20 +138,18 @@ mary =
 |> Repo.insert!()
 
 aaaaa =
-  %Crew{}
-  |> Crew.changeset(%{
+  %Crew{
     name: "AAAAA",
     description: "K리전 공동존 가상머신 처리팀"
-  })
+  }
   |> Crew.leader_changeset(alex)
   |> Repo.insert!()
 
 bbbbb =
-  %Crew{}
-  |> Crew.changeset(%{
+  %Crew{
     name: "BBBBB",
     description: "K리전 은행존 가상머신 처리팀"
-  })
+  }
   |> Crew.leader_changeset(mary)
   |> Repo.insert!()
 

--- a/priv/templates/phx.gen.itsm.admin_live/form_component.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/form_component.ex.eex
@@ -3,7 +3,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   alias <%= inspect context.module %>
 
-  @impl true
   def update(%{conflict: {event, user}} = _assigns, socket) do
     msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
 
@@ -13,7 +12,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
      |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
   end
 
-  @impl true
   def update(%{<%= schema.singular %>: <%= schema.singular %>} = assigns, socket) do
     {:ok,
      socket
@@ -24,7 +22,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
      end)}
   end
 
-  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -67,13 +64,11 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     """
   end
 
-  @impl true
   def handle_event("validate", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
     changeset = <%= inspect context.alias %>.change_<%= schema.singular %>(socket.assigns.<%= schema.singular %>, <%= schema.singular %>_params)
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  @impl true
   def handle_event("save", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
     save_<%= schema.singular %>(socket, socket.assigns.action, <%= schema.singular %>_params)
   end

--- a/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
@@ -2,34 +2,28 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   use <%= inspect context.web_module %>, :live_view
 
   alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
   alias <%= inspect context.base_module %>.Paging
 
-  @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(<%= inspect schema.alias %>)
+    if connected?(socket), do: Itsm.Utils.subscribes(<%= inspect context.module %>)
 
     {:ok, stream(socket, :<%= schema.collection %>, [])}
   end
 
-  @impl true
   def handle_params(params, url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
-  @impl true
   def handle_event("delete", %{"id" => _id} = <%= schema.singular %>_params, socket) do
     {:ok, _} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>_params)
 
     {:noreply, stream_delete(socket, :<%= schema.collection %>, <%= schema.singular %>)}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp apply_action(socket, :index, params, url) do
@@ -55,11 +49,13 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))
   end
 
-  defp handle_pubsub(user, event, item, socket) do
+  defp handle_pubsub(action_user, event, item, socket) do
     opts = [
       context_key: :<%= schema.singular %>,
       resource_name: gettext("<%= schema.human_singular %>"),
       stream_name: :<%= schema.collection %>,
       push_patch: [to: ~p"/admin/:<%= schema.collection %>?#{socket.assigns[:results][:params] || %{}}"]
     ]
+
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
 end

--- a/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
@@ -2,18 +2,15 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   use <%= inspect context.web_module %>, :live_view
 
   alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
 
-  @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
-  @impl true
   def handle_params(%{"id" => id}, _, socket) do
     if(connected?(socket)) do
-      Itsm.Utils.subscribe(<%= inspect schema.alias %>, id)
-      Itsm.Utils.subscribes(<%= inspect schema.alias %>)
+      Itsm.Utils.subscribe(<%= inspect context.module %>, id)
+      Itsm.Utils.subscribes(<%= inspect context.module %>)
     end
 
     {:noreply,
@@ -22,19 +19,17 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
      |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))}
   end
 
-  @impl true
-  def handle_info({:pubsub, {user, event, item}}, socket) do
-    handle_pubsub(user, event, item, socket)
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
   end
 
-  @impl true
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp page_title(:show), do: "Show <%= schema.human_singular %>"
   defp page_title(:edit), do: "Edit <%= schema.human_singular %>"
 
   defp handle_pubsub(
-         user,
+         action_user,
          event,
          %{id: id} = item,
          %{assigns: %{<%= schema.singular %>: %{id: id}}} = socket
@@ -45,7 +40,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
   end
 
   defp handle_pubsub(_user, _event, _item, socket) do


### PR DESCRIPTION
## 📌 작업 개요
- **주요 변경 사항:** 공통 코드 캐싱 처리를 위한 ETS 도입 및 관련 PubSub 로직 최적화

## 📝 상세 변경 내용

### 1. CommonData ETS 캐싱 도입
- 데이터베이스 부하를 줄이기 위해 자주 조회되는 공통 코드(`common_codes`)를 **ETS(Erlang Term Storage)**에 캐싱하도록 구현했습니다.
- `GenServer`를 이용해 애플리케이션 시작 시 데이터를 ETS로 로드하며, 데이터 정합성을 위한 관리 로직을 추가했습니다.

### 2. PubSub 브로드캐스트 로직 수정
- ETS 캐시와 데이터베이스 간의 동기화를 위해 **PubSub** 메시징 구조를 개선했습니다.
- 특정 노드에서 공통 코드가 갱신될 경우, 모든 클러스터 노드의 ETS 캐시가 즉시 업데이트되도록 이벤트를 표준화했습니다.

## 🚀 테스트 결과
- [x] ETS 캐시 로드 및 조회 성능 확인
- [x] 데이터 수정 시 PubSub을 통한 전 노드 캐시 갱신 여부 확인
- [x] 기존 기능(CRUD) 영향도 체크
- [x] common_code 변경시 다른 사용자 화면에 즉각적용

## 🔗 관련 이슈 및 참고 사항
- 공통 코드 조회 시 DB I/O 감소로 인한 전체적인 응답 속도 향상이 기대됩니다.