### PR TITLE
itsm_calendar 수정,  어드민 유저 추가, audit_log 강화, seed에 공통코드 추가기입

### DIFF
--- a/assets/js/hooks/Calendar.js
+++ b/assets/js/hooks/Calendar.js
@@ -1,7 +1,11 @@
+import  LocalTime  from './LocalTime';
+
 const Calendar = {};
 
 Calendar.DateGrid = {
   mounted() {
+    this.init();
+
     this.el.addEventListener("click", e => {
       const dateCell = e.target.closest("[data-date]");
       if (!dateCell || dateCell.hasAttribute("data-disabled")) return;
@@ -27,10 +31,33 @@ Calendar.DateGrid = {
       this.pushEventTo(this.el.getAttribute("phx-target"), "selected_date_time", { datetime: dt.toISOString() });
     });
   },
+  updated() {
+    this.init();
+  },
+
+  init() {
+    if (!this.el.querySelector(".today-active")) {
+      Calendar.setTodayDate(this.el);
+    }
+
+    const utcValue = this.el.getAttribute("utc-value");
+    const selectedDate = this.el.querySelector(".selected-date");
+    if (utcValue && !selectedDate) {
+      const rawDate = LocalTime.getValue(utcValue, "datetime");
+      const targetDate = new Date(rawDate);
+      const year = targetDate.getFullYear();
+      const month = String(targetDate.getMonth() + 1).padStart(2, "0");
+      const date = String(targetDate.getDate()).padStart(2, "0");
+      const targetDateString = `${year}-${month}-${date}`;
+      const targetElement = this.el.querySelector(`[data-date="${targetDateString}"]`);
+      targetElement?.classList.add(...Calendar.selectDateClass);
+    }
+  }
 };
 
 Calendar.Input = {
   mounted() {
+    LocalTime.renderElement(this.el);
     this.el.addEventListener("blur", e => {
       const [dt, ctx] = Calendar.getDtAndContext(this.el);
       if (e.target.value !== ctx.mInput.value || e.target.value !== ctx.hInput.value) {
@@ -58,12 +85,7 @@ Calendar.Toggle = {
     dateEls.forEach(el => Calendar.updateDateElementStatus(el));
 
     if (!popup.querySelector(".today-active")) {
-      const today = new Date();
-      const year = today.getFullYear();
-      const month = String(today.getMonth() + 1).padStart(2, '0');
-      const day = String(today.getDate()).padStart(2, '0');
-      const todayStr = `${year}-${month}-${day}`;
-      popup.querySelector(`[data-date="${todayStr}"]`)?.classList.add(...Calendar.todayDateClass);
+      Calendar.setTodayDate(popup);
     }
   }
 };
@@ -153,6 +175,15 @@ Calendar.updateTime =(input, dt) => {
   input.value = targetValue;
   input.setAttribute("utc-value", dt.toISOString());
   input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+Calendar.setTodayDate = (e) => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  const todayStr = `${year}-${month}-${day}`;
+  e.querySelector(`[data-date="${todayStr}"]`)?.classList.add(...Calendar.todayDateClass);
 }
 
 Calendar.selectDateClass = ["bg-indigo-600", "text-white", "shadow-md", "selected-date"];

--- a/lib/itsm/accounts.ex
+++ b/lib/itsm/accounts.ex
@@ -410,4 +410,52 @@ defmodule Itsm.Accounts do
     )
     |> Repo.all()
   end
+
+  def list_users, do: Repo.all(User)
+
+  def create_user(attrs \\ %{}) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, user} ->
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_user, user})
+        {:ok, user}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.changeset(attrs)
+    |> Repo.update()
+    |> case do
+      {:ok, user} ->
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_user, user})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_user, user})
+        {:ok, user}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  def delete_user(%{"id" => id} = attrs) do
+    Repo.delete(get_user!(id))
+    |> case do
+      {:ok, user} ->
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :delete_user, user})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :delete_user, user})
+        {:ok, user}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  def change_user(%User{} = user, attrs \\ %{}) do
+    User.changeset(user, attrs)
+  end
 end

--- a/lib/itsm/accounts/user.ex
+++ b/lib/itsm/accounts/user.ex
@@ -194,4 +194,28 @@ defmodule Itsm.Accounts.User do
       add_error(changeset, :current_password, "is not valid")
     end
   end
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [
+      :email,
+      :password,
+      :employee_number,
+      :display_name,
+      :organization,
+      :organization_code,
+      :department,
+      :department_code,
+      :role
+    ])
+    |> validate_required([
+      :employee_number,
+      :display_name,
+      :organization,
+      :organization_code,
+      :department,
+      :department_code,
+      :role
+    ])
+  end
 end

--- a/lib/itsm/admin/accounts.ex
+++ b/lib/itsm/admin/accounts.ex
@@ -8,4 +8,33 @@ defmodule Itsm.Admin.Accounts do
     |> select([c], {c.display_name, c.id})
     |> Repo.all()
   end
