### PR TITLE
[feat]"요청한 건" 페이징, 검색, 제어 드롭다운 메뉴

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -135,6 +135,26 @@
     .nav-hover-item {
         @apply hover:bg-gray-700 hover:text-white transition-all duration-200;
     }
+    /* KB 스타일의 슬림 스크롤바 */
+    .custom-scrollbar::-webkit-scrollbar {
+        height: 6px; /* 가로 스크롤 두께 */
+    }
+    .custom-scrollbar::-webkit-scrollbar-track {
+        @apply bg-kb-light-gray;
+    }
+    .custom-scrollbar::-webkit-scrollbar-thumb {
+        @apply bg-gray-300 rounded-full;
+    }
+    .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+        @apply bg-kb-yellow; /* 호버 시 KB 포인트 컬러 */
+    }
+
+    /* 텍스트 생략 유틸리티 강화 */
+    .truncate {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -102,3 +102,45 @@ liveSocket.connect();
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket;
+
+// 전역 타이머 변수 (중복 클릭 방지용)
+let copyToastTimeout;
+
+window.addEventListener("phx:copy", (event) => {
+  if ("clipboard" in navigator) {
+    navigator.clipboard.writeText(event.detail.text).then(() => {
+      const toast = document.getElementById("copy-toast");
+      if (!toast) return;
+
+      // 이전 타이머가 있다면 초기화
+      if (copyToastTimeout) clearTimeout(copyToastTimeout);
+
+      // 1. 나타나기
+      toast.classList.remove("hidden"); // 일단 DOM에는 표시
+
+      // 브라우저가 hidden 제거를 렌더링한 후 애니메이션 클래스를 적용하기 위해 requestAnimationFrame 사용
+      requestAnimationFrame(() => {
+        // KB 스타일 애니메이션 시작 상태 제거
+        toast.classList.remove("translate-y-[-20px]", "opacity-0");
+        // 실제 노출 상태 클래스 추가 (필요시 스타일 추가 정의)
+        toast.classList.add("translate-y-0", "opacity-100");
+      });
+
+      // 2. 2.5초 후 사라지기 (금융권 알림은 조금 더 오래 보여주는 경향이 있음)
+      copyToastTimeout = setTimeout(() => {
+        // 사라지는 애니메이션 적용
+        toast.classList.add("opacity-0");
+        toast.classList.remove("opacity-100");
+
+        // 애니메이션이 끝난 후 hidden 처리 (duration-300 고려)
+        setTimeout(() => {
+            toast.classList.add("hidden", "translate-y-[-20px]");
+        }, 300);
+      }, 2500);
+
+    }).catch(err => {
+      console.error("KB Style Copy Toast Failed: ", err);
+      // 실패 시 로직 (예: 빨간색 토스트)을 여기에 추가할 수 있습니다.
+    });
+  }
+});

--- a/lib/itsm/admin/requests.ex
+++ b/lib/itsm/admin/requests.ex
@@ -3,8 +3,6 @@ defmodule Itsm.Admin.Requests do
   alias Itsm.Repo
   alias Itsm.Service.Request
 
-  defdelegate list_requests, to: Itsm.Requests
-
   defdelegate get_request!(id), to: Itsm.Requests
 
   defdelegate change_request(request, attrs \\ %{}), to: Itsm.Requests

--- a/lib/itsm/requests.ex
+++ b/lib/itsm/requests.ex
@@ -14,12 +14,6 @@ defmodule Itsm.Requests do
     |> Repo.get!(id)
   end
 
-  def list_requests do
-    Request
-    |> Repo.all()
-    |> Repo.preload(:category)
-  end
-
   def with_assoc(%Request{} = request, preloads) do
     Repo.preload(request, preloads)
   end

--- a/lib/itsm_web/components/core_components.ex
+++ b/lib/itsm_web/components/core_components.ex
@@ -463,43 +463,70 @@ defmodule ItsmWeb.CoreComponents do
       end
 
     ~H"""
-    <div class="table-wrapper card-base !p-0 overflow-hidden shadow-sm">
-      <table class="table-kb">
-        <thead>
-          <tr>
-            <th :for={col <- @col} class="text-left">{col[:label]}</th>
-            
-            <th :if={@action != []} class="text-right">설정</th>
-          </tr>
-        </thead>
-        
-        <tbody
-          id={@id}
-          phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
-        >
-          <tr :for={row <- @rows} id={@row_id && @row_id.(row)} class="group">
-            <td
-              :for={{col, i} <- Enum.with_index(@col)}
-              phx-click={@row_click && @row_click.(row)}
-              class={[@row_click && "cursor-pointer"]}
+    <div class="table-wrapper card-base !p-0 shadow-sm border-t-2 border-kb-yellow overflow-hidden">
+      <div class="w-full overflow-x-auto block custom-scrollbar">
+        <table class="table-kb min-w-max w-full table-auto border-collapse">
+          <thead>
+            <tr class="bg-kb-light-gray">
+              <th
+                :for={col <- @col}
+                class="p-3 font-bold text-kb-medium-gray border-b-2 border-kb-border-gray text-left border-r border-kb-border-gray/50 last:border-r-0"
+              >
+                <span class="px-2">{col[:label]}</span>
+              </th>
+              
+              <th
+                :if={@action != []}
+                class="p-3 text-center bg-kb-light-gray border-b-2 border-kb-border-gray sticky right-0 bg-kb-light-gray shadow-[-4px_0_4px_rgba(0,0,0,0.05)]"
+              >
+                <.icon
+                  name="hero-adjustments-horizontal"
+                  class="w-5 h-5 text-kb-medium-gray group-hover:rotate-90 transition-transform duration-300"
+                />
+              </th>
+            </tr>
+          </thead>
+          
+          <tbody
+            id={@id}
+            phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
+            class="bg-white"
+          >
+            <tr
+              :for={row <- @rows}
+              id={@row_id && @row_id.(row)}
+              class="group hover:bg-yellow-50/40 transition-colors"
             >
-              <div class="block">
-                <span class={[i == 0 && "font-bold text-kb-dark-gray"]}>
-                  {render_slot(col, @row_item.(row))}
-                </span>
-              </div>
-            </td>
-            
-            <td :if={@action != []} class="text-right whitespace-nowrap">
-              <div class="flex justify-end gap-3">
-                <span :for={action <- @action} class="btn-text">
-                  {render_slot(action, @row_item.(row))}
-                </span>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <td
+                :for={{col, i} <- Enum.with_index(@col)}
+                phx-click={@row_click && @row_click.(row)}
+                class={[@row_click && "cursor-pointer"]}
+              >
+                <div class="block">
+                  <span class={[i == 0 && "font-bold text-kb-dark-gray"]}>
+                    {render_slot(col, @row_item.(row))}
+                  </span>
+                </div>
+              </td>
+              
+              <td
+                :if={@action != []}
+                class={[
+                  "sticky right-0 z-10 border-b border-kb-border-gray text-right whitespace-nowrap",
+                  "bg-white shadow-[-8px_0_10px_-5px_rgba(0,0,0,0.1)]",
+                  "group-hover:bg-[#FFF9E5]"
+                ]}
+              >
+                <div class="flex justify-end gap-3 px-2">
+                  <span :for={action <- @action} class="btn-text !text-xs">
+                    {render_slot(action, @row_item.(row))}
+                  </span>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     """
   end

--- a/lib/itsm_web/components/itsm_components.ex
+++ b/lib/itsm_web/components/itsm_components.ex
@@ -92,6 +92,7 @@ defmodule ItsmWeb.ItsmComponents do
         >
           {@label}
         </d>
+        
         <div
           id={"datepicker-input-#{@id}"}
           class="flex items-center border rounded-lg px-3 py-2 cursor-pointer hover:border-indigo-500 bg-white"
@@ -121,11 +122,12 @@ defmodule ItsmWeb.ItsmComponents do
             format={if @show_time, do: "datetime", else: "date"}
           >
           </div>
-          <span class="text-gray-400">📅</span>
+           <span class="text-gray-400">📅</span>
         </div>
+        
         <.error :for={msg <- @errors}>{msg}</.error>
       </div>
-
+      
       <div
         {@rests[:popup]}
         id={"#{@id}-calendar-popup"}
@@ -155,9 +157,9 @@ defmodule ItsmWeb.ItsmComponents do
               ◀
             </button>
           </div>
-
+          
           <div class="font-bold text-lg">{"#{@view_date.year}년 #{@view_date.month}월"}</div>
-
+          
           <div class="flex gap-1">
             <button
               type="button"
@@ -181,7 +183,7 @@ defmodule ItsmWeb.ItsmComponents do
             </button>
           </div>
         </div>
-
+        
         <div
           {@rests[:grid]}
           id={"#{@id}-calendar-grid"}
@@ -195,7 +197,7 @@ defmodule ItsmWeb.ItsmComponents do
           <div :for={day_name <- ~w(일 월 화 수 목 금 토)} class="text-xs text-gray-400 pb-2">
             {day_name}
           </div>
-
+          
           <div
             :for={{date, index} <- Enum.with_index(@days)}
             {@rests[:date]}
@@ -211,7 +213,7 @@ defmodule ItsmWeb.ItsmComponents do
             {date.day}
           </div>
         </div>
-
+        
         <div
           :if={@show_time}
           class="flex items-center justify-center gap-2 mt-4 pt-4 border-t border-gray-100"
@@ -298,7 +300,7 @@ defmodule ItsmWeb.ItsmComponents do
             value={@results.params.search_columns}
           />
         </div>
-
+        
         <div class="md:col-span-6">
           <label class="form-label">검색</label>
           <.input
@@ -309,7 +311,7 @@ defmodule ItsmWeb.ItsmComponents do
             phx-debounce="300"
           />
         </div>
-
+        
         <div class="md:col-span-2 flex justify-end pb-1">
           <.link
             patch={@results.current_path}
@@ -329,6 +331,7 @@ defmodule ItsmWeb.ItsmComponents do
     <div class="grid grid-cols-3 items-center w-full mt-6">
       <div class="justify-self-start flex items-center">
         <div class="text-sm text-zinc-600">Total: {@results.total_count}</div>
+        
         <form phx-change="update-filters" phx-target={@target} class="ml-4">
           <input
             type="number"
@@ -339,6 +342,7 @@ defmodule ItsmWeb.ItsmComponents do
           />
         </form>
       </div>
+      
       <nav class="justify-self-center flex gap-2 items-center">
         <div class="pagination flex items-center">
           <.link
@@ -351,7 +355,6 @@ defmodule ItsmWeb.ItsmComponents do
           <span :if={@results.params.page <= 1} class="pagination-item pagination-item-disabled">
             &lt;
           </span>
-
           <div class="pagination flex items-center">
             <span
               :for={
@@ -375,7 +378,6 @@ defmodule ItsmWeb.ItsmComponents do
               >
                 ...
               </span>
-
               <.link
                 patch={"#{@results.current_path}?#{Plug.Conn.Query.encode(Map.put(@results.params, :page, page_num))}"}
                 class={[
@@ -393,7 +395,7 @@ defmodule ItsmWeb.ItsmComponents do
               </span>
             </span>
           </div>
-
+          
           <.link
             :if={@results.params.page < @results.total_pages}
             patch={"#{@results.current_path}?#{Plug.Conn.Query.encode(Map.put(@results.params, :page, @results.params.page + 1))}"}
@@ -418,9 +420,7 @@ defmodule ItsmWeb.ItsmComponents do
 
   def common_code_label(assigns) do
     ~H"""
-    <span data-common-code={"#{@group}:#{@code}"}>
-      {Itsm.CommonCodes.get_label(@group, @code)}
-    </span>
+    <span data-common-code={"#{@group}:#{@code}"}>{Itsm.CommonCodes.get_label(@group, @code)}</span>
     """
   end
 
@@ -494,27 +494,27 @@ defmodule ItsmWeb.ItsmComponents do
     ~H"""
     <div class={["lds-spinner", @class]}>
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
-
+      
       <div></div>
     </div>
     """
@@ -531,7 +531,7 @@ defmodule ItsmWeb.ItsmComponents do
     ~H"""
     <div phx-feedback-for={@field.name}>
       <.label for={@field.id}>{@label}</.label>
-
+      
       <LiveSelect.live_select
         field={@field}
         allow_clear={true}
@@ -572,5 +572,26 @@ defmodule ItsmWeb.ItsmComponents do
       %{} ->
         false
     end
+  end
+
+  attr :value, :string, required: true, doc: "복사할 전체 텍스트"
+  attr :label, :string, default: nil, doc: "툴팁 등에 표시할 이름 (예: ID, Email)"
+  attr :slice_range, :integer, default: 8
+
+  def copyable_text(assigns) do
+    assigns =
+      assign_new(assigns, :title, fn ->
+        if assigns[:label], do: "Click to copy #{assigns.label}", else: "Click to copy"
+      end)
+
+    ~H"""
+    <span
+      class="font-mono text-blue-600 cursor-pointer hover:text-blue-800 hover:underline"
+      title={@title}
+      phx-click={JS.dispatch("phx:copy", detail: %{text: @value})}
+    >
+      {String.slice(@value, 0, @slice_range)}
+    </span>
+    """
   end
 end

--- a/lib/itsm_web/components/layouts/admin.html.heex
+++ b/lib/itsm_web/components/layouts/admin.html.heex
@@ -6,7 +6,7 @@
           <img src={~p"/images/itsm_banner.svg"} alt="KB ITSM" class="h-10 w-auto" />
         </a>
       </div>
-
+      
       <nav :if={@current_user} class="flex-1 px-4 py-6 space-y-2 overflow-y-auto no-scrollbar">
         <% current_path = assigns[:current_path] || ""
 
@@ -55,14 +55,13 @@
           href={menu.path}
           class={get_link_class.(menu.path)}
         >
-          <.icon name={get_icon_name.(menu.path)} class={get_icon_class.(menu.path)} />
-          {Gettext.gettext(
+          <.icon name={get_icon_name.(menu.path)} class={get_icon_class.(menu.path)} /> {Gettext.gettext(
             ItsmWeb.Gettext,
             menu.name
           )}
         </.link>
       </nav>
-
+      
       <div class="p-4 bg-[#24272b] border-t border-gray-700">
         <div class="flex items-center justify-between px-2 mb-4 bg-gray-800/50 rounded-full py-1.5 border border-gray-700">
           <% is_ko = Gettext.get_locale(ItsmWeb.Gettext) == "ko" %>
@@ -70,7 +69,7 @@
             KO
           </span>
           <.link
-            href={"?locale=#{if is_ko, do: "en", else: "ko"}"}
+            navigate={"?locale=#{if is_ko, do: "en", else: "ko"}"}
             class="relative inline-flex h-5 w-10 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-600 transition-colors duration-200"
           >
             <span class={"pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition duration-200 #{if is_ko, do: "translate-x-0", else: "translate-x-5"}"}>
@@ -80,7 +79,7 @@
             EN
           </span>
         </div>
-
+        
         <div :if={@current_user} class="flex items-center justify-between px-2 pt-2">
           <div class="flex flex-col min-w-0">
             <span class="text-[10px] text-gray-500 font-bold uppercase">Authorized User</span>
@@ -88,7 +87,7 @@
               {@current_user.email}
             </span>
           </div>
-
+          
           <div class="flex gap-1">
             <.link
               href={~p"/users/settings"}
@@ -108,7 +107,7 @@
       </div>
     </div>
   </aside>
-
+  
   <main class="flex-1 p-8">
     <div class="max-w-6xl mx-auto"><.flash_group flash={@flash} /> {@inner_content}</div>
   </main>

--- a/lib/itsm_web/components/layouts/default.html.heex
+++ b/lib/itsm_web/components/layouts/default.html.heex
@@ -19,14 +19,14 @@
 
         # 헬퍼 함수: 현재 경로와 일치하면 active 스타일 반환
         get_link_class = fn path ->
-          if current_path == path or String.starts_with?(current_path, path <> "/"),
+          if current_path == path,
             do: "#{struct_class} #{active_styles}",
             else: "#{struct_class} #{inactive_styles}"
         end
 
         # 헬퍼 함수: 아이콘 색상 제어
         get_icon_class = fn path ->
-          if current_path == path or String.starts_with?(current_path, path <> "/"),
+          if current_path == path,
             # 활성화 시 아이콘은 어두운 색
             do: "w-5 h-5 mr-3 text-kb-dark-gray",
             # 비활성화 시 노란색 -> 호버 시 흰색
@@ -57,6 +57,11 @@
         <.link navigate={~p"/crews"} class={get_link_class.(~p"/crews")}>
           <.icon name="hero-users" class={get_icon_class.(~p"/crews")} /> {gettext("My Crews")}
         </.link>
+        <.link navigate={~p"/crews/all"} class={get_link_class.(~p"/crews/all")}>
+          <.icon name="hero-rectangle-stack" class={get_icon_class.(~p"/crews/all")} /> {gettext(
+            "All Crews"
+          )}
+        </.link>
         <.link navigate={~p"/assets"} class={get_link_class.(~p"/assets")}>
           <.icon name="hero-computer-desktop" class={get_icon_class.(~p"/assets")} /> {gettext(
             "Assets"
@@ -82,7 +87,7 @@
             KO
           </span>
           <.link
-            href={"?locale=#{if is_ko, do: "en", else: "ko"}"}
+            navigate={"?locale=#{if is_ko, do: "en", else: "ko"}"}
             class="relative inline-flex h-5 w-10 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-600 transition-colors duration-200"
           >
             <span class={"pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition duration-200 #{if is_ko, do: "translate-x-0", else: "translate-x-5"}"}>

--- a/lib/itsm_web/components/layouts/root.html.heex
+++ b/lib/itsm_web/components/layouts/root.html.heex
@@ -13,6 +13,37 @@
   </head>
   
   <body class="bg-white">
+    <div
+      id="toast-container"
+      class="fixed top-5 right-5 z-[100] flex flex-col gap-3 pointer-events-none"
+    >
+      <div
+        id="copy-toast"
+        class="hidden items-start p-4 w-auto min-w-[300px] max-w-md bg-white border border-gray-100 rounded-lg shadow-2xl pointer-events-auto transition-all duration-300 ease-in-out transform translate-y-[-20px] opacity-0"
+        role="alert"
+      >
+        <div class="flex items-center gap-3">
+          <div class="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-full bg-[#FFBC00]/10 text-[#FFBC00]">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 13l4 4L19 7"
+              >
+              </path>
+            </svg>
+          </div>
+          
+          <div class="flex-col">
+            <h3 class="text-sm font-semibold text-gray-900">{gettext("Info")}</h3>
+            
+            <p class="text-xs text-gray-600 mt-1">{gettext("copied to clipboard.")}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    
     <div>{@inner_content}</div>
   </body>
 </html>

--- a/lib/itsm_web/live/request_live/index.ex
+++ b/lib/itsm_web/live/request_live/index.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.RequestLive.Index do
 
   alias Itsm.Requests
   alias Itsm.Service.Request
+  alias Itsm.Paging
 
   def mount(_params, _session, socket) do
     if connected?(socket), do: Itsm.Utils.subscribes(Requests)
@@ -10,12 +11,13 @@ defmodule ItsmWeb.RequestLive.Index do
     {:ok, stream(socket, :requests, [])}
   end
 
-  def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  def handle_params(params, url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, url, params)}
   end
 
-  def handle_event("delete", %{"id" => _id} = request_params, socket) do
-    %{current_user: user, request: request} = socket.assigns
+  def handle_event("delete", %{"id" => id} = request_params, socket) do
+    %{current_user: user} = socket.assigns
+    request = Requests.get_request!(id)
 
     {:ok, request} = Requests.delete_request(user, request, request_params)
 
@@ -30,19 +32,28 @@ defmodule ItsmWeb.RequestLive.Index do
     {:noreply, socket}
   end
 
-  defp apply_action(socket, :index, _params) do
+  defp apply_action(socket, :index, url, params) do
+    value =
+      Paging.search_and_pagination(
+        params,
+        url,
+        Request,
+        [
+          :title,
+          :description,
+          :env,
+          :requestor_name
+        ],
+        [:category, :requestor, :assignee_crew]
+      )
+
     socket
     |> assign(:page_title, "Listing Requests")
-    |> stream(:requests, Requests.list_requests(), reset: true)
+    |> assign(:results, value.results)
+    |> stream(:requests, value.entries, reset: true)
   end
 
-  defp apply_action(socket, :new, _params) do
-    socket
-    |> assign(:page_title, "New Requests")
-    |> assign(:request, %Request{})
-  end
-
-  defp apply_action(socket, :edit, %{"id" => id}) do
+  defp apply_action(socket, :edit, _url, %{"id" => id}) do
     socket
     |> assign(:page_title, "Edit Requests")
     |> assign(:request, Requests.get_request!(id))

--- a/lib/itsm_web/live/request_live/index.html.heex
+++ b/lib/itsm_web/live/request_live/index.html.heex
@@ -1,54 +1,58 @@
-<.header>Listing Requests</.header>
+<.header>{gettext("Listing Requests")}</.header>
 
-<.table
-  id="requests"
-  rows={@streams.requests}
-  row_click={
-    fn {_id, request} -> JS.navigate("/#{request.category.request_name}/#{request.id}") end
-  }
->
-  <:col :let={{_id, request}} label={gettext("Title")}>{request.title}</:col>
-
-  <:col
-    :let={{_id, request}}
-    label={gettext("Description")}
+<.itsm_table_container results={assigns[:results]}>
+  <.table
+    id="requests"
+    rows={@streams.requests}
+    row_click={
+      fn {_id, request} -> JS.navigate("/#{request.category.request_name}/#{request.id}") end
+    }
   >
-    <div class="w-[90px] truncate">{request.description}</div>
-  </:col>
-
-  <:col :let={{_id, request}} label={gettext("Environment")}>
-    <.common_code_label group="운영_구분" code={request.env} />
-  </:col>
-
-  <:col :let={{id, request}} label={gettext("Due Date")}>
-    <div id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date} />
-  </:col>
-
-  <:col :let={{_id, request}} label={gettext("Request Type")}>
-    {request.category.request_name}
-  </:col>
-
-  <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
-
-  <:action :let={{_id, request}}>
-    <div class="sr-only"><.link navigate={~p"/requests/#{request}"}>Show</.link></div>
-    <.link
-      :if={request.requestor_id == @current_user.id}
-      navigate={"/#{request.category.request_name}/#{request.id}/edit"}
-    >
-      Edit
-    </.link>
-  </:action>
-
-  <:action :let={{_id, request}}>
-    <.link
-      :if={request.requestor_id == @current_user.id}
-      id={request.id}
-      phx-click={JS.push("delete", value: %{id: request.id})}
-      class="phx-click-loading:opacity-50 phx-click-loading:cursor-wait"
-      data-confirm="Are you sure?"
-    >
-      Delete
-    </.link>
-  </:action>
-</.table>
+    <:col :let={{_id, request}} label={gettext("ID")}>
+      <.copyable_text label={gettext("ID")} value={request.id} />
+    </:col>
+    
+    <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
+    
+    <:col :let={{id, request}} label={gettext("Reqeust Date")}>
+      <div id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.inserted_at} />
+    </:col>
+    
+    <:col :let={{id, request}} label={gettext("Due Date")}>
+      <div id={"due_date_#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date} />
+    </:col>
+    
+    <:col :let={{_id, request}} label={gettext("Status")}>{request.status}</:col>
+    
+    <:col :let={{_id, request}} label={gettext("Title")}>{request.title}</:col>
+    
+    <:col :let={{_id, request}} label={gettext("Env")}>
+      <.common_code_label group="운영_구분" code={request.env} />
+    </:col>
+    
+    <:col :let={{_id, request}} label={gettext("Requestor Name")}>
+      {request.requestor.display_name}
+    </:col>
+    
+    <:col :let={{_id, request}} label={gettext("Action Crew")}>{request.assignee_crew.name}</:col>
+    
+    <:action :let={{_id, request}}>
+      <.dropdown_menu :if={request.requestor_id == @current_user.id} id={"#{request.id}-menu"}>
+        <.link
+          patch={"/#{request.category.request_name}/#{request.id}/edit"}
+          class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
+        >
+          <.icon name="hero-pencil" class="w-4 h-4" /> Edit
+        </.link>
+        <.link
+          phx-click="delete"
+          phx-value-id={request.id}
+          data-confirm="Are you sure?"
+          class="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
+        >
+          <.icon name="hero-trash" class="w-4 h-4" /> Delete
+        </.link>
+      </.dropdown_menu>
+    </:action>
+  </.table>
+</.itsm_table_container>

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -132,7 +132,7 @@ msgid "Only the creator can delete this delegation."
 msgstr "등록자만 이 위임을 삭제할 수 있습니다."
 
 msgid "Crew updated successfully"
-msgstr "Crew 변경이 성공하였습니다."
+msgstr "Crew 변경이 성공하였습니다"
 
 msgid "An unknown error occurred."
 msgstr "알 수 없는 오류가 발생했습니다."
@@ -141,7 +141,7 @@ msgid "New Delegation"
 msgstr "신규 대결"
 
 msgid "Listing Delegations"
-msgstr "대결 "
+msgstr "대결"
 
 msgid "Delete"
 msgstr "삭제"
@@ -260,7 +260,7 @@ msgid "Service Name"
 msgstr "서비스명"
 
 msgid "Is DMZ?"
-msgstr "DMZ 설치여부"
+msgstr "DMZ 설치여부?"
 
 msgid "Task Name"
 msgstr "작업명"
@@ -276,3 +276,24 @@ msgstr "한"
 
 msgid "EN"
 msgstr "영"
+
+msgid "Request Name"
+msgstr "요청명"
+
+msgid "Requestor Name"
+msgstr "요청자명"
+
+msgid "Reqeust Date"
+msgstr "요청일시"
+
+msgid "Status"
+msgstr "상태"
+
+msgid "Action Crew"
+msgstr "처리 Crew"
+
+msgid "Env"
+msgstr "환경"
+
+msgid "Listing Requests"
+msgstr "요청한 건"


### PR DESCRIPTION
- ID 클립보드복사 및 토스트 팝어 메뉴추가
- ID, 요청명, 요청일시, 완료기한, 상태, 제목, 환경, 요청자명, 처리 Crew 순으로 표춣
- 페이징 추가
- 번역 추가
- EN/KO 변경시 herf 대신 navigate로 변경
- 메뉴에 누락된 모든 Crews 추가

이슈 번호 : #128