### PR TITLE
[feat]서비스요청-가상머신 신청 수정시 첨부파일 삭제 가능하게 기능개발

### DIFF
--- a/lib/itsm/attachments.ex
+++ b/lib/itsm/attachments.ex
@@ -10,6 +10,14 @@ defmodule Itsm.Attachments do
     |> Repo.get!(id)
   end
 
+  def get_list_attachments(resource) do
+    Attachment
+    |> where([a], a.resource_type == ^Utils.resource_name(resource))
+    |> where([a], a.resource_id == ^resource.id)
+    |> where([a], a.status == :active)
+    |> Repo.all()
+  end
+
   def create_attachment(attrs \\ %{}) do
     %Attachment{}
     |> Attachment.changeset(attrs)
@@ -28,8 +36,8 @@ defmodule Itsm.Attachments do
     end
   end
 
-  def create_attachments(repo, resource, attachments_callback, attachments_attrs) do
-    attachments = attachments_callback.()
+  def create_attachments(repo, resource, consumer_fn, attachments_attrs) do
+    attachments = consumer_fn.()
 
     Enum.reduce_while(attachments, {:ok, []}, fn attrs, {:ok, acc} ->
       %Attachment{resource_type: Utils.resource_name(resource), resource_id: resource.id}
@@ -49,4 +57,24 @@ defmodule Itsm.Attachments do
       end
     end)
   end
+
+  def delete_attachment(id, attrs \\ []) do
+    get_attachment!(id)
+    |> Attachment.delete_changeset()
+    |> Repo.update()
+    |> case do
+      {:ok, attachment} ->
+        Itsm.Utils.broadcasts(
+          __MODULE__,
+          {attrs["current_user"], :delete_attachment, attachment}
+        )
+
+        {:ok, attachment}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  def active_attachment(), do: Attachment |> where([a], a.status == :active)
 end

--- a/lib/itsm/attachments/attachment.ex
+++ b/lib/itsm/attachments/attachment.ex
@@ -5,15 +5,17 @@ defmodule Itsm.Attachments.Attachment do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "attachments" do
-    field :byte_size, :integer
     field :filename, :string
     field :local_path, :string
     field :file_type, :string
+    field :byte_size, :integer
+
+    field :status, Ecto.Enum, values: [:active, :pending_delete, :deleted], default: :active
 
     field :resource_type, :string
     field :resource_id, :binary_id
 
-    # belongs_to :request, Itsm.Service.Request
+    field :deleted_at, :utc_datetime
 
     timestamps(type: :utc_datetime)
   end
@@ -27,8 +29,16 @@ defmodule Itsm.Attachments.Attachment do
       :file_type,
       :byte_size,
       :resource_type,
-      :resource_id
+      :resource_id,
+      :status
     ])
     |> validate_required([:filename, :local_path, :resource_type])
+  end
+
+  def delete_changeset(attachment) do
+    attachment
+    |> change()
+    |> put_change(:status, :pending_delete)
+    |> put_change(:deleted_at, DateTime.utc_now() |> DateTime.truncate(:second))
   end
 end

--- a/lib/itsm/service.ex
+++ b/lib/itsm/service.ex
@@ -19,10 +19,10 @@ defmodule Itsm.Service do
         %User{} = user,
         %Category{} = category,
         crews,
-        handle_attachments,
+        consumer_fn,
         attrs \\ %{}
       )
-      when is_list(crews) and is_function(handle_attachments) do
+      when is_list(crews) and is_function(consumer_fn) do
     Multi.new()
     |> Multi.insert(:request, Requests.change_request(user, category, attrs))
     |> check_minimum_k_vms(attrs)
@@ -30,7 +30,7 @@ defmodule Itsm.Service do
       Approvals.create_approval(repo, request, user, attrs)
     end)
     |> Multi.run(:attachment, fn repo, %{request: request} ->
-      Attachments.create_attachments(repo, request, handle_attachments, attrs)
+      Attachments.create_attachments(repo, request, consumer_fn, attrs)
     end)
     |> Multi.run(:crew_reference, fn repo, %{request: request} ->
       Crews.create_crew_references(repo, request, crews)
@@ -50,10 +50,14 @@ defmodule Itsm.Service do
 
   def update_request(
         %Request{requestor_id: user_id} = request,
+        consumer_fn,
         %{"current_user" => %{id: user_id}} = attrs
       ) do
     Ecto.Multi.new()
     |> Ecto.Multi.update(:request, Request.changeset(request, attrs))
+    |> Multi.run(:attachment, fn repo, %{request: request} ->
+      Attachments.create_attachments(repo, request, consumer_fn, attrs)
+    end)
     |> sync_crew_references(request, attrs["referenced_crews"])
     |> Repo.transact()
     |> case do
@@ -71,13 +75,13 @@ defmodule Itsm.Service do
   def create_comment(
         resource,
         %User{} = user,
-        handle_attachments,
+        consumer_fn,
         attrs \\ %{}
       ) do
     Multi.new()
     |> Multi.insert(:comment, Comments.changeset_comment(resource, user, attrs))
     |> Multi.run(:attachments, fn repo, %{comment: comment} ->
-      Attachments.create_attachments(repo, comment, handle_attachments, attrs)
+      Attachments.create_attachments(repo, comment, consumer_fn, attrs)
     end)
     |> Repo.transact()
     |> case do

--- a/lib/itsm_web/live/common_k_create_vm_live/components.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/components.ex
@@ -1,5 +1,5 @@
 defmodule ItsmWeb.CommonKCreateVmLive.Components do
-  use ItsmWeb, :live_component
+  use ItsmWeb, :html
 
   alias Itsm.Workflow
   alias ItsmWeb.CustomComponents
@@ -122,38 +122,64 @@ defmodule ItsmWeb.CommonKCreateVmLive.Components do
     """
   end
 
+  attr :id, :string, required: true
+  attr :attachments_count, :integer, required: true
+  slot :inner_block, required: true
+
   def attachments_section(assigns) do
     ~H"""
     <div class="mt-8">
-      <h2 class="text-lg font-semibold text-zinc-700 mb-4">첨부파일 ({length(@attachments)})</h2>
+      <h2 class="text-lg font-semibold text-zinc-700 mb-4">첨부파일 ({@attachments_count})</h2>
       
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-        <div
-          :for={attachment <- @attachments}
-          class="group relative border border-zinc-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow cursor-pointer"
-          phx-click="view_attachment"
-          phx-value-filename={attachment.filename}
-          phx-value-id={attachment.id}
-        >
-          <div class="aspect-square bg-zinc-100">
-            <img
-              src={~p"/attachments/download/#{attachment.id}"}
-              alt={attachment.filename}
-              class="w-full h-full object-cover"
-            />
-          </div>
+      <div id={@id} class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4" phx-update="stream">
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :attachment, :any, required: true, doc: "%Itsm.Attachments.attachment{}"
+  attr :live_action, :atom, default: :view
+
+  def attachment(assigns) do
+    ~H"""
+    <div id={@id} class="relative group">
+      <div
+        class="group relative border border-zinc-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow cursor-pointer"
+        phx-click="view_attachment"
+        phx-value-filename={@attachment.filename}
+        phx-value-id={@attachment.id}
+      >
+        <div class="aspect-square bg-zinc-100">
+          <img
+            src={~p"/attachments/download/#{@attachment.id}"}
+            alt={@attachment.filename}
+            class="w-full h-full object-cover"
+          />
+        </div>
+        
+        <div class="p-2 bg-white">
+          <p class="text-xs text-zinc-700 truncate">{@attachment.filename}</p>
           
-          <div class="p-2 bg-white">
-            <p class="text-xs text-zinc-700 truncate">{attachment.filename}</p>
-            
-            <p class="text-xs text-zinc-400">{format_file_size(attachment.byte_size)}</p>
-          </div>
-          
-          <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-            <.icon name="hero-magnifying-glass-plus" class="w-8 h-8 text-white" />
-          </div>
+          <p class="text-xs text-zinc-400">{format_file_size(@attachment.byte_size)}</p>
+        </div>
+        
+        <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+          <.icon name="hero-magnifying-glass-plus" class="w-8 h-8 text-white" />
         </div>
       </div>
+      
+      <.button
+        :if={@live_action == :edit}
+        type="button"
+        class="top-2 right-2 p-1 bg-white/80 rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-50"
+        phx-click="delete_attachment"
+        phx-value-id={@attachment.id}
+        data-confirm="정말로 이 첨부파일을 삭제하시겠습니까?"
+      >
+        <.icon name="hero-x-mark" class="w-6 h-6 text-red-600" />
+      </.button>
     </div>
     """
   end

--- a/lib/itsm_web/live/common_k_create_vm_live/form.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/form.ex
@@ -9,6 +9,9 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   alias Itsm.Crews
   alias ItsmWeb.LiveUtils
   alias Itsm.CommonCodes
+  alias Itsm.Attachments
+
+  import ItsmWeb.CommonKCreateVmLive.Components
 
   def mount(_params, _session, socket) do
     {:ok,
@@ -16,6 +19,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
      |> LiveUtils.allow_uploads()
      |> assign(:conflict, false)
      |> assign(:form, to_form(Requests.change_request(%Request{})))
+     |> assign(:selected_attachment, nil)
      |> assign_new_options()}
   end
 
@@ -61,6 +65,26 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
     save_request(socket, socket.assigns.live_action, params)
   end
 
+  def handle_event("delete_attachment", %{"id" => id}, socket) do
+    %{current_user: current_user} = socket.assigns
+
+    case Attachments.delete_attachment(id, %{"current_user" => current_user}) do
+      {:ok, attachment} ->
+        {:noreply, stream_delete(socket, :attachments, attachment)}
+
+      {:error, _} ->
+        {:noreply, socket |> put_flash(:error, "Failed to delete attachment.")}
+    end
+  end
+
+  def handle_event("view_attachment", %{"id" => id, "filename" => filename}, socket) do
+    {:noreply, assign(socket, :selected_attachment, %{id: id, filename: filename})}
+  end
+
+  def handle_event("close_attachment", _, socket) do
+    {:noreply, assign(socket, :selected_attachment, nil)}
+  end
+
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
     handle_pubsub(action_user, event, item, socket)
   end
@@ -97,10 +121,14 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
       |> Requests.with_assoc(crew_references: [crew: [:users]])
       |> Requests.assign_referenced_crews()
 
+    attachments = Attachments.get_list_attachments(request)
+
     socket
     |> assign(:page_title, "Edit Request")
     |> assign(:request, request)
     |> assign(:form, to_form(Requests.change_request(request)))
+    |> assign(:attachments_count, length(attachments))
+    |> stream(:attachments, attachments, reset: true)
   end
 
   defp apply_action(socket, :copy, %{"id" => id}) do
@@ -115,7 +143,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   defp save_request(socket, :edit, params) do
     %{request: request} = socket.assigns
 
-    case Service.update_request(request, params) do
+    case Service.update_request(request, LiveUtils.build_attachment_consumer(socket), params) do
       {:ok, request} ->
         {:noreply,
          socket
@@ -142,7 +170,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
            user,
            category,
            crews,
-           fn -> LiveUtils.consume_attachments(socket) end,
+           LiveUtils.build_attachment_consumer(socket),
            params
          ) do
       {:ok, request} ->

--- a/lib/itsm_web/live/common_k_create_vm_live/form.html.heex
+++ b/lib/itsm_web/live/common_k_create_vm_live/form.html.heex
@@ -141,6 +141,19 @@
        <input type="hidden" name="request[common_k_create_vms_drop][]" />
     </div>
   </div>
+  
+  <.attachments_section
+    :if={@live_action == :edit and @attachments_count > 0}
+    id="attachments"
+    attachments_count={@attachments_count}
+  >
+    <.attachment
+      :for={{dom_id, attachment} <- @streams.attachments}
+      id={dom_id}
+      attachment={attachment}
+      live_action={@live_action}
+    />
+  </.attachments_section>
    <%!-- 파일업로드 --%>
   <label class="block text-sm font-semibold text-zinc-700 mb-2">{gettext("Attachments")}</label>
   <.live_file_input class="hidden" upload={@uploads.attachment} />
@@ -217,3 +230,8 @@
 </.form>
 
 <.back navigate={if @live_action == :new, do: ~p"/categories", else: ~p"/requests"}>Back</.back>
+
+<.attachment_modal
+  :if={@selected_attachment}
+  attachment={@selected_attachment}
+/>

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -9,6 +9,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
   alias Itsm.Requests
   alias ItsmWeb.LiveUtils
   alias Itsm.Service
+  alias Itsm.Attachments
 
   def mount(_params, _session, socket) do
     {:ok,
@@ -21,23 +22,27 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     if(connected?(socket)) do
       Itsm.Utils.subscribe(Requests, id)
       Itsm.Utils.subscribes(Requests)
+      Itsm.Utils.subscribes(Attachments)
     end
 
     request =
       Requests.get_request!(id)
       |> Requests.with_assoc([
         :category,
-        :attachments,
         requestor_crew: [:users],
         assignee_crew: [:users],
         crew_references: [crew: [:users]]
       ])
+
+    attachments = Attachments.get_list_attachments(request)
 
     {:noreply,
      socket
      |> assign(:page_title, "Show Request")
      |> assign(:request, request)
      |> assign(:selected_attachment, nil)
+     |> assign(:attachments_count, length(attachments))
+     |> stream(:attachments, attachments, reset: true)
      |> stream(:comments, Comments.list_comments(Requests.get_request!(id)), reset: true)}
   end
 
@@ -60,7 +65,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     case Service.create_comment(
            request,
            current_user,
-           fn -> LiveUtils.consume_attachments(socket) end,
+           LiveUtils.build_attachment_consumer(socket),
            comment_params
          ) do
       {:ok, comment} ->
@@ -86,6 +91,15 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp handle_pubsub(action_user, :delete_attachment = event, item, socket) do
+    opts = [resource_name: gettext("attachment"), stream_name: :attachments]
+
+    {:noreply,
+     socket
+     |> assign(:live_action, :index)
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
 
   defp handle_pubsub(
          action_user,

--- a/lib/itsm_web/live/common_k_create_vm_live/show.html.heex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.html.heex
@@ -6,9 +6,17 @@
       vms={@request.common_k_create_vms}
     />
     <.attachments_section
-      :if={Enum.any?(@request.attachments)}
-      attachments={@request.attachments}
-    /> <.comments_section streams={@streams} />
+      :if={@attachments_count > 1}
+      id="attachments"
+      attachments_count={@attachments_count}
+    >
+      <.attachment
+        :for={{dom_id, attachment} <- @streams.attachments}
+        id={dom_id}
+        attachment={attachment}
+      />
+    </.attachments_section>
+     <.comments_section streams={@streams} />
     <.comment_form
       :if={@request.status not in [:closed, :rejected]}
       form={@form}

--- a/lib/itsm_web/live_utils.ex
+++ b/lib/itsm_web/live_utils.ex
@@ -44,7 +44,11 @@ defmodule ItsmWeb.LiveUtils do
     )
   end
 
-  def consume_attachments(%Phoenix.LiveView.Socket{} = socket, upload_key \\ :attachment) do
+  def build_attachment_consumer(%Phoenix.LiveView.Socket{} = socket, upload_key \\ :attachment) do
+    fn -> consume_attachments(socket, upload_key) end
+  end
+
+  defp consume_attachments(%Phoenix.LiveView.Socket{} = socket, upload_key) do
     dest_dir = Application.get_env(:itsm, :upload_path) || "C:\\uploads"
     File.mkdir_p!(dest_dir)
 

--- a/priv/repo/migrations/20260106083104_create_attachments.exs
+++ b/priv/repo/migrations/20260106083104_create_attachments.exs
@@ -6,18 +6,15 @@ defmodule Itsm.Repo.Migrations.CreateAttachments do
       add :id, :binary_id, primary_key: true
       add :filename, :string
       add :local_path, :string
-      # add :content_type, :string
       add :file_type, :string
       add :byte_size, :integer
-
-      # Request와 연결 (삭제 시 파일 정보도 삭제되도록 on_delete: :delete_all)
-      # 다형성 컬럼으로 대체 ('26.01.06)
-      # add :request_id, references(:requests, type: :binary_id, on_delete: :delete_all)
+      add :status, :string, default: "active", null: false
 
       # 예: "Request", "Comment" 등
       add :resource_type, :string, null: false
       # 해당 테이블의 UUID
       add :resource_id, :binary_id, null: false
+      add :deleted_at, :utc_datetime
 
       timestamps(type: :utc_datetime)
     end


### PR DESCRIPTION
서비스 요청(Service Request) 편집 모드에서 첨부파일의 추가 및 삭제를 지원하고, 파일 처리 로직을 공통화하여 코드의 재사용성과 유지보수성을 향상합니다.

* **`Attachments.get_list_attachments/1` 메소드 추가**
    * 특정 리소스와 연결된 첨부파일 목록을 조회하는 표준화된 인터페이스를 제공합니다.
* **`build_attachment_consumer/1` 도입**
    * 기존의 `consume_attachments` 로직을 대체하여, Phoenix LiveView의 `consume_uploaded_entries`와 연동하기 쉬운 구조로 리팩토링합니다.
* **Schema 변경 (Migration 필요)**
    * `attachments` 테이블에 다음 컬럼을 추가합니다: * `status`: 파일의 현재 상태(예: `active`, `pending_delete`, `delete`) 관리 * `deleted_at`: 소프트 딜리트(Soft Delete) 구현을 위한 타임스탬프

* **컴포넌트 분리 (`ItsmWeb.CommonKCreateVmLive`)**
    * `attachments_section` 내부에 복잡하게 얽혀있던 개별 파일 렌더링 로직을 `attachment` 단일 컴포넌트로 분리합니다.
    * 이를 통해 개별 파일에 대한 삭제 버튼, 상태 표시 등의 기능을 독립적으로 관리할 수 있습니다.

* **Edit 모드 파일 편집 지원**
    * 기존에 생성 시에만 가능했던 파일 업로드 기능을 수정 페이지까지 확장합니다.
    * `deleted_at` 컬럼을 활용하여 수정 중 삭제된 파일이 즉시 DB에서 삭제되지 않고 최종 저장 시 처리되도록 구현합니다.
    * **build 폴더 삭제후 ecto.reset을 할것**

이슈 번호 : #112