+
+  defdelegate get_user!(id), to: Itsm.Accounts
+
+  defdelegate list_users, to: Itsm.Accounts
+
+  defdelegate create_user(attrs \\ %{}), to: Itsm.Accounts
+
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
+    |> Repo.update()
+    |> case do
+      {:ok, user} ->
+        Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_user, user})
+        Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_user, user})
+        {:ok, user}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defdelegate delete_user(attrs), to: Itsm.Accounts
+
+  def change_user(%User{} = user, attrs \\ %{}) do
+    User.changeset(user, attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
+  end
 end

--- a/lib/itsm/audit_logger.ex
+++ b/lib/itsm/audit_logger.ex
@@ -3,14 +3,25 @@ defmodule Itsm.AuditLogger do
   alias Itsm.Logs.AuditLog
 
   def handle_event([:itsm, :repo, :query], measurements, metadata, _config) do
-    query = metadata.query
+    query = metadata[:query]
     source = metadata[:source]
 
-    unless source in ["audit_logs", "access_logs"] or extract_action(query) in ["READ"] do
+    is_success =
+      case metadata[:result] do
+        {:ok, _} -> true
+        {:error, _} -> false
+        _ -> false
+      end
+
+    action_type = extract_action(query)
+
+    unless source in ["audit_logs", "access_logs"] or (action_type == "READ" and is_success) do
+      action = if !is_success, do: "#{action_type}_FAILED", else: action_type
+
       params = %{
         table_name: source,
         target_id: metadata |> extract_id() |> ensure_string_id(),
-        action: extract_action(query),
+        action: action,
         query_time_ms: Float.round(measurements.query_time / 1_000_000.0, 3),
         user_id: Process.get(:current_user_id)
       }

--- a/lib/itsm_web/components/itsm_components.ex
+++ b/lib/itsm_web/components/itsm_components.ex
@@ -220,7 +220,7 @@ defmodule ItsmWeb.ItsmComponents do
             <input
               {@rests[:hour]}
               id={"#{@id}-selected_date_time-hour"}
-              name={"calendar_ui[#{@field.name}][hour]"}
+              name={"#{@field.form.name}[calendar_ui][#{@field.name}][hour]"}
               phx-hook="Calendar.Input"
               utc-value={@selected_date_time}
               type="number"
@@ -234,7 +234,7 @@ defmodule ItsmWeb.ItsmComponents do
             <input
               {@rests[:minute]}
               id={"#{@id}-selected_date_time-minute"}
-              name={"calendar_ui[#{@field.name}][minute]"}
+              name={"#{@field.form.name}[calendar_ui][#{@field.name}][minute]"}
               phx-hook="Calendar.Input"
               utc-value={@selected_date_time}
               type="number"

--- a/lib/itsm_web/components/layouts/admin.html.heex
+++ b/lib/itsm_web/components/layouts/admin.html.heex
@@ -6,9 +6,22 @@
           <img src={~p"/images/itsm_banner.svg"} alt="KB ITSM" class="h-10 w-auto" />
         </a>
       </div>
-      
+
       <nav :if={@current_user} class="flex-1 px-4 py-6 space-y-2 overflow-y-auto no-scrollbar">
         <% current_path = assigns[:current_path] || ""
+
+        icon_map = %{
+          "categories" => "hero-document-plus",
+          "requests" => "hero-list-bullet",
+          "approvals" => "hero-check-badge",
+          "delegations" => "hero-user-group",
+          "crews" => "hero-users",
+          "assets" => "hero-computer-desktop",
+          "admin" => "hero-shield-check",
+          "comments" => "hero-chat-bubble-left",
+          "common_codes" => "hero-squares-2x2",
+          "users" => "hero-user-circle-solid"
+        }
 
         struct_class =
           "flex items-center px-4 py-3 text-sm font-bold rounded-lg transition-all duration-200"
@@ -24,6 +37,11 @@
             else: "#{struct_class} #{inactive_styles}"
         end
 
+        get_icon_name = fn path ->
+          path = String.replace(path, "/admin/", "")
+          Map.get(icon_map, path) || "hero-question-mark-circle"
+        end
+
         # 헬퍼 함수: 아이콘 색상 제어
         get_icon_class = fn path ->
           if current_path == path or String.starts_with?(current_path, path <> "/"),
@@ -37,13 +55,14 @@
           href={menu.path}
           class={get_link_class.(menu.path)}
         >
-          <.icon name="hero-cog-6-tooth" class={get_icon_class.(menu.path)} /> {Gettext.gettext(
+          <.icon name={get_icon_name.(menu.path)} class={get_icon_class.(menu.path)} />
+          {Gettext.gettext(
             ItsmWeb.Gettext,
             menu.name
           )}
         </.link>
       </nav>
-      
+
       <div class="p-4 bg-[#24272b] border-t border-gray-700">
         <div class="flex items-center justify-between px-2 mb-4 bg-gray-800/50 rounded-full py-1.5 border border-gray-700">
           <% is_ko = Gettext.get_locale(ItsmWeb.Gettext) == "ko" %>
@@ -61,7 +80,7 @@
             EN
           </span>
         </div>
-        
+
         <div :if={@current_user} class="flex items-center justify-between px-2 pt-2">
           <div class="flex flex-col min-w-0">
             <span class="text-[10px] text-gray-500 font-bold uppercase">Authorized User</span>
@@ -69,7 +88,7 @@
               {@current_user.email}
             </span>
           </div>
-          
+
           <div class="flex gap-1">
             <.link
               href={~p"/users/settings"}
@@ -89,7 +108,7 @@
       </div>
     </div>
   </aside>
-  
+
   <main class="flex-1 p-8">
     <div class="max-w-6xl mx-auto"><.flash_group flash={@flash} /> {@inner_content}</div>
   </main>

--- a/lib/itsm_web/live/admin/user_live/form_component.ex
+++ b/lib/itsm_web/live/admin/user_live/form_component.ex
@@ -1,0 +1,145 @@
+defmodule ItsmWeb.Admin.UserLive.FormComponent do
+  use ItsmWeb, :live_component
+
+  alias Itsm.Admin.Accounts
+  alias Itsm.Admin.CommonCodes
+
+  def update(%{conflict: {event, user}} = _assigns, socket) do
+    msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
+
+    {:ok,
+     socket
+     |> assign(:conflict, true)
+     |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
+  end
+
+  def update(%{user: user} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:conflict, false)
+     |> assign_new(:form, fn -> to_form(Accounts.change_user(user)) end)
+     |> assign_new_options()}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        {@title}
+        <:subtitle>Use this form to manage user records in your database.</:subtitle>
+      </.header>
+
+      <div
+        :if={@conflict}
+        class="p-4 mb-4 bg-red-50 border border-red-200 text-red-800 rounded animate-pulse"
+      >
+        <div class="flex items-center gap-2 font-bold">
+          <span>⚠️ 충돌 발생!</span>
+        </div>
+        <p class="mt-1 text-sm">{@conflict_msg}</p>
+        <p class="mt-2 text-xs opacity-75">현재 편집 내용을 저장할 수 없습니다. 창을 닫고 다시 시도해 주세요.</p>
+      </div>
+
+      <.simple_form
+        for={@form}
+        id="user-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:email]} type="text" label={gettext("Email")} />
+        <.input
+          :if={@action == :new}
+          field={@form[:password]}
+          type="text"
+          label={gettext("Password")}
+        />
+        <.itsm_calendar
+          field={@form[:confirmed_at]}
+          label={gettext("Confirmed At")}
+          show_time
+          default_selected_date_time={@form[:confirmed_at].value}
+        />
+        <.input field={@form[:employee_number]} type="text" label={gettext("Employee Number")} />
+        <.input field={@form[:display_name]} type="text" label={gettext("Display Name")} />
+        <.input
+          field={@form[:organization_code]}
+          type="select"
+          label={gettext("Organization")}
+          prompt="Choose a value"
+          options={@organization_options}
+        />
+        <%!-- <.input field={@form[:organization]} type="text" label={gettext("Organization")} />
+        <.input field={@form[:organization_code]} type="text" label={gettext("Organization Code")} /> --%>
+        <.input
+          field={@form[:department_code]}
+          type="select"
+          label={gettext("Department")}
+          prompt="Choose a value"
+          options={@department_options}
+        />
+        <%!-- <.input field={@form[:department]} type="text" label={gettext("Department")} />
+        <.input field={@form[:department_code]} type="text" label={gettext("Department Code")} /> --%>
+        <.input field={@form[:role]} type="text" label={gettext("Role")} />
+        <.itsm_calendar
+          :if={@action == :edit}
+          field={@form[:inserted_at]}
+          label={gettext("Inserted At")}
+          show_time
+          default_selected_date_time={@form[:inserted_at].value}
+        />
+        <:actions>
+          <.button :if={!@conflict} phx-disable-with="Saving...">Save User</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  def handle_event("validate", %{"user" => user_params}, socket) do
+    changeset = Accounts.change_user(socket.assigns.user, user_params)
+    {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
+  end
+
+  def handle_event("save", %{"user" => user_params}, socket) do
+    save_user(socket, socket.assigns.action, fill_org_dept_codes(user_params))
+  end
+
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:organization_options, fn -> CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:department_options, fn -> CommonCodes.get_select_options("부서") end)
+  end
+
+  defp save_user(socket, :edit, user_params) do
+    case Accounts.update_user(socket.assigns.user, user_params) do
+      {:ok, _user} ->
+        {:noreply, socket |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp save_user(socket, :new, user_params) do
+    case Itsm.Accounts.register_user(user_params) do
+      {:ok, _user} ->
+        {:noreply, socket |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp fill_org_dept_codes(attrs) do
+    org_code = attrs["organization_code"]
+    org_name = CommonCodes.get_label("계열사", org_code)
+    dept_code = attrs["department_code"]
+    dept_name = CommonCodes.get_label("부서", dept_code)
+
+    attrs
+    |> Map.put("department", dept_name)
+    |> Map.put("organization", org_name)
+  end
+end

--- a/lib/itsm_web/live/admin/user_live/index.ex
+++ b/lib/itsm_web/live/admin/user_live/index.ex
@@ -1,0 +1,76 @@
+defmodule ItsmWeb.Admin.UserLive.Index do
+  use ItsmWeb, :live_view
+
+  alias Itsm.Admin.Accounts
+  alias Itsm.Accounts.User
+  alias Itsm.Paging
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Itsm.Utils.subscribes(Accounts)
+
+    {:ok, stream(socket, :users, [])}
+  end
+
+  def handle_params(params, url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
+  end
+
+  def handle_event("delete", %{"id" => _id} = user_params, socket) do
+    {:ok, user} = Accounts.delete_user(user_params)
+
+    {:noreply, stream_delete(socket, :users, user)}
+  end
+
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
+  end
+
+  def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp apply_action(socket, :index, params, url) do
+    value =
+      Paging.search_and_pagination(params, url, User, [
+        :email,
+        :password,
+        :hashed_password,
+        :current_password,
+        :confirmed_at,
+        :employee_number,
+        :display_name,
+        :organization,
+        :organization_code,
+        :department,
+        :department_code,
+        :role
+      ])
+
+    socket
+    |> assign(:results, value.results)
+    |> stream(:users, value.entries, reset: true)
+    |> assign(:page_title, "Listing Users")
+    |> assign(:user, nil)
+  end
+
+  defp apply_action(socket, :new, _params, _url) do
+    socket
+    |> assign(:page_title, "New User")
+    |> assign(:user, %User{})
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}, _url) do
+    socket
+    |> assign(:page_title, "Edit User")
+    |> assign(:user, Accounts.get_user!(id))
+  end
+
+  defp handle_pubsub(action_user, event, item, socket) do
+    opts = [
+      context_key: :user,
+      resource_name: gettext("User"),
+      stream_name: :users,
+      push_patch: [to: ~p"/admin/users?#{socket.assigns[:results][:params] || %{}}"]
+    ]
+
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
+end

--- a/lib/itsm_web/live/admin/user_live/index.html.heex
+++ b/lib/itsm_web/live/admin/user_live/index.html.heex
@@ -1,0 +1,68 @@
+<.header>
+  Listing Users
+  <:actions>
+    <.link patch={~p"/admin/users/new"}>
+      <.button>New User</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.itsm_table_container results={assigns[:results]}>
+  <.table
+    id="users"
+    rows={@streams.users}
+    row_click={fn {_id, user} -> JS.navigate(~p"/admin/users/#{user}") end}
+  >
+    <:col :let={{_id, user}} label={gettext("Email")}>{user.email}</:col>
+    <:col :let={{id, user}} label={gettext("Confirmed At")}>
+      <div id={"confirmed_at_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={user.confirmed_at} />
+    </:col>
+    <:col :let={{_id, user}} label={gettext("Employee Number")}>{user.employee_number}</:col>
+    <:col :let={{_id, user}} label={gettext("Display Name")}>{user.display_name}</:col>
+    <:col :let={{_id, user}} label={gettext("Organization")}>{user.organization}</:col>
+    <:col :let={{_id, user}} label={gettext("Organization Code")}>
+      <.common_code_label group="계열사" code={user.organization_code} />
+    </:col>
+    <:col :let={{_id, user}} label={gettext("Department")}>{user.department}</:col>
+    <:col :let={{_id, user}} label={gettext("Department Code")}>
+      <.common_code_label group="부서" code={user.department_code} />
+    </:col>
+    <:col :let={{_id, user}} label={gettext("Role")}>
+      <.common_code_label group="역할" code={user.role} />
+    </:col>
+
+    <:action :let={{_id, user}}>
+      <div class="sr-only">
+        <.link navigate={~p"/admin/users/#{user}"}>Show</.link>
+      </div>
+      <.link patch={~p"/admin/users/#{user}/edit"}>Edit</.link>
+    </:action>
+    <:action :let={{_id, user}}>
+      <.link
+        id={user.id}
+        phx-click={JS.push("delete", value: %{id: user.id})}
+        class="phx-click-loading:opacity-50 phx-click-loading:cursor-wait"
+        data-confirm="Are you sure?"
+      >
+        Delete
+      </.link>
+    </:action>
+  </.table>
+</.itsm_table_container>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="user-modal"
+  show
+  on_cancel={JS.patch(~p"/admin/users?#{assigns[:results][:params] || %{}}")}
+>
+  <.live_component
+    module={ItsmWeb.Admin.UserLive.FormComponent}
+    id={@user.id || :new}
+    title={@page_title}
+    action={@live_action}
+    user={@user}
+    current_user={@current_user}
+    patch={~p"/admin/users?#{assigns[:results][:params] || %{}}"}
+  />
+</.modal>

--- a/lib/itsm_web/live/admin/user_live/show.ex
+++ b/lib/itsm_web/live/admin/user_live/show.ex
@@ -1,0 +1,54 @@
+defmodule ItsmWeb.Admin.UserLive.Show do
+  use ItsmWeb, :live_view
+
+  alias Itsm.Admin.Accounts
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(%{"id" => id}, _, socket) do
+    if(connected?(socket)) do
+      Itsm.Utils.subscribe(Itsm.Admin.Accounts, id)
+      Itsm.Utils.subscribes(Itsm.Admin.Accounts)
+    end
+
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:user, Accounts.get_user!(id))}
+  end
+
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
+  end
+
+  def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp page_title(:show), do: "Show User"
+  defp page_title(:edit), do: "Edit User"
+
+  defp handle_pubsub(
+         action_user,
+         event,
+         %{id: id} = item,
+         %{assigns: %{user: %{id: id}}} = socket
+       ) do
+    opts =
+      [context_key: :user, resource_name: gettext("User")]
+      |> Keyword.merge(push_event_action(event))
+
+    {:noreply,
+     socket
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
+
+  defp handle_pubsub(_user, _event, _item, socket) do
+    {:noreply, socket}
+  end
+
+  defp push_event_action(:delete_user),
+    do: [push_navigate: [to: ~p"/admin/users"]]
+
+  defp push_event_action(_), do: []
+end

--- a/lib/itsm_web/live/admin/user_live/show.html.heex
+++ b/lib/itsm_web/live/admin/user_live/show.html.heex
@@ -1,0 +1,64 @@
+<.header>
+  User {@user.id}
+  <:subtitle>This is a user record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/admin/users/#{@user}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit user</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title={gettext("Email")}>{@user.email}</:item>
+  <:item title={gettext("Confirmed At")}>
+    <span
+      id={"user-confirmed_at_#{@user.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@user.confirmed_at}
+    />
+  </:item>
+  <:item title={gettext("Employee Number")}>{@user.employee_number}</:item>
+  <:item title={gettext("Display Name")}>{@user.display_name}</:item>
+  <:item title={gettext("Organization")}>{@user.organization}</:item>
+  <:item title={gettext("Organization Code")}>
+    <.common_code_label group="계열사" code={@user.organization_code} />
+  </:item>
+  <:item title={gettext("Department")}>{@user.department}</:item>
+  <:item title={gettext("Department Code")}>
+    <.common_code_label group="부서" code={@user.department_code} />
+  </:item>
+  <:item title={gettext("Role")}><.common_code_label group="역할" code={@user.role} /></:item>
+  <:item title={gettext("Inserted At")}>
+    <span
+      id={"user-inserted-at_#{@user.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@user.inserted_at}
+    />
+  </:item>
+  <:item title={gettext("Updated At")}>
+    <span
+      id={"user-updated-at_#{@user.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@user.updated_at}
+    />
+  </:item>
+</.list>
+
+<.back navigate={~p"/admin/users"}>Back to users</.back>
+
+<.modal
+  :if={@live_action == :edit}
+  id="user-modal"
+  show
+  on_cancel={JS.patch(~p"/admin/users/#{@user}")}
+>
+  <.live_component
+    module={ItsmWeb.Admin.UserLive.FormComponent}
+    id={@user.id}
+    title={@page_title}
+    action={@live_action}
+    user={@user}
+    current_user={@current_user}
+    patch={~p"/admin/users/#{@user}"}
+  />
+</.modal>

--- a/lib/itsm_web/router.ex
+++ b/lib/itsm_web/router.ex
@@ -152,6 +152,13 @@ defmodule ItsmWeb.Router do
       layout: {ItsmWeb.Layouts, :admin} do
       live "/", Admin.CategoryLive.Index, :index
 
+      live "/users", Admin.UserLive.Index, :index
+      live "/users/new", Admin.UserLive.Index, :new
+      live "/users/:id/edit", Admin.UserLive.Index, :edit
+
+      live "/users/:id", Admin.UserLive.Show, :show
+      live "/users/:id/show/edit", Admin.UserLive.Show, :edit
+
       live "/requests", Admin.RequestLive.Index, :index
       live "/requests/new", Admin.RequestLive.Index, :new
       live "/requests/:id/edit", Admin.RequestLive.Index, :edit

--- a/lib/mix/tasks/gen.Itsm.admin_html.ex
+++ b/lib/mix/tasks/gen.Itsm.admin_html.ex
@@ -213,7 +213,7 @@ defmodule Mix.Tasks.Phx.Gen.Itsm.AdminHtml do
   field={@form[#{inspect(key)}]}
   label=#{label(key)}
   show_time
-  default_selected_date_time={@form[:inserted_at].value}
+  default_selected_date_time={@form[#{inspect(key)}].value}
 />)
 
       {key, :naive_datetime} ->

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -645,3 +645,30 @@ bbbbb =
 
 %CommonCode{sort_order: 2, group_code: "역할", code: "감사자", label: "감사자", description: "감사자 권한입니다."}
 |> Repo.insert!()
+
+%CommonCode{
+  sort_order: 1,
+  group_code: "부서",
+  code: "883310",
+  label: "인프라시스템부",
+  description: "인프라시스템부 부서입니다."
+}
+|> Repo.insert!()
+
+%CommonCode{
+  sort_order: 2,
+  group_code: "부서",
+  code: "813219",
+  label: "정보보호부",
+  description: "정보보호부 부서입니다."
+}
+|> Repo.insert!()
+
+%CommonCode{
+  sort_order: 3,
+  group_code: "부서",
+  code: "813211",
+  label: "정보보호부",
+  description: "정보보호부 부서입니다."
+}
+|> Repo.insert!()

--- a/priv/templates/phx.gen.context/access_no_schema.ex
+++ b/priv/templates/phx.gen.context/access_no_schema.ex
@@ -10,7 +10,7 @@
     |> Repo.insert()
     |> case do
       {:ok, <%= schema.singular %>} ->
-       Itsm.Utils.broadcasts(<%= inspect schema.alias %>, {attrs["current_user"], :create_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :create_<%= schema.singular %>, <%= schema.singular %>})
        {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->
@@ -24,8 +24,8 @@
     |> Repo.update()
     |> case do
       {:ok, <%= schema.singular %>} ->
-       Itsm.Utils.broadcast(<%= inspect schema.alias %>, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
-       Itsm.Utils.broadcasts(<%= inspect schema.alias %>, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
        {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->

--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -13,8 +13,8 @@
     |> Repo.update()
     |> case do
       {:ok, <%= schema.singular %>} ->
-       Itsm.Utils.broadcast(<%= inspect schema.alias %>, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
-       Itsm.Utils.broadcasts(<%= inspect schema.alias %>, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
        {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->
@@ -22,7 +22,7 @@
     end
   end
 
-  defdelegate delete_<%= schema.singular %>(%{"id" => _id}), to: Itsm.<%= inspect context.alias %>
+  defdelegate delete_<%= schema.singular %>(attrs), to: Itsm.<%= inspect context.alias %>
 
   def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
     <%= inspect schema.alias %>.changeset(<%= schema.singular %>, attrs)

--- a/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
@@ -2,10 +2,11 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   use <%= inspect context.web_module %>, :live_view
 
   alias <%= inspect context.module %>
+  alias <%= inspect schema.module %>
   alias <%= inspect context.base_module %>.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(<%= inspect context.module %>)
+    if connected?(socket), do: Itsm.Utils.subscribes(<%= inspect context.alias %>)
 
     {:ok, stream(socket, :<%= schema.collection %>, [])}
   end
@@ -15,7 +16,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def handle_event("delete", %{"id" => _id} = <%= schema.singular %>_params, socket) do
-    {:ok, _} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>_params)
+    {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>_params)
 
     {:noreply, stream_delete(socket, :<%= schema.collection %>, <%= schema.singular %>)}
   end
@@ -54,8 +55,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       context_key: :<%= schema.singular %>,
       resource_name: gettext("<%= schema.human_singular %>"),
       stream_name: :<%= schema.collection %>,
-      push_patch: [to: ~p"/admin/:<%= schema.collection %>?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: ~p"/admin/<%= schema.collection %>?#{socket.assigns[:results][:params] || %{}}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
 end

--- a/test/itsm/accounts_test.exs
+++ b/test/itsm/accounts_test.exs
@@ -505,4 +505,158 @@ defmodule Itsm.AccountsTest do
       refute inspect(%User{password: "123456"}) =~ "password: \"123456\""
     end
   end
+
+  describe "users" do
+    alias Itsm.Accounts.User
+
+    import Itsm.AccountsFixtures
+
+    @invalid_attrs %{"": nil, password: nil, role: nil, organization: nil, email: nil, hashed_password: nil, current_password: nil, confirmed_at: nil, employee_number: nil, display_name: nil, organization_code: nil, department: nil, department_code: nil}
+
+    test "list_users/0 returns all users" do
+      user = user_fixture()
+      assert Accounts.list_users() == [user]
+    end
+
+    test "get_user!/1 returns the user with given id" do
+      user = user_fixture()
+      assert Accounts.get_user!(user.id) == user
+    end
+
+    test "create_user/1 with valid data creates a user" do
+      valid_attrs = %{"": "some ", password: "some password", role: "some role", organization: "some organization", email: "some email", hashed_password: "some hashed_password", current_password: "some current_password", confirmed_at: "some confirmed_at", employee_number: "some employee_number", display_name: "some display_name", organization_code: "some organization_code", department: "some department", department_code: "some department_code"}
+
+      assert {:ok, %User{} = user} = Accounts.create_user(valid_attrs)
+      assert user. == "some "
+      assert user.password == "some password"
+      assert user.role == "some role"
+      assert user.organization == "some organization"
+      assert user.email == "some email"
+      assert user.hashed_password == "some hashed_password"
+      assert user.current_password == "some current_password"
+      assert user.confirmed_at == "some confirmed_at"
+      assert user.employee_number == "some employee_number"
+      assert user.display_name == "some display_name"
+      assert user.organization_code == "some organization_code"
+      assert user.department == "some department"
+      assert user.department_code == "some department_code"
+    end
+
+    test "create_user/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
+    end
+
+    test "update_user/2 with valid data updates the user" do
+      user = user_fixture()
+      update_attrs = %{"": "some updated ", password: "some updated password", role: "some updated role", organization: "some updated organization", email: "some updated email", hashed_password: "some updated hashed_password", current_password: "some updated current_password", confirmed_at: "some updated confirmed_at", employee_number: "some updated employee_number", display_name: "some updated display_name", organization_code: "some updated organization_code", department: "some updated department", department_code: "some updated department_code"}
+
+      assert {:ok, %User{} = user} = Accounts.update_user(user, update_attrs)
+      assert user. == "some updated "
+      assert user.password == "some updated password"
+      assert user.role == "some updated role"
+      assert user.organization == "some updated organization"
+      assert user.email == "some updated email"
+      assert user.hashed_password == "some updated hashed_password"
+      assert user.current_password == "some updated current_password"
+      assert user.confirmed_at == "some updated confirmed_at"
+      assert user.employee_number == "some updated employee_number"
+      assert user.display_name == "some updated display_name"
+      assert user.organization_code == "some updated organization_code"
+      assert user.department == "some updated department"
+      assert user.department_code == "some updated department_code"
+    end
+
+    test "update_user/2 with invalid data returns error changeset" do
+      user = user_fixture()
+      assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
+      assert user == Accounts.get_user!(user.id)
+    end
+
+    test "delete_user/1 deletes the user" do
+      user = user_fixture()
+      assert {:ok, %User{}} = Accounts.delete_user(user)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(user.id) end
+    end
+
+    test "change_user/1 returns a user changeset" do
+      user = user_fixture()
+      assert %Ecto.Changeset{} = Accounts.change_user(user)
+    end
+  end
+
+  describe "users" do
+    alias Itsm.Accounts.User
+
+    import Itsm.AccountsFixtures
+
+    @invalid_attrs %{password: nil, role: nil, organization: nil, email: nil, hashed_password: nil, current_password: nil, confirmed_at: nil, employee_number: nil, display_name: nil, organization_code: nil, department: nil, department_code: nil}
+
+    test "list_users/0 returns all users" do
+      user = user_fixture()
+      assert Accounts.list_users() == [user]
+    end
+
+    test "get_user!/1 returns the user with given id" do
+      user = user_fixture()
+      assert Accounts.get_user!(user.id) == user
+    end
+
+    test "create_user/1 with valid data creates a user" do
+      valid_attrs = %{password: "some password", role: "some role", organization: "some organization", email: "some email", hashed_password: "some hashed_password", current_password: "some current_password", confirmed_at: ~U[2026-04-19 07:59:00Z], employee_number: "some employee_number", display_name: "some display_name", organization_code: "some organization_code", department: "some department", department_code: "some department_code"}
+
+      assert {:ok, %User{} = user} = Accounts.create_user(valid_attrs)
+      assert user.password == "some password"
+      assert user.role == "some role"
+      assert user.organization == "some organization"
+      assert user.email == "some email"
+      assert user.hashed_password == "some hashed_password"
+      assert user.current_password == "some current_password"
+      assert user.confirmed_at == ~U[2026-04-19 07:59:00Z]
+      assert user.employee_number == "some employee_number"
+      assert user.display_name == "some display_name"
+      assert user.organization_code == "some organization_code"
+      assert user.department == "some department"
+      assert user.department_code == "some department_code"
+    end
+
+    test "create_user/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
+    end
+
+    test "update_user/2 with valid data updates the user" do
+      user = user_fixture()
+      update_attrs = %{password: "some updated password", role: "some updated role", organization: "some updated organization", email: "some updated email", hashed_password: "some updated hashed_password", current_password: "some updated current_password", confirmed_at: ~U[2026-04-20 07:59:00Z], employee_number: "some updated employee_number", display_name: "some updated display_name", organization_code: "some updated organization_code", department: "some updated department", department_code: "some updated department_code"}
+
+      assert {:ok, %User{} = user} = Accounts.update_user(user, update_attrs)
+      assert user.password == "some updated password"
+      assert user.role == "some updated role"
+      assert user.organization == "some updated organization"
+      assert user.email == "some updated email"
+      assert user.hashed_password == "some updated hashed_password"
+      assert user.current_password == "some updated current_password"
+      assert user.confirmed_at == ~U[2026-04-20 07:59:00Z]
+      assert user.employee_number == "some updated employee_number"
+      assert user.display_name == "some updated display_name"
+      assert user.organization_code == "some updated organization_code"
+      assert user.department == "some updated department"
+      assert user.department_code == "some updated department_code"
+    end
+
+    test "update_user/2 with invalid data returns error changeset" do
+      user = user_fixture()
+      assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
+      assert user == Accounts.get_user!(user.id)
+    end
+
+    test "delete_user/1 deletes the user" do
+      user = user_fixture()
+      assert {:ok, %User{}} = Accounts.delete_user(user)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(user.id) end
+    end
+
+    test "change_user/1 returns a user changeset" do
+      user = user_fixture()
+      assert %Ecto.Changeset{} = Accounts.change_user(user)
+    end
+  end
 end

--- a/test/itsm/admin/accounts_test.exs
+++ b/test/itsm/admin/accounts_test.exs
@@ -1,0 +1,81 @@
+defmodule Itsm.Admin.AccountsTest do
+  use Itsm.DataCase
+
+  alias Itsm.Admin.Accounts
+
+  describe "users" do
+    alias Itsm.Accounts.User
+
+    import Itsm.Admin.AccountsFixtures
+
+    @invalid_attrs %{password: nil, role: nil, organization: nil, email: nil, hashed_password: nil, current_password: nil, confirmed_at: nil, employee_number: nil, display_name: nil, organization_code: nil, department: nil, department_code: nil}
+
+    test "list_users/0 returns all users" do
+      user = user_fixture()
+      assert Accounts.list_users() == [user]
+    end
+
+    test "get_user!/1 returns the user with given id" do
+      user = user_fixture()
+      assert Accounts.get_user!(user.id) == user
+    end
+
+    test "create_user/1 with valid data creates a user" do
+      valid_attrs = %{password: "some password", role: "some role", organization: "some organization", email: "some email", hashed_password: "some hashed_password", current_password: "some current_password", confirmed_at: ~U[2026-04-19 07:59:00Z], employee_number: "some employee_number", display_name: "some display_name", organization_code: "some organization_code", department: "some department", department_code: "some department_code"}
+
+      assert {:ok, %User{} = user} = Accounts.create_user(valid_attrs)
+      assert user.password == "some password"
+      assert user.role == "some role"
+      assert user.organization == "some organization"
+      assert user.email == "some email"
+      assert user.hashed_password == "some hashed_password"
+      assert user.current_password == "some current_password"
+      assert user.confirmed_at == ~U[2026-04-19 07:59:00Z]
+      assert user.employee_number == "some employee_number"
+      assert user.display_name == "some display_name"
+      assert user.organization_code == "some organization_code"
+      assert user.department == "some department"
+      assert user.department_code == "some department_code"
+    end
+
+    test "create_user/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
+    end
+
+    test "update_user/2 with valid data updates the user" do
+      user = user_fixture()
+      update_attrs = %{password: "some updated password", role: "some updated role", organization: "some updated organization", email: "some updated email", hashed_password: "some updated hashed_password", current_password: "some updated current_password", confirmed_at: ~U[2026-04-20 07:59:00Z], employee_number: "some updated employee_number", display_name: "some updated display_name", organization_code: "some updated organization_code", department: "some updated department", department_code: "some updated department_code"}
+
+      assert {:ok, %User{} = user} = Accounts.update_user(user, update_attrs)
+      assert user.password == "some updated password"
+      assert user.role == "some updated role"
+      assert user.organization == "some updated organization"
+      assert user.email == "some updated email"
+      assert user.hashed_password == "some updated hashed_password"
+      assert user.current_password == "some updated current_password"
+      assert user.confirmed_at == ~U[2026-04-20 07:59:00Z]
+      assert user.employee_number == "some updated employee_number"
+      assert user.display_name == "some updated display_name"
+      assert user.organization_code == "some updated organization_code"
+      assert user.department == "some updated department"
+      assert user.department_code == "some updated department_code"
+    end
+
+    test "update_user/2 with invalid data returns error changeset" do
+      user = user_fixture()
+      assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
+      assert user == Accounts.get_user!(user.id)
+    end
+
+    test "delete_user/1 deletes the user" do
+      user = user_fixture()
+      assert {:ok, %User{}} = Accounts.delete_user(user)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(user.id) end
+    end
+
+    test "change_user/1 returns a user changeset" do
+      user = user_fixture()
+      assert %Ecto.Changeset{} = Accounts.change_user(user)
+    end
+  end
+end

--- a/test/itsm_web/live/admin/user_live_test.exs
+++ b/test/itsm_web/live/admin/user_live_test.exs
@@ -1,0 +1,113 @@
+defmodule ItsmWeb.Admin.UserLiveTest do
+  use ItsmWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Itsm.Admin.AccountsFixtures
+
+  @create_attrs %{password: "some password", role: "some role", organization: "some organization", email: "some email", hashed_password: "some hashed_password", current_password: "some current_password", confirmed_at: "2026-04-19T07:59:00Z", employee_number: "some employee_number", display_name: "some display_name", organization_code: "some organization_code", department: "some department", department_code: "some department_code"}
+  @update_attrs %{password: "some updated password", role: "some updated role", organization: "some updated organization", email: "some updated email", hashed_password: "some updated hashed_password", current_password: "some updated current_password", confirmed_at: "2026-04-20T07:59:00Z", employee_number: "some updated employee_number", display_name: "some updated display_name", organization_code: "some updated organization_code", department: "some updated department", department_code: "some updated department_code"}
+  @invalid_attrs %{password: nil, role: nil, organization: nil, email: nil, hashed_password: nil, current_password: nil, confirmed_at: nil, employee_number: nil, display_name: nil, organization_code: nil, department: nil, department_code: nil}
+
+  defp create_user(_) do
+    user = user_fixture()
+    %{user: user}
+  end
+
+  describe "Index" do
+    setup [:create_user]
+
+    test "lists all users", %{conn: conn, user: user} do
+      {:ok, _index_live, html} = live(conn, ~p"/admin/users")
+
+      assert html =~ "Listing Users"
+      assert html =~ user.password
+    end
+
+    test "saves new user", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/users")
+
+      assert index_live |> element("a", "New User") |> render_click() =~
+               "New User"
+
+      assert_patch(index_live, ~p"/admin/users/new")
+
+      assert index_live
+             |> form("#user-form", user: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#user-form", user: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/admin/users")
+
+      html = render(index_live)
+      assert html =~ "User created successfully"
+      assert html =~ "some password"
+    end
+
+    test "updates user in listing", %{conn: conn, user: user} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/users")
+
+      assert index_live |> element("#users-#{user.id} a", "Edit") |> render_click() =~
+               "Edit User"
+
+      assert_patch(index_live, ~p"/admin/users/#{user}/edit")
+
+      assert index_live
+             |> form("#user-form", user: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#user-form", user: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/admin/users")
+
+      html = render(index_live)
+      assert html =~ "User updated successfully"
+      assert html =~ "some updated password"
+    end
+
+    test "deletes user in listing", %{conn: conn, user: user} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/users")
+
+      assert index_live |> element("#users-#{user.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#users-#{user.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_user]
+
+    test "displays user", %{conn: conn, user: user} do
+      {:ok, _show_live, html} = live(conn, ~p"/admin/users/#{user}")
+
+      assert html =~ "Show User"
+      assert html =~ user.password
+    end
+
+    test "updates user within modal", %{conn: conn, user: user} do
+      {:ok, show_live, _html} = live(conn, ~p"/admin/users/#{user}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit User"
+
+      assert_patch(show_live, ~p"/admin/users/#{user}/show/edit")
+
+      assert show_live
+             |> form("#user-form", user: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#user-form", user: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/admin/users/#{user}")
+
+      html = render(show_live)
+      assert html =~ "User updated successfully"
+      assert html =~ "some updated password"
+    end
+  end
+end

--- a/test/support/fixtures/admin/accounts_fixtures.ex
+++ b/test/support/fixtures/admin/accounts_fixtures.ex
@@ -1,0 +1,31 @@
+defmodule Itsm.Admin.AccountsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Itsm.Admin.Accounts` context.
+  """
+
+  @doc """
+  Generate a user.
+  """
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} =
+      attrs
+      |> Enum.into(%{
+        confirmed_at: ~U[2026-04-19 07:59:00Z],
+        current_password: "some current_password",
+        department: "some department",
+        department_code: "some department_code",
+        display_name: "some display_name",
+        email: "some email",
+        employee_number: "some employee_number",
+        hashed_password: "some hashed_password",
+        organization: "some organization",
+        organization_code: "some organization_code",
+        password: "some password",
+        role: "some role"
+      })
+      |> Itsm.Admin.Accounts.create_user()
+
+    user
+  end
+end


### PR DESCRIPTION
## 📝 Description
- 시스템 운영의 효율성과 보안성을 높이기 위해 ITSM 캘린더 수정, 어드민 유저 관리, 감사 로그(Audit Log) 강화 및 초기 데이터(Seed) 보강 작업을 진행했습니다.

### 🛠 Key Changes
### 1. ITSM 캘린더 (itsm_calendar) 수정
- 버그 수정 및 일정 표시 로직을 개선했습니다.

### 2. 어드민 유저 페이지 추가
- 시스템 관리를 위한 어드민 유저 페이지 기능을 추가했습니다.

### 3. 감사 로그 (audit_log) 강화
- 주요 리소스(생성, 수정, 삭제) 실패에 대한 이력을 상세히 기록하도록 로직을 보강했습니다.

### 4. Seed 데이터 업데이트
- 시스템 운영에 필수적인 공통 코드(Common Codes) 데이터를 seeds.exs에 추가 기입했습니다.