### PR TITLE
feat/refactor: PubSub 구조 변경, Admin 첨부파일 기능 추가 및 Crews/Requests 페이징 추가(#121)

### DIFF
--- a/lib/itsm/access_logger.ex
+++ b/lib/itsm/access_logger.ex
@@ -98,7 +98,10 @@ defmodule Itsm.AccessLogger do
   end
 
   defp extract_user_id(nil), do: "anonymous_guest"
-  defp extract_user_id(user) when is_map(user), do: user.id || user[:email]
+
+  defp extract_user_id(user) when is_map(user),
+    do: Map.get(user, :id, Map.get(user, :email, "anonymous_guest"))
+
   defp extract_user_id(user), do: to_string(user)
 
   defp get_header(%Plug.Conn{} = conn, header_name) do

--- a/lib/itsm/accounts.ex
+++ b/lib/itsm/accounts.ex
@@ -88,6 +88,14 @@ defmodule Itsm.Accounts do
     %User{}
     |> User.registration_changeset(attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, user} ->
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {user, :register_user, user})
+        {:ok, user}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def register_user(%User{} = action_user, attrs) do
@@ -96,7 +104,7 @@ defmodule Itsm.Accounts do
     |> Repo.insert()
     |> case do
       {:ok, user} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :register_user, user})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :register_user, user})
         {:ok, user}
 
       {:error, changeset} ->
@@ -427,13 +435,27 @@ defmodule Itsm.Accounts do
 
   def list_users, do: Repo.all(User)
 
-  def create_user(%User{} = action_user, attrs \\ %{}) do
+  def create_user(attrs) do
     %User{}
-    |> User.changeset(attrs)
+    |> User.registration_changeset(attrs)
     |> Repo.insert()
     |> case do
       {:ok, user} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_user, user})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {user, :create_user, user})
+        {:ok, user}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  def create_user(%User{} = action_user, attrs) do
+    %User{}
+    |> User.registration_changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, user} ->
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_user, user})
         {:ok, user}
 
       {:error, changeset} ->
@@ -447,8 +469,7 @@ defmodule Itsm.Accounts do
     |> Repo.update()
     |> case do
       {:ok, user} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_user, user})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_user, user})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_user, user}, id: user.id)
         {:ok, user}
 
       {:error, changeset} ->
@@ -457,11 +478,14 @@ defmodule Itsm.Accounts do
   end
 
   def delete_user(%User{} = action_user, %{"id" => id}) do
-    Repo.delete(get_user!(id))
+    get_user!(id)
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.foreign_key_constraint(:id, name: :requests_requestor_id_fkey)
+    |> Repo.delete()
     |> case do
       {:ok, user} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_user, user})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_user, user})
+        Itsm.Accounts.UserToken.by_user_and_contexts_query(user, :all) |> Repo.delete_all()
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_user, user}, id: user.id)
         {:ok, user}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/accounts.ex
+++ b/lib/itsm/admin/accounts.ex
@@ -24,8 +24,7 @@ defmodule Itsm.Admin.Accounts do
     |> Repo.update()
     |> case do
       {:ok, user} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_user, user})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_user, user})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_user, user}, id: user.id)
         {:ok, user}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/approvals.ex
+++ b/lib/itsm/admin/approvals.ex
@@ -6,6 +6,8 @@ defmodule Itsm.Admin.Approvals do
 
   def get_approval!(id), do: Repo.get!(Approval, id)
 
+  defdelegate list_approvals_by_request(request_id), to: Itsm.Approvals
+
   def change_approval(%Approval{} = approval, attrs \\ %{}) do
     Approval.changeset(approval, attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
@@ -19,8 +21,8 @@ defmodule Itsm.Admin.Approvals do
     |> case do
       {:ok, approval} ->
         event = :update_approval
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, approval})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, approval})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, approval}, id: approval.id)
+
         {:ok, approval}
 
       {:error, changeset} ->
@@ -33,8 +35,8 @@ defmodule Itsm.Admin.Approvals do
     |> case do
       {:ok, approval} ->
         event = :delete_approval
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, approval})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, approval})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, approval}, id: approval.id)
+
         {:ok, approval}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/assets.ex
+++ b/lib/itsm/admin/assets.ex
@@ -22,8 +22,8 @@ defmodule Itsm.Admin.Assets do
     |> case do
       {:ok, asset} ->
         event = :update_asset
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, asset})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, asset})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, asset}, id: asset.id)
+
         {:ok, asset}
 
       {:error, changeset} ->
@@ -36,8 +36,7 @@ defmodule Itsm.Admin.Assets do
     |> case do
       {:ok, asset} ->
         event = :delete_asset
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, asset})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, asset})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, asset}, id: asset.id)
         {:ok, asset}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/attachments.ex
+++ b/lib/itsm/admin/attachments.ex
@@ -1,0 +1,46 @@
+defmodule Itsm.Admin.Attachments do
+  @moduledoc """
+  The Attachments context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Itsm.Repo
+  alias Itsm.Accounts.User
+  alias Itsm.Attachments.Attachment
+
+  defdelegate get_attachment!(id), to: Itsm.Attachments
+
+  def list_attachments_by_resource(resource) do
+    Attachment
+    |> where([a], a.resource_type == ^Itsm.Utils.resource_name(resource))
+    |> where([a], a.resource_id == ^resource.id)
+    |> Repo.all()
+  end
+
+  defdelegate create_attachment(action_user, attrs), to: Itsm.Attachments
+
+  def update_attachment(%User{} = action_user, %Attachment{} = attachment, attrs) do
+    attachment
+    |> Attachment.changeset(attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
+    |> Repo.update()
+    |> case do
+      {:ok, attachment} ->
+        attachment.broadcast(__MODULE__, {action_user, :update_attachment, attachment},
+          id: attachment.id
+        )
+
+        {:ok, attachment}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defdelegate delete_attachment(action_user, attrs), to: Itsm.Attachments
+
+  def change_attachment(%Attachment{} = attachment, attrs \\ %{}) do
+    Attachment.changeset(attachment, attrs)
+    |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
+  end
+end

--- a/lib/itsm/admin/boards.ex
+++ b/lib/itsm/admin/boards.ex
@@ -23,8 +23,10 @@ defmodule Itsm.Admin.Boards do
     |> Repo.update()
     |> case do
       {:ok, board} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_board, board})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_board, board})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_board, board},
+          id: board.id
+        )
+
         {:ok, board}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/categories.ex
+++ b/lib/itsm/admin/categories.ex
@@ -18,8 +18,7 @@ defmodule Itsm.Admin.Categories do
     |> case do
       {:ok, category} ->
         event = :create_category
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, category})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, category})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, category})
         {:ok, category}
 
       {:error, changeset} ->
@@ -35,8 +34,8 @@ defmodule Itsm.Admin.Categories do
     |> case do
       {:ok, category} ->
         event = :update_category
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, category})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, category})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, category}, id: category.id)
+
         {:ok, category}
 
       {:error, changeset} ->
@@ -49,8 +48,7 @@ defmodule Itsm.Admin.Categories do
     |> case do
       {:ok, category} ->
         event = :delete_category
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, category})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, category})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, category}, id: category.id)
         {:ok, category}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/comments.ex
+++ b/lib/itsm/admin/comments.ex
@@ -7,6 +7,8 @@ defmodule Itsm.Admin.Comments do
 
   def get_comment!(id), do: Repo.get!(Comment, id)
 
+  defdelegate list_comments_by_resource(resource), to: Itsm.Comments
+
   def change_comment(comment, attrs \\ %{}) do
     Comment.changeset(comment, attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
@@ -22,10 +24,8 @@ defmodule Itsm.Admin.Comments do
     |> case do
       {:ok, comment} ->
         event = :update_comment
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, comment})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, comment})
-        Itsm.Utils.broadcast(Requests, {action_user, event, comment})
-        Itsm.Utils.broadcasts(Requests, {action_user, event, comment})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, comment}, id: comment.id)
+        Itsm.PubSub.Helper.broadcast(Requests, {action_user, event, comment}, id: comment.id)
         {:ok, comment}
 
       {:error, changeset} ->
@@ -38,10 +38,8 @@ defmodule Itsm.Admin.Comments do
     |> case do
       {:ok, comment} ->
         event = :delete_comment
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, comment})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, comment})
-        Itsm.Utils.broadcast(Requests, {action_user, event, comment})
-        Itsm.Utils.broadcasts(Requests, {action_user, event, comment})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, comment}, id: comment.id)
+        Itsm.PubSub.Helper.broadcast(Requests, {action_user, event, comment}, id: comment.id)
         {:ok, comment}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/common_codes.ex
+++ b/lib/itsm/admin/common_codes.ex
@@ -18,7 +18,7 @@ defmodule Itsm.Admin.CommonCodes do
     |> case do
       {:ok, common_code} ->
         event = :create_common_code
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, common_code})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, common_code})
         {:ok, common_code}
 
       {:error, changeset} ->
@@ -34,8 +34,11 @@ defmodule Itsm.Admin.CommonCodes do
     |> case do
       {:ok, common_code} ->
         event = :update_common_code
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, common_code})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, common_code})
+
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, common_code},
+          id: common_code.id
+        )
+
         {:ok, common_code}
 
       {:error, changeset} ->
@@ -48,8 +51,11 @@ defmodule Itsm.Admin.CommonCodes do
     |> case do
       {:ok, common_code} ->
         event = :delete_common_code
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, common_code})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, common_code})
+
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, common_code},
+          id: common_code.id
+        )
+
         {:ok, common_code}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/crews.ex
+++ b/lib/itsm/admin/crews.ex
@@ -22,8 +22,8 @@ defmodule Itsm.Admin.Crews do
       {:ok, crew} ->
         crew = Repo.preload(crew, [:leader])
         event = :update_crew
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, crew})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, crew})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, crew}, id: crew.id)
+
         {:ok, crew}
 
       {:error, changeset} ->
@@ -36,8 +36,8 @@ defmodule Itsm.Admin.Crews do
     |> case do
       {:ok, crew} ->
         event = :delete_crew
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, crew})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, crew})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, crew}, id: crew.id)
+
         {:ok, crew}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/posts.ex
+++ b/lib/itsm/admin/posts.ex
@@ -25,8 +25,8 @@ defmodule Itsm.Admin.Posts do
     |> Repo.update()
     |> case do
       {:ok, post} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_post, post})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_post, post})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_post, post}, id: post.id)
+
         {:ok, post}
 
       {:error, changeset} ->

--- a/lib/itsm/admin/requests.ex
+++ b/lib/itsm/admin/requests.ex
@@ -19,8 +19,8 @@ defmodule Itsm.Admin.Requests do
     |> case do
       {:ok, request} ->
         event = :update_request
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, request})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, request})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, request}, id: request.id)
+
         {:ok, request}
 
       {:error, changeset} ->
@@ -29,16 +29,23 @@ defmodule Itsm.Admin.Requests do
   end
 
   def delete_request(%User{} = action_user, %{"id" => id}) do
-    Repo.delete(get_request!(id))
+    get_request!(id)
+    |> Request.delete_changeset()
+    |> Repo.delete()
     |> case do
       {:ok, request} ->
         event = :delete_request
-        Itsm.Utils.broadcast(__MODULE__, {action_user, event, request})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, event, request})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, event, request}, id: request.id)
+
         {:ok, request}
 
-      {:error, changeset} ->
-        {:error, changeset}
+      {:error,
+       %Ecto.Changeset{
+         errors: [
+           id: {message, [constraint: :foreign, constraint_name: "approvals_request_id_fkey"]}
+         ]
+       }} ->
+        {:error, :foreign_approvals, message}
     end
   end
 end

--- a/lib/itsm/approvals.ex
+++ b/lib/itsm/approvals.ex
@@ -10,18 +10,6 @@ defmodule Itsm.Approvals do
   alias Itsm.Finalization
 
   # ==================================================
-  # PubSub
-  # ==================================================
-
-  def subscribe_approvals_list do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "approvals_list")
-  end
-
-  def broadcast_approvals_list(message) do
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "approvals_list", message)
-  end
-
-  # ==================================================
   # 조회
   # ==================================================
 
@@ -62,7 +50,7 @@ defmodule Itsm.Approvals do
     )
     |> order_by(desc: :inserted_at)
     |> Repo.all()
-    |> Repo.preload([:category, :assignee_crew])
+    |> Repo.preload([:category, :assignee_crew, :requestor_crew])
   end
 
   # ==================================================
@@ -114,8 +102,8 @@ defmodule Itsm.Approvals do
           Finalization.execute_after_finish(approver, preloaded_request)
         end
 
-        broadcast_approvals_list({:request_updated, preloaded_request})
-        Itsm.Utils.broadcast(__MODULE__, {approver, :request_updated, preloaded_request})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {approver, :request_updated, preloaded_request})
+
         result
 
       error ->
@@ -136,7 +124,7 @@ defmodule Itsm.Approvals do
     |> repo.insert()
     |> case do
       {:ok, approval} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_approval, approval})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_approval, approval})
         {:ok, approval}
 
       {:error, changeset} ->
@@ -150,7 +138,7 @@ defmodule Itsm.Approvals do
     |> Repo.insert()
     |> case do
       {:ok, approval} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_approval, approval})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_approval, approval})
         {:ok, approval}
 
       {:error, changeset} ->

--- a/lib/itsm/assets.ex
+++ b/lib/itsm/assets.ex
@@ -15,29 +15,6 @@ defmodule Itsm.Assets do
   # @resource_preloads [:os_instance, :db_instances, :was_instances, :applications]
   @resource_preloads [:os_instance]
 
-  # ==================================================
-  # PubSub
-  # ==================================================
-
-  def subscribe_assets_list do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "assets_list")
-  end
-
-  def subscribe_asset(asset_id) do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "asset:#{asset_id}")
-  end
-
-  def broadcast_asset(asset, event_name) do
-    # Index.ex의 handle_info와 포맷을 맞추기 위해 튜플로 묶습니다.
-    # 예: {Itsm.Assets, [:asset, :created], %Asset{}}
-    message = {__MODULE__, event_name, asset}
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "assets_list", message)
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "asset:#{asset.id}", message)
-
-    # 함수 체이닝을 위해 결과를 반환해 줍니다.
-    {:ok, asset}
-  end
-
   @doc """
   Returns the list of assets.
 
@@ -101,8 +78,8 @@ defmodule Itsm.Assets do
     |> Repo.insert()
     |> case do
       {:ok, asset} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :create_asset, asset})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_asset, asset})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_asset, asset})
+
         {:ok, asset}
 
       {:error, changeset} ->
@@ -128,8 +105,10 @@ defmodule Itsm.Assets do
     |> Repo.update()
     |> case do
       {:ok, asset} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_asset, asset})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_asset, asset})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_asset, asset},
+          id: asset.id
+        )
+
         {:ok, asset}
 
       {:error, changeset} ->
@@ -153,8 +132,10 @@ defmodule Itsm.Assets do
     Repo.delete(get_asset!(id))
     |> case do
       {:ok, asset} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_asset, asset})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_asset, asset})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_asset, asset},
+          id: asset.id
+        )
+
         {:ok, asset}
 
       {:error, changeset} ->
@@ -229,11 +210,6 @@ defmodule Itsm.Assets do
 
     case result do
       {:ok, created_items} ->
-        # created_items는 [%{asset: asset1, ...}, %{asset: asset2, ...}] 형태의 리스트입니다.
-        Enum.each(created_items, fn %{asset: asset} ->
-          broadcast_asset(asset, [:asset, :created])
-        end)
-
         {:ok, created_items}
 
       {:error, reason} ->

--- a/lib/itsm/attachments.ex
+++ b/lib/itsm/attachments.ex
@@ -25,7 +25,7 @@ defmodule Itsm.Attachments do
     |> Repo.insert()
     |> case do
       {:ok, attachment} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_attachments, attachment})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_attachments, attachment})
 
         {:ok, attachment}
 
@@ -43,7 +43,7 @@ defmodule Itsm.Attachments do
       |> repo.insert()
       |> case do
         {:ok, attachment} ->
-          Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_attachments, attachment})
+          Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_attachments, attachment})
 
           {:cont, {:ok, [attachment | acc]}}
 
@@ -59,8 +59,9 @@ defmodule Itsm.Attachments do
     |> Repo.update()
     |> case do
       {:ok, attachment} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_attachment, attachment})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_attachment, attachment})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_attachment, attachment},
+          id: attachment.id
+        )
 
         {:ok, attachment}
 

--- a/lib/itsm/boards.ex
+++ b/lib/itsm/boards.ex
@@ -19,7 +19,7 @@ defmodule Itsm.Boards do
     |> Repo.insert()
     |> case do
       {:ok, board} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_board, board})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_board, board})
         {:ok, board}
 
       {:error, changeset} ->
@@ -33,8 +33,10 @@ defmodule Itsm.Boards do
     |> Repo.update()
     |> case do
       {:ok, board} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_board, board})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_board, board})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_board, board},
+          id: board.id
+        )
+
         {:ok, board}
 
       {:error, changeset} ->
@@ -46,8 +48,10 @@ defmodule Itsm.Boards do
     Repo.delete(get_board!(id))
     |> case do
       {:ok, board} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_board, board})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_board, board})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_board, board},
+          id: board.id
+        )
+
         {:ok, board}
 
       {:error, changeset} ->

--- a/lib/itsm/cache/common_code_cache.ex
+++ b/lib/itsm/cache/common_code_cache.ex
@@ -9,8 +9,7 @@ defmodule Itsm.CommonCodeCache do
 
   def init(_) do
     :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
-
-    Itsm.Utils.subscribes(CommonCodes)
+    Itsm.PubSub.Helper.subscribe(nil, CommonCodes)
 
     send(self(), :load_from_db)
     {:ok, %{}}

--- a/lib/itsm/comments.ex
+++ b/lib/itsm/comments.ex
@@ -7,17 +7,7 @@ defmodule Itsm.Comments do
   alias Itsm.Accounts.User
   alias Itsm.Utils
 
-  # 결과 처리
-  def broadcast_result({:ok, %{comment: comment}}, action_user) do
-    Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_comment, comment})
-    Itsm.Utils.broadcast(Requests, {action_user, :create_comment, comment})
-
-    {:ok, comment}
-  end
-
-  def broadcast_result({:error, _, failed, _}, _, _), do: {:error, failed}
-
-  def list_comments(resource) do
+  def list_comments_by_resource(resource) do
     Comment
     # "Request"
     |> where([c], c.resource_type == ^Utils.resource_name(resource))
@@ -50,10 +40,12 @@ defmodule Itsm.Comments do
         # 🌟 1. Show.ex 화면을 위해 :user와 :attachments 둘 다 Preload!
         preloaded_comment = Repo.preload(comment, [:user, :attachments])
 
-        # 🌟 2. 여기서 직접 PubSub 방송을 쏩니다! (기존 로직 활용)
-        # Requests.broadcast_request(resource.id, {:comment_created, preloaded_comment})
-        Itsm.Utils.broadcast(Requests, {action_user, :create_comment, preloaded_comment})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_comment, comment})
+        Itsm.PubSub.Helper.broadcast(Requests, {action_user, :create_comment, preloaded_comment},
+          id: resource.id,
+          only: :detail
+        )
+
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_comment, comment})
 
         {:ok, preloaded_comment}
 

--- a/lib/itsm/crews.ex
+++ b/lib/itsm/crews.ex
@@ -107,7 +107,7 @@ defmodule Itsm.Crews do
     |> case do
       {:ok, crew} ->
         crew = Repo.preload(crew, [:leader, :users])
-        Utils.broadcasts(__MODULE__, {action_user, :create_crew, {:crews, crew}})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_crew, {:crews, crew}})
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -126,7 +126,11 @@ defmodule Itsm.Crews do
       |> repo.insert()
       |> case do
         {:ok, crew_reference} ->
-          Utils.broadcasts(__MODULE__, {action_user, :create_crew_references, crew_reference})
+          Itsm.PubSub.Helper.broadcast(
+            __MODULE__,
+            {action_user, :create_crew_references, crew_reference}
+          )
+
           {:cont, {:ok, [crew_reference | acc]}}
 
         {:error, reason} ->
@@ -147,8 +151,10 @@ defmodule Itsm.Crews do
     |> Repo.update()
     |> case do
       {:ok, crew} ->
-        Utils.broadcast(__MODULE__, crew, {action_user, :add_users, {:crew, add_users}})
-        Utils.broadcasts(__MODULE__, {action_user, :add_users, {:crews, crew}})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :add_users, {:crew, add_users}},
+          id: crew.id
+        )
+
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -162,8 +168,9 @@ defmodule Itsm.Crews do
     with :ok <- ensure_leader(crew, action_user),
          :ok <- ensure_crew(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
-      Utils.broadcast(__MODULE__, crew, {action_user, :switch_leader, {:crew, crew}})
-      Utils.broadcasts(__MODULE__, {action_user, :switch_leader, {:crews, crew}})
+      Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :switch_leader, {:crew, crew}},
+        id: crew.id
+      )
 
       {:ok, crew}
     else
@@ -181,7 +188,7 @@ defmodule Itsm.Crews do
 
     with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
-      Utils.broadcasts(__MODULE__, {action_user, :update_crew, {:crews, crew}})
+      Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_crew, {:crews, crew}})
       {:ok, crew}
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -197,8 +204,9 @@ defmodule Itsm.Crews do
 
     with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.delete(crew) do
-      Utils.broadcast(__MODULE__, crew, {action_user, :delete_crew, {:crew, crew}})
-      Utils.broadcasts(__MODULE__, {action_user, :delete_crew, {:crews, crew}})
+      Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_crew, {:crew, crew}},
+        id: crew.id
+      )
 
       {:ok, crew}
     else
@@ -215,8 +223,9 @@ defmodule Itsm.Crews do
 
     with :ok <- ensure_delete_auth(crew, target_user, action_user),
          {:ok, _} <- Repo.delete(crews_users) do
-      Utils.broadcast(__MODULE__, crew, {action_user, :delete_user, {:crew, target_user}})
-      Utils.broadcasts(__MODULE__, {action_user, :delete_user, {:crews, crew, target_user}})
+      Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_user, {:crew, target_user}},
+        id: crew.id
+      )
 
       {:ok, target_user}
     else

--- a/lib/itsm/delegations.ex
+++ b/lib/itsm/delegations.ex
@@ -9,15 +9,6 @@ defmodule Itsm.Delegations do
   alias Itsm.Delegations.Delegation
   alias Itsm.Accounts.User
 
-  # ✅ 모든 delegation 리스트 변경사항 구독 (생성, 업데이트 등)
-  def subscribe_delegation_list do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "delegation_list")
-  end
-
-  def broadcast_delegation_list(message) do
-    Phoenix.PubSub.broadcast(Itsm.PubSub, "delegation_list", message)
-  end
-
   @doc """
   Returns the list of delegations.
 
@@ -106,7 +97,7 @@ defmodule Itsm.Delegations do
     |> Repo.insert()
     |> case do
       {:ok, delegation} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_delegation, delegation})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_delegation, delegation})
 
         {:ok, delegation}
 
@@ -209,8 +200,10 @@ defmodule Itsm.Delegations do
       |> Repo.delete()
       |> case do
         {:ok, delegation} ->
-          Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_delegation, delegation})
-          Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_delegation, delegation})
+          Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_delegation, delegation},
+            id: delegation.id
+          )
+
           {:ok, delegation}
 
         {:error, delegation} ->

--- a/lib/itsm/evaluations.ex
+++ b/lib/itsm/evaluations.ex
@@ -56,7 +56,7 @@ defmodule Itsm.Evaluations do
     |> Repo.insert()
     |> case do
       {:ok, evaluation} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_evaluation, evaluation})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_evaluation, evaluation})
         {:ok, evaluation}
 
       {:error, changeset} ->
@@ -82,8 +82,10 @@ defmodule Itsm.Evaluations do
     |> Repo.update()
     |> case do
       {:ok, evaluation} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_evaluation, evaluation})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_evaluation, evaluation})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_evaluation, evaluation},
+          id: evaluation.id
+        )
+
         {:ok, evaluation}
 
       {:error, changeset} ->
@@ -107,8 +109,10 @@ defmodule Itsm.Evaluations do
     Repo.delete(get_evaluation!(id))
     |> case do
       {:ok, evaluation} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_evaluation, evaluation})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_evaluation, evaluation})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_evaluation, evaluation},
+          id: evaluation.id
+        )
+
         {:ok, evaluation}
 
       {:error, changeset} ->

--- a/lib/itsm/os_instances.ex
+++ b/lib/itsm/os_instances.ex
@@ -56,7 +56,7 @@ defmodule Itsm.OsInstances do
     |> Repo.insert()
     |> case do
       {:ok, os_istance} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_os_instance, os_istance})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_os_instance, os_istance})
 
         {:ok, os_istance}
 
@@ -82,10 +82,12 @@ defmodule Itsm.OsInstances do
     |> OsInstance.changeset(attrs)
     |> Repo.update()
     |> case do
-      {:ok, os_istance} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_os_instance, os_istance})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_os_instance, os_istance})
-        {:ok, os_istance}
+      {:ok, os_instance} ->
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_os_instance, os_instance},
+          id: os_instance.id
+        )
+
+        {:ok, os_instance}
 
       {:error, changeset} ->
         {:error, changeset}
@@ -107,10 +109,12 @@ defmodule Itsm.OsInstances do
   def delete_os_instance(%User{} = action_user, %{"id" => id}) do
     Repo.delete(get_os_instance!(id))
     |> case do
-      {:ok, os_istance} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_os_instance, os_istance})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_os_instance, os_istance})
-        {:ok, os_istance}
+      {:ok, os_instance} ->
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_os_instance, os_instance},
+          id: os_instance.id
+        )
+
+        {:ok, os_instance}
 
       {:error, changeset} ->
         {:error, changeset}

--- a/lib/itsm/paging.ex
+++ b/lib/itsm/paging.ex
@@ -135,7 +135,7 @@ defmodule Itsm.Paging do
           url :: String.t(),
           opts :: [
             default_columns: [atom() | {atom(), atom() | tuple()} | list()],
-            preloads: [atom() | {atom(), atom() | tuple()} | list()],
+            preloads: [atom() | {atom(), atom() | tuple() | list(atom())} | list(atom())],
             range_columns: [atom()],
             column_custom_label: map(),
             query_cond: atom()

--- a/lib/itsm/paging.ex
+++ b/lib/itsm/paging.ex
@@ -135,7 +135,7 @@ defmodule Itsm.Paging do
           url :: String.t(),
           opts :: [
             default_columns: [atom() | {atom(), atom() | tuple()} | list()],
-            preloads: [atom()],
+            preloads: [atom() | {atom(), atom() | tuple()} | list()],
             range_columns: [atom()],
             column_custom_label: map(),
             query_cond: atom()
@@ -210,11 +210,17 @@ defmodule Itsm.Paging do
       page: page,
       page_size: page_size,
       search: search,
-      search_columns: formatted_columns,
+      search_columns: formatted_columns
+    }
+
+    range_params = %{
       range_column: formatted_range_column,
       start_date: start_date,
       end_date: end_date
     }
+
+    results_params =
+      if range_columns != [], do: Map.merge(results_params, range_params), else: results_params
 
     %{
       entries: entries,
@@ -452,11 +458,11 @@ defmodule Itsm.Paging do
     end
   end
 
-  def build_optimized_preloads(%Ecto.Query{from: %{source: {_, module}}}, preloads) do
+  defp build_optimized_preloads(%Ecto.Query{from: %{source: {_, module}}}, preloads) do
     do_build_optimized_preloads(module, preloads)
   end
 
-  def build_optimized_preloads(schema, preloads) do
+  defp build_optimized_preloads(schema, preloads) do
     do_build_optimized_preloads(schema, preloads)
   end
 

--- a/lib/itsm/posts.ex
+++ b/lib/itsm/posts.ex
@@ -25,7 +25,7 @@ defmodule Itsm.Posts do
     |> Repo.insert()
     |> case do
       {:ok, post} ->
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_post, post})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_post, post})
         {:ok, post}
 
       {:error, changeset} ->
@@ -43,8 +43,8 @@ defmodule Itsm.Posts do
     |> Repo.update()
     |> case do
       {:ok, post} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_post, post})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_post, post})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_post, post}, id: post.id)
+
         {:ok, post}
 
       {:error, changeset} ->
@@ -56,8 +56,8 @@ defmodule Itsm.Posts do
     Repo.delete(get_post!(id))
     |> case do
       {:ok, post} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_post, post})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_post, post})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_post, post}, id: post.id)
+
         {:ok, post}
 
       {:error, changeset} ->

--- a/lib/itsm/pub_sub/helper.ex
+++ b/lib/itsm/pub_sub/helper.ex
@@ -1,0 +1,107 @@
+defmodule Itsm.PubSub.Helper do
+  import Phoenix.LiveView, only: [connected?: 1]
+
+  def subscribe(socket_or_nil, domain, opts \\ [])
+
+  def subscribe(%Phoenix.LiveView.Socket{} = socket, domain, opts) do
+    if connected?(socket) do
+      current_user = socket.assigns.current_user
+      affiliate = Keyword.get(opts, :affiliate, find_affiliate(current_user))
+
+      subscribe(nil, domain, Keyword.put(opts, :affiliate, affiliate))
+    end
+
+    socket
+  end
+
+  def subscribe(nil, domain, opts) do
+    id = Keyword.get(opts, :id)
+    only = Keyword.get(opts, :only, :all)
+    affiliate = Keyword.get(opts, :affiliate)
+    is_admin = Keyword.get(opts, :is_admin)
+
+    if only in [:all, :list] do
+      if is_admin do
+        Phoenix.PubSub.subscribe(Itsm.PubSub, "admin:#{get_topic(domain)}")
+      else
+        if !is_nil(affiliate),
+          do: Phoenix.PubSub.subscribe(Itsm.PubSub, "#{affiliate}:#{get_topic(domain)}")
+
+        Phoenix.PubSub.subscribe(Itsm.PubSub, "common:#{get_topic(domain)}")
+      end
+    end
+
+    if id && only in [:all, :detail] do
+      if is_admin do
+        Phoenix.PubSub.subscribe(Itsm.PubSub, "admin:#{get_topic(domain)}:#{id}")
+      else
+        if !is_nil(affiliate),
+          do: Phoenix.PubSub.subscribe(Itsm.PubSub, "#{affiliate}:#{get_topic(domain)}:#{id}")
+
+        Phoenix.PubSub.subscribe(Itsm.PubSub, "common:#{get_topic(domain)}:#{id}")
+      end
+    end
+  end
+
+  def broadcast(domain, message, opts \\ []) do
+    id = Keyword.get(opts, :id)
+    only = Keyword.get(opts, :only, :all)
+    affiliate = Keyword.get(opts, :affiliate, extract_affiliate(message)) || "common"
+
+    if only in [:all, :list] do
+      topic = "#{get_topic(domain)}"
+
+      Phoenix.PubSub.broadcast_from(
+        Itsm.PubSub,
+        self(),
+        "#{affiliate}:#{topic}",
+        {:pubsub, message}
+      )
+
+      Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), "admin:#{topic}", {:pubsub, message})
+    end
+
+    if id && only in [:all, :detail] do
+      topic = "#{get_topic(domain)}:#{id}"
+
+      Phoenix.PubSub.broadcast_from(
+        Itsm.PubSub,
+        self(),
+        "#{affiliate}:#{topic}",
+        {:pubsub, message}
+      )
+
+      Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), "admin:#{topic}", {:pubsub, message})
+    end
+  end
+
+  defp get_topic(%{__struct__: module}), do: extract_domain(module)
+
+  defp get_topic(module) when is_atom(module) do
+    if module |> to_string() |> String.starts_with?("Elixir."),
+      do: extract_domain(module),
+      else: module
+  end
+
+  defp get_topic(anything_else), do: anything_else
+
+  defp extract_domain(input) do
+    input
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+  end
+
+  defp extract_affiliate({_user, _event, data}), do: find_affiliate(data)
+  defp extract_affiliate({_event, data}), do: find_affiliate(data)
+  defp extract_affiliate(data), do: find_affiliate(data)
+
+  defp find_affiliate({data, _extra}) when is_map(data), do: find_affiliate(data)
+
+  defp find_affiliate(%{affiliate: affiliate}), do: affiliate
+  defp find_affiliate(%{organization_code: organization_code}), do: organization_code
+  defp find_affiliate(%{organization: organization_code}), do: organization_code
+  defp find_affiliate(%{category: %{affiliate: affiliate}}), do: affiliate
+
+  defp find_affiliate(_), do: nil
+end

--- a/lib/itsm/requests.ex
+++ b/lib/itsm/requests.ex
@@ -54,7 +54,7 @@ defmodule Itsm.Requests do
     |> case do
       {:ok, request} ->
         request = Repo.preload(request, :category)
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_request, request})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_request, request})
         {:ok, request}
 
       {:error, _} = error ->
@@ -68,8 +68,10 @@ defmodule Itsm.Requests do
     Repo.delete(get_request!(id))
     |> case do
       {:ok, request} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_request, request})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_request, request})
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_request, request},
+          id: request.id
+        )
+
         {:ok, request}
 
       {:error, _} = error ->

--- a/lib/itsm/service.ex
+++ b/lib/itsm/service.ex
@@ -39,8 +39,7 @@ defmodule Itsm.Service do
     |> case do
       {:ok, %{request: request}} ->
         request = Repo.preload(request, [:category, :attachments])
-        Approvals.broadcast_approvals_list({:request_created, request})
-        Itsm.Utils.broadcasts(Requests, {action_user, :created_request, request})
+        Itsm.PubSub.Helper.broadcast(Requests, {action_user, :created_request, request})
         {:ok, request}
 
       error ->
@@ -64,8 +63,11 @@ defmodule Itsm.Service do
     |> case do
       {:ok, %{request: request}} ->
         request = Repo.preload(request, :category)
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :update_request, request})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_request, request})
+
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_request, request},
+          id: request.id
+        )
+
         {:ok, request}
 
       error ->
@@ -87,9 +89,13 @@ defmodule Itsm.Service do
     |> Repo.transact()
     |> case do
       {:ok, %{comment: comment, attachments: attachments}} ->
-        Itsm.Utils.broadcasts(Comments, {action_user, :create_comment, comment})
-        Itsm.Utils.broadcast(Requests, resource, {action_user, :create_comment, comment})
-        Itsm.Utils.broadcasts(Attachments, {action_user, :create_attachments, attachments})
+        Itsm.PubSub.Helper.broadcast(Requests, {action_user, :create_comment, comment},
+          id: resource.id,
+          only: :detail
+        )
+
+        Itsm.PubSub.Helper.broadcast(Comments, {action_user, :create_comment, comment})
+        Itsm.PubSub.Helper.broadcast(Attachments, {action_user, :create_attachments, attachments})
         {:ok, comment}
 
       {:error, _} = error ->

--- a/lib/itsm/service/request.ex
+++ b/lib/itsm/service/request.ex
@@ -94,4 +94,27 @@ defmodule Itsm.Service.Request do
     |> assoc_constraint(:category)
     |> cast_assoc(:attachments, with: &Attachment.changeset/2)
   end
+
+  def delete_changeset(%Ecto.Changeset{} = request) do
+    request
+    |> foreign_key_constraint(:id,
+      name: :approvals_request_id_fkey,
+      message: "결제를 먼저 지워주세요"
+    )
+
+    # |> foreign_key_constraint(:id,
+    #   name: :comments_request_id_fkey,
+    #   message: "댓글을 먼저 지워주세요"
+    # )
+    # |> foreign_key_constraint(:id,
+    #   name: :attachments_request_id_fkey,
+    #   message: "첨부파일을 먼저 지워주세요"
+    # )
+  end
+
+  def delete_changeset(%__MODULE__{} = request) do
+    request
+    |> change()
+    |> delete_changeset()
+  end
 end

--- a/lib/itsm/utils.ex
+++ b/lib/itsm/utils.ex
@@ -26,28 +26,6 @@ defmodule Itsm.Utils do
     Ecto.Changeset.put_change(changeset, field, value)
   end
 
-  def broadcast(domain, %{id: id}, message) do
-    topic = "#{get_topic(domain)}:#{id}"
-    Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), topic, {:pubsub, message})
-  end
-
-  def broadcast(domain, message) do
-    topic = "#{get_topic(domain)}:#{extract_id(message)}"
-    Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), topic, {:pubsub, message})
-  end
-
-  def broadcasts(domain, message) do
-    Phoenix.PubSub.broadcast_from(Itsm.PubSub, self(), "#{get_topic(domain)}", {:pubsub, message})
-  end
-
-  def subscribe(domain, id) do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "#{get_topic(domain)}:#{id}")
-  end
-
-  def subscribes(domain) do
-    Phoenix.PubSub.subscribe(Itsm.PubSub, "#{get_topic(domain)}")
-  end
-
   def maybe_parse_json(attrs, key) do
     metadata = attrs[Atom.to_string(key)] || attrs[key]
 
@@ -67,28 +45,4 @@ defmodule Itsm.Utils do
   def blank?(nil), do: true
   def blank?(""), do: true
   def blank?(_), do: false
-
-  defp get_topic(%{__struct__: module}), do: extract_domain(module)
-
-  defp get_topic(module) when is_atom(module) do
-    if module |> to_string() |> String.starts_with?("Elixir."),
-      do: extract_domain(module),
-      else: module
-  end
-
-  defp get_topic(anything_else), do: anything_else
-
-  defp extract_domain(input) do
-    input
-    |> Module.split()
-    |> List.last()
-    |> Macro.underscore()
-  end
-
-  defp extract_id({_user, _event, data}), do: find_id(data)
-  defp extract_id({_event, data}), do: find_id(data)
-
-  defp find_id(%{id: id}), do: id
-  defp find_id({%{id: id}, _extra}), do: id
-  defp find_id(_), do: nil
 end

--- a/lib/itsm_web/components/create_comment_dialog.ex
+++ b/lib/itsm_web/components/create_comment_dialog.ex
@@ -80,8 +80,7 @@ defmodule ItsmWeb.CreateCommentDialog do
        |> clear_flash()
        |> push_patch(to: ~p"/approvals")}
     else
-      {:error, %Ecto.Changeset{} = changeset} ->
-        IO.inspect(changeset, label: "Approval Error")
+      {:error, %Ecto.Changeset{}} ->
         {:noreply, put_flash(socket, :error, "Failed")}
     end
   end

--- a/lib/itsm_web/components/itsm_components.ex
+++ b/lib/itsm_web/components/itsm_components.ex
@@ -287,7 +287,7 @@ defmodule ItsmWeb.ItsmComponents do
         phx-target={@target}
       >
         <div
-          :if={@results.range_column_options != []}
+          :if={@results.range_column_options != [] and @results.range_column_options != [""]}
           class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end"
         >
           <div class="md:col-span-4">
@@ -333,7 +333,13 @@ defmodule ItsmWeb.ItsmComponents do
             </div>
           </div>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end">
+        <div
+          :if={
+            @results.columns_options != [] and @results.columns_options != [""] and
+              @results.columns_options != ["전체"]
+          }
+          class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end"
+        >
           <div class="md:col-span-4">
             <label class="form-label">검색 컬럼 선택</label>
             <.input

--- a/lib/itsm_web/live/admin/approval_live/index.ex
+++ b/lib/itsm_web/live/admin/approval_live/index.ex
@@ -6,9 +6,10 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Approvals)
-
-    {:ok, stream(socket, :approvals, [])}
+    {:ok,
+     socket
+     |> stream(:approvals, [])
+     |> Itsm.PubSub.Helper.subscribe(Approvals, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -31,7 +32,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
   defp apply_action(socket, :index, params, url) do
     opts = [
       default_columns: [:status, :action, :approver_name],
-      preloads: [request: [category: :name]]
+      preloads: [request: [:title, category: :name]]
     ]
 
     value =
@@ -61,7 +62,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.Index do
       context_key: :approval,
       resource_name: gettext("Approval"),
       stream_name: :approvals,
-      push_patch: [to: ~p"/admin/approvals?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/approval_live/index.html.heex
+++ b/lib/itsm_web/live/admin/approval_live/index.html.heex
@@ -7,6 +7,9 @@
     rows={@streams.approvals}
     row_click={fn {_id, approval} -> JS.navigate(~p"/admin/approvals/#{approval}") end}
   >
+    <:col :let={{_id, approval}} label={gettext("request")}>
+      {approval.request.title}
+    </:col>
     <:col :let={{_id, approval}} label={gettext("Category")}>
       {approval.request.category.name}
     </:col>

--- a/lib/itsm_web/live/admin/approval_live/show.ex
+++ b/lib/itsm_web/live/admin/approval_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Approvals, id)
-      Itsm.Utils.subscribes(Approvals)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:approval, Approvals.get_approval!(id) |> Approvals.preload_category())}
+     |> assign(:approval, Approvals.get_approval!(id) |> Approvals.preload_category())
+     |> Itsm.PubSub.Helper.subscribe(Approvals, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
        ) do
     opts =
       [context_key: :approval, resource_name: gettext("Approval")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.ApprovalLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_approval),
-    do: [push_navigate: [to: ~p"/admin/approvals"]]
+  defp push_event_action(socket, :delete_approval),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/asset_live/index.ex
+++ b/lib/itsm_web/live/admin/asset_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Assets)
-
-    {:ok, stream(socket, :assets, [])}
+    {:ok, socket |> stream(:assets, []) |> Itsm.PubSub.Helper.subscribe(Assets, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -72,7 +70,7 @@ defmodule ItsmWeb.Admin.AssetLive.Index do
       context_key: :asset,
       resource_name: gettext("Asset"),
       stream_name: :assets,
-      push_patch: [to: ~p"/admin/assets?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/asset_live/show.ex
+++ b/lib/itsm_web/live/admin/asset_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Assets, id)
-      Itsm.Utils.subscribes(Assets)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:asset, Assets.get_asset!(id))}
+     |> assign(:asset, Assets.get_asset!(id))
+     |> Itsm.PubSub.Helper.subscribe(Assets, id: id, is_admin: true)}
   end
 
   def handle_event("live_select_change", %{"text" => text, "id" => live_select_id}, socket) do
@@ -47,7 +43,7 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
        ) do
     opts =
       [context_key: :asset, resource_name: gettext("Asset")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -58,8 +54,8 @@ defmodule ItsmWeb.Admin.AssetLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_asset),
-    do: [push_navigate: [to: ~p"/admin/assets"]]
+  defp push_event_action(socket, :delete_asset),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/attachment_live/form_component.ex
+++ b/lib/itsm_web/live/admin/attachment_live/form_component.ex
@@ -1,0 +1,112 @@
+defmodule ItsmWeb.Admin.AttachmentLive.FormComponent do
+  use ItsmWeb, :live_component
+
+  alias Itsm.Admin.Attachments
+
+  def update(%{conflict: {event, user}} = _assigns, socket) do
+    msg = if String.contains?(to_string(event), "delete"), do: "삭제", else: "수정"
+
+    {:ok,
+     socket
+     |> assign(:conflict, true)
+     |> assign(:conflict_msg, "#{user.display_name}님이 데이터를 #{msg}했습니다.")}
+  end
+
+  def update(%{attachment: attachment} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:conflict, false)
+     |> assign_new(:form, fn ->
+       to_form(Attachments.change_attachment(attachment))
+     end)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        {@title}
+        <:subtitle>Use this form to manage attachment records in your database.</:subtitle>
+      </.header>
+
+      <div
+        :if={@conflict}
+        class="p-4 mb-4 bg-red-50 border border-red-200 text-red-800 rounded animate-pulse"
+      >
+        <div class="flex items-center gap-2 font-bold">
+          <span>⚠️ 충돌 발생!</span>
+        </div>
+        <p class="mt-1 text-sm">{@conflict_msg}</p>
+        <p class="mt-2 text-xs opacity-75">현재 편집 내용을 저장할 수 없습니다. 창을 닫고 다시 시도해 주세요.</p>
+      </div>
+
+      <.simple_form
+        for={@form}
+        id="attachment-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:filename]} type="text" label={gettext("Filename")} />
+        <.input field={@form[:local_path]} type="text" label={gettext("Local Path")} />
+        <.input field={@form[:file_type]} type="text" label={gettext("File Type")} />
+        <.input field={@form[:byte_size]} type="number" label={gettext("Byte Size")} />
+        <.input field={@form[:status]} type="text" label={gettext("Status")} />
+        <.input field={@form[:resource_type]} type="text" label={gettext("Resource Type")} />
+        <.input field={@form[:resource_id]} type="text" label={gettext("Resource Id")} />
+        <.itsm_calendar
+          field={@form[:deleted_at]}
+          label={gettext("Deleted At")}
+          show_time
+          default_selected_date_time={@form[:deleted_at].value}
+        />
+        <.itsm_calendar
+          :if={@action == :edit}
+          field={@form[:inserted_at]}
+          label={gettext("Inserted At")}
+          show_time
+          default_selected_date_time={@form[:inserted_at].value}
+        />
+        <:actions>
+          <.button :if={!@conflict} phx-disable-with="Saving...">Save Attachment</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  def handle_event("validate", %{"attachment" => attachment_params}, socket) do
+    changeset = Attachments.change_attachment(socket.assigns.attachment, attachment_params)
+    {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
+  end
+
+  def handle_event("save", %{"attachment" => attachment_params}, socket) do
+    save_attachment(socket, socket.assigns.action, attachment_params)
+  end
+
+  defp save_attachment(socket, :edit, attachment_params) do
+    %{current_user: action_user, attachment: attachment} = socket.assigns
+
+    case Attachments.update_attachment(action_user, attachment, attachment_params) do
+      {:ok, _attachment} ->
+        {:noreply, socket |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp save_attachment(socket, :new, attachment_params) do
+    %{current_user: action_user} = socket.assigns
+
+    case Attachments.create_attachment(action_user, attachment_params) do
+      {:ok, _attachment} ->
+        {:noreply, socket |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+end

--- a/lib/itsm_web/live/admin/attachment_live/index.ex
+++ b/lib/itsm_web/live/admin/attachment_live/index.ex
@@ -1,0 +1,75 @@
+defmodule ItsmWeb.Admin.AttachmentLive.Index do
+  use ItsmWeb, :live_view
+
+  alias Itsm.Admin.Attachments
+  alias Itsm.Attachments.Attachment
+  alias Itsm.Paging
+
+  def mount(_params, _session, socket) do
+    {:ok, socket |> stream(:attachments, []) |> Itsm.PubSub.Helper.subscribe(Attachments)}
+  end
+
+  def handle_params(params, url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
+  end
+
+  def handle_event("delete", %{"id" => _id} = attachment_params, socket) do
+    %{current_user: action_user} = socket.assigns
+    {:ok, attachment} = Attachments.delete_attachment(action_user, attachment_params)
+
+    {:noreply, stream_delete(socket, :attachments, attachment)}
+  end
+
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
+  end
+
+  def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp apply_action(socket, :index, params, url) do
+    opts = [
+      default_columns: [
+        :filename,
+        :local_path,
+        :file_type,
+        :byte_size,
+        :status,
+        :resource_type,
+        :resource_id,
+        :deleted_at
+      ]
+    ]
+
+    value =
+      Paging.search_and_pagination(Attachment, params, url, opts)
+
+    socket
+    |> assign(:results, value.results)
+    |> stream(:attachments, value.entries, reset: true)
+    |> assign(:page_title, "Listing Attachments")
+    |> assign(:attachment, nil)
+  end
+
+  defp apply_action(socket, :new, _params, _url) do
+    socket
+    |> assign(:page_title, "New Attachment")
+    |> assign(:attachment, %Attachment{})
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}, _url) do
+    socket
+    |> assign(:page_title, "Edit Attachment")
+    |> assign(:attachment, Attachments.get_attachment!(id))
+  end
+
+  defp handle_pubsub(action_user, event, item, socket) do
+    opts = [
+      context_key: :attachment,
+      resource_name: gettext("Attachment"),
+      stream_name: :attachments,
+      push_patch: [to: "#{socket.assigns.current_path}"]
+    ]
+
+    {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
+end

--- a/lib/itsm_web/live/admin/attachment_live/index.html.heex
+++ b/lib/itsm_web/live/admin/attachment_live/index.html.heex
@@ -1,0 +1,68 @@
+<.header>
+  Listing Attachments
+  <:actions>
+    <.link patch={~p"/admin/attachments/new"}>
+      <.button>New Attachment</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.itsm_table_container results={assigns[:results]}>
+  <.table
+    id="attachments"
+    rows={@streams.attachments}
+    row_click={fn {_id, attachment} -> JS.navigate(~p"/admin/attachments/#{attachment}") end}
+  >
+    <:col :let={{_id, attachment}} label={gettext("Resource ID")}>
+      <.copyable_text label={gettext("ID")} value={attachment.resource_id} />
+    </:col>
+    <:col :let={{_id, attachment}} label={gettext("Resource Type")}>
+      {attachment.resource_type}
+    </:col>
+    <:col :let={{_id, attachment}} label={gettext("Filename")}>{attachment.filename}</:col>
+    <:col :let={{_id, attachment}} label={gettext("Local Path")}>{attachment.local_path}</:col>
+    <:col :let={{_id, attachment}} label={gettext("File Type")}>{attachment.file_type}</:col>
+    <:col :let={{_id, attachment}} label={gettext("Byte Size")}>{attachment.byte_size}</:col>
+    <:col :let={{_id, attachment}} label={gettext("Status")}>{attachment.status}</:col>
+    <:col :let={{id, attachment}} label={gettext("Deleted At")}>
+      <div
+        id={"deleted_at-#{id}"}
+        phx-hook="LocalTime.ToLocale"
+        utc-value={attachment.deleted_at}
+      />
+    </:col>
+    <:action :let={{_id, attachment}}>
+      <div class="sr-only">
+        <.link navigate={~p"/admin/attachments/#{attachment}"}>Show</.link>
+      </div>
+      <.link patch={~p"/admin/attachments/#{attachment}/edit"}>Edit</.link>
+    </:action>
+    <:action :let={{_id, attachment}}>
+      <.link
+        id={attachment.id}
+        phx-click={JS.push("delete", value: %{id: attachment.id})}
+        class="phx-click-loading:opacity-50 phx-click-loading:cursor-wait"
+        data-confirm="Are you sure?"
+      >
+        Delete
+      </.link>
+    </:action>
+  </.table>
+</.itsm_table_container>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="attachment-modal"
+  show
+  on_cancel={JS.patch(~p"/admin/attachments?#{assigns[:results][:params] || %{}}")}
+>
+  <.live_component
+    module={ItsmWeb.Admin.AttachmentLive.FormComponent}
+    id={@attachment.id || :new}
+    title={@page_title}
+    action={@live_action}
+    attachment={@attachment}
+    current_user={@current_user}
+    patch={~p"/admin/attachments?#{assigns[:results][:params] || %{}}"}
+  />
+</.modal>

--- a/lib/itsm_web/live/admin/attachment_live/show.ex
+++ b/lib/itsm_web/live/admin/attachment_live/show.ex
@@ -1,0 +1,50 @@
+defmodule ItsmWeb.Admin.AttachmentLive.Show do
+  use ItsmWeb, :live_view
+
+  alias Itsm.Admin.Attachments
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:attachment, Attachments.get_attachment!(id))
+     |> Itsm.PubSub.Helper.subscribe(Itsm.Admin.Attachments, id: id)}
+  end
+
+  def handle_info({:pubsub, {action_user, event, item}}, socket) do
+    handle_pubsub(action_user, event, item, socket)
+  end
+
+  def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp page_title(:show), do: "Show Attachment"
+  defp page_title(:edit), do: "Edit Attachment"
+
+  defp handle_pubsub(
+         action_user,
+         event,
+         %{id: id} = item,
+         %{assigns: %{attachment: %{id: id}}} = socket
+        ) do
+    opts =
+      [context_key: :attachment, resource_name: gettext("Attachment")]
+      |> Keyword.merge(push_event_action(socket, event))
+
+    {:noreply,
+     socket
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+  end
+
+  defp handle_pubsub(_user, _event, _item, socket) do
+    {:noreply, socket}
+  end
+
+  defp push_event_action(socket, :delete_attachment),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
+
+  defp push_event_action(_socket, _), do: []
+end

--- a/lib/itsm_web/live/admin/attachment_live/show.html.heex
+++ b/lib/itsm_web/live/admin/attachment_live/show.html.heex
@@ -1,0 +1,50 @@
+<.header>
+  Attachment {@attachment.id}
+  <:subtitle>This is a attachment record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/admin/attachments/#{@attachment}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit attachment</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title={gettext("Filename")}>{@attachment.filename}</:item>
+  <:item title={gettext("Local Path")}>{@attachment.local_path}</:item>
+  <:item title={gettext("File Type")}>{@attachment.file_type}</:item>
+  <:item title={gettext("Byte Size")}>{@attachment.byte_size}</:item>
+  <:item title={gettext("Status")}>{@attachment.status}</:item>
+  <:item title={gettext("Resource Type")}>{@attachment.resource_type}</:item>
+  <:item title={gettext("Resource Id")}>{@attachment.resource_id}</:item>
+  <:item title={gettext("Deleted At")}>
+    <span id={"attachment-deleted_at-#{@attachment.id}"} phx-hook="LocalTime.ToLocale" utc-value={@attachment.deleted_at} />
+  </:item>
+  <:item title={gettext("Inserted At")}>
+    <span
+      id={"attachment-inserted-at-#{@attachment.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@attachment.inserted_at}
+    />
+  </:item>
+  <:item title={gettext("Updated At")}>
+    <span
+      id={"attachment-updated-at-#{@attachment.id}"}
+      phx-hook="LocalTime.ToLocale"
+      utc-value={@attachment.updated_at}
+    />
+  </:item>
+</.list>
+
+<.back navigate={~p"/admin/attachments"}>Back to attachments</.back>
+
+<.modal :if={@live_action == :edit} id="attachment-modal" show on_cancel={JS.patch(~p"/admin/attachments/#{@attachment}")}>
+  <.live_component
+    module={ItsmWeb.Admin.AttachmentLive.FormComponent}
+    id={@attachment.id}
+    title={@page_title}
+    action={@live_action}
+    attachment={@attachment}
+    current_user={@current_user}
+    patch={~p"/admin/attachments/#{@attachment}"}
+  />
+</.modal>

--- a/lib/itsm_web/live/admin/board_live/index.ex
+++ b/lib/itsm_web/live/admin/board_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.Admin.BoardLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Boards)
-
-    {:ok, stream(socket, :boards, [])}
+    {:ok, socket |> stream(:boards, []) |> Itsm.PubSub.Helper.subscribe(Boards, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -58,7 +56,7 @@ defmodule ItsmWeb.Admin.BoardLive.Index do
       context_key: :board,
       resource_name: gettext("Board"),
       stream_name: :boards,
-      push_patch: [to: ~p"/admin/boards?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/board_live/show.ex
+++ b/lib/itsm_web/live/admin/board_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.BoardLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Itsm.Admin.Boards, id)
-      Itsm.Utils.subscribes(Itsm.Admin.Boards)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:board, Boards.get_board!(id))}
+     |> assign(:board, Boards.get_board!(id))
+     |> Itsm.PubSub.Helper.subscribe(Boards, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -33,10 +29,10 @@ defmodule ItsmWeb.Admin.BoardLive.Show do
          event,
          %{id: id} = item,
          %{assigns: %{board: %{id: id}}} = socket
-        ) do
+       ) do
     opts =
       [context_key: :board, resource_name: gettext("Board")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.BoardLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_board),
-    do: [push_navigate: [to: ~p"/admin/boards"]]
+  defp push_event_action(socket, :delete_board),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/category_live/index.ex
+++ b/lib/itsm_web/live/admin/category_live/index.ex
@@ -7,9 +7,11 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
   alias Itsm.Admin.CommonCodes
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Categories)
-
-    {:ok, socket |> stream(:categories, []) |> assign_new_options()}
+    {:ok,
+     socket
+     |> stream(:categories, [])
+     |> assign_new_options()
+     |> Itsm.PubSub.Helper.subscribe(Categories, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -65,7 +67,7 @@ defmodule ItsmWeb.Admin.CategoryLive.Index do
       context_key: :category,
       resource_name: gettext("Category"),
       stream_name: :categories,
-      push_patch: [to: ~p"/admin/categories?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/category_live/show.ex
+++ b/lib/itsm_web/live/admin/category_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Categories, id)
-      Itsm.Utils.subscribes(Categories)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:category, Categories.get_category!(id))}
+     |> assign(:category, Categories.get_category!(id))
+     |> Itsm.PubSub.Helper.subscribe(Categories, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
        ) do
     opts =
       [context_key: :category, resource_name: gettext("Category")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.CategoryLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_category),
-    do: [push_navigate: [to: ~p"/admin/categories"]]
+  defp push_event_action(socket, :delete_category),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/comment_live/index.ex
+++ b/lib/itsm_web/live/admin/comment_live/index.ex
@@ -6,9 +6,8 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Comments)
-
-    {:ok, stream(socket, :comments, [])}
+    {:ok,
+     socket |> stream(:comments, []) |> Itsm.PubSub.Helper.subscribe(Comments, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -60,7 +59,7 @@ defmodule ItsmWeb.Admin.CommentLive.Index do
       context_key: :comment,
       resource_name: gettext("Comment"),
       stream_name: :comments,
-      push_patch: [to: ~p"/admin/comments?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/comment_live/index.html.heex
+++ b/lib/itsm_web/live/admin/comment_live/index.html.heex
@@ -7,6 +7,9 @@
     rows={@streams.comments}
     row_click={fn {_id, comment} -> JS.navigate(~p"/admin/comments/#{comment}") end}
   >
+    <:col :let={{_id, comment}} label={gettext("Resource ID")}>
+      <.copyable_text label={gettext("ID")} value={comment.resource_id} />
+    </:col>
     <:col :let={{_id, comment}} label={gettext("Resource")}>{comment.resource_type}</:col>
     <:col :let={{_id, comment}} label={gettext("Comment")}>{comment.comment}</:col>
     <:col :let={{_id, comment}} label={gettext("User")}>{comment.user.display_name}</:col>

--- a/lib/itsm_web/live/admin/comment_live/show.ex
+++ b/lib/itsm_web/live/admin/comment_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Comments, id)
-      Itsm.Utils.subscribes(Comments)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:comment, Comments.get_comment!(id) |> Comments.with_assoc(:user))}
+     |> assign(:comment, Comments.get_comment!(id) |> Comments.with_assoc(:user))
+     |> Itsm.PubSub.Helper.subscribe(Comments, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
        ) do
     opts =
       [context_key: :comment, resource_name: gettext("Comment")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.CommentLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_comment),
-    do: [push_navigate: [to: ~p"/admin/comments"]]
+  defp push_event_action(socket, :delete_comment),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/common_code_live/index.ex
+++ b/lib/itsm_web/live/admin/common_code_live/index.ex
@@ -6,9 +6,10 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(CommonCodes)
-
-    {:ok, stream(socket, :common_codes, [])}
+    {:ok,
+     socket
+     |> stream(:common_codes, [])
+     |> Itsm.PubSub.Helper.subscribe(CommonCodes, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -59,7 +60,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Index do
       context_key: :common_code,
       resource_name: gettext("Common Code"),
       stream_name: :common_codes,
-      push_patch: [to: ~p"/admin/common_codes?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/common_code_live/show.ex
+++ b/lib/itsm_web/live/admin/common_code_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(CommonCodes, id)
-      Itsm.Utils.subscribes(CommonCodes)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:common_code, CommonCodes.get_common_code!(id))}
+     |> assign(:common_code, CommonCodes.get_common_code!(id))
+     |> Itsm.PubSub.Helper.subscribe(CommonCodes, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
        ) do
     opts =
       [context_key: :common_code, resource_name: gettext("Common Code")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.CommonCodeLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_common_code),
-    do: [push_navigate: [to: ~p"/admin/common_codes"]]
+  defp push_event_action(socket, :delete_common_code),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/crew_live/index.ex
+++ b/lib/itsm_web/live/admin/crew_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Crews)
-
-    {:ok, stream(socket, :crews, [])}
+    {:ok, socket |> stream(:crews, []) |> Itsm.PubSub.Helper.subscribe(Crews, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -57,7 +55,7 @@ defmodule ItsmWeb.Admin.CrewLive.Index do
       context_key: :crew,
       resource_name: gettext("Crew"),
       stream_name: :crews,
-      push_patch: [to: ~p"/admin/crews?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/crew_live/show.ex
+++ b/lib/itsm_web/live/admin/crew_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Crews, id)
-      Itsm.Utils.subscribes(Crews)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:crew, Crews.get_crew!(id))}
+     |> assign(:crew, Crews.get_crew!(id))
+     |> Itsm.PubSub.Helper.subscribe(Crews, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
        ) do
     opts =
       [context_key: :crew, resource_name: gettext("Crew")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.CrewLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_crew),
-    do: [push_navigate: [to: ~p"/admin/crews"]]
+  defp push_event_action(socket, :delete_crew),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/post_live/index.ex
+++ b/lib/itsm_web/live/admin/post_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.Admin.PostLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Posts)
-
-    {:ok, stream(socket, :posts, [])}
+    {:ok, socket |> stream(:posts, []) |> Itsm.PubSub.Helper.subscribe(Posts, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -43,11 +41,6 @@ defmodule ItsmWeb.Admin.PostLive.Index do
 
     value =
       Post
-      |> Paging.filter_status(
-        [author: :organization_code],
-        socket.assigns[:current_user].organization_code,
-        query_cond: :in
-      )
       |> Paging.search_and_pagination(params, url, opts)
 
     socket
@@ -74,7 +67,7 @@ defmodule ItsmWeb.Admin.PostLive.Index do
       context_key: :post,
       resource_name: gettext("Post"),
       stream_name: :posts,
-      push_patch: [to: ~p"/admin/posts?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/post_live/show.ex
+++ b/lib/itsm_web/live/admin/post_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.PostLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Itsm.Admin.Posts, id)
-      Itsm.Utils.subscribes(Itsm.Admin.Posts)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:post, Posts.get_post!(id) |> Posts.with_assoc([:board, :author]))}
+     |> assign(:post, Posts.get_post!(id) |> Posts.with_assoc([:board, :author]))
+     |> Itsm.PubSub.Helper.subscribe(Posts, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.PostLive.Show do
        ) do
     opts =
       [context_key: :post, resource_name: gettext("Post")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.PostLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_post),
-    do: [push_navigate: [to: ~p"/admin/posts"]]
+  defp push_event_action(socket, :delete_post),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/request_live/index.ex
+++ b/lib/itsm_web/live/admin/request_live/index.ex
@@ -6,9 +6,8 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
   alias Itsm.Service.Request
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Requests)
-
-    {:ok, stream(socket, :requests, [])}
+    {:ok,
+     socket |> stream(:requests, []) |> Itsm.PubSub.Helper.subscribe(Requests, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -17,9 +16,14 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
 
   def handle_event("delete", %{"id" => _id} = request_params, socket) do
     %{current_user: action_user} = socket.assigns
-    {:ok, request} = Requests.delete_request(action_user, request_params)
 
-    {:noreply, stream_delete(socket, :requests, request)}
+    case Requests.delete_request(action_user, request_params) do
+      {:ok, request} ->
+        {:noreply, stream_delete(socket, :requests, request)}
+
+      {:error, :foreign_approvals, message} ->
+        {:noreply, put_flash(socket, :error, message)}
+    end
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -30,8 +34,8 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
 
   defp apply_action(socket, :index, params, url) do
     opts = [
-      default_columns: [:title, :description, :env, :requestor_name],
-      preloads: [category: [:request_name, :name]]
+      default_columns: [:id, :title, :description, :env, :requestor_name],
+      preloads: [requestor: :organization_code, category: [:request_name, :name, :affiliate]]
     ]
 
     value =
@@ -61,7 +65,7 @@ defmodule ItsmWeb.Admin.RequestLive.Index do
       context_key: :request,
       resource_name: gettext("Request"),
       stream_name: :requests,
-      push_patch: [to: ~p"/admin/requests?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/request_live/index.html.heex
+++ b/lib/itsm_web/live/admin/request_live/index.html.heex
@@ -21,6 +21,13 @@
       {request.category.request_name}
     </:col>
     <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
+    <:col :let={{_id, request}} label={gettext("Requestor Affiliate")}>
+      <.common_code_label group="계열사" code={request.requestor.organization_code} />
+    </:col>
+    <:col :let={{_id, request}} label={gettext("Category Affiliate")}>
+      <.common_code_label group="계열사" code={request.category.affiliate} />
+    </:col>
+
     <:action :let={{_id, request}}>
       <div class="sr-only"><.link navigate={~p"/admin/requests/#{request}"}>Show</.link></div>
       <.link patch={~p"/admin/requests/#{request.id}/edit"}>Edit</.link>

--- a/lib/itsm_web/live/admin/request_live/show.ex
+++ b/lib/itsm_web/live/admin/request_live/show.ex
@@ -1,22 +1,46 @@
 defmodule ItsmWeb.Admin.RequestLive.Show do
+  alias Itsm.Admin.Attachments
+  alias Itsm.Admin.Approvals
+  alias Itsm.Admin.Comments
   use ItsmWeb, :live_view
 
   alias Itsm.Admin.Requests
 
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, socket |> stream(:attachments, []) |> stream(:comments, []) |> stream(:approvals, [])}
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Requests, id)
-      Itsm.Utils.subscribes(Requests)
-    end
+    request =
+      Requests.get_request!(id)
+      |> Requests.with_assoc([:category, :requestor_crew, :requestor])
 
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:request, Requests.get_request!(id) |> Requests.with_assoc(:category))}
+     |> assign(:request, request)
+     |> stream(:attachments, Attachments.list_attachments_by_resource(request), reset: true)
+     |> stream(:comments, Comments.list_comments_by_resource(request), reset: true)
+     |> stream(:approvals, Approvals.list_approvals_by_request(request.id), reset: true)
+     |> Itsm.PubSub.Helper.subscribe(Requests, id: id, is_admin: true)}
+  end
+
+  def handle_event("delete", %{"schema" => schema, "id" => _id} = params, socket) do
+    %{current_user: action_user} = socket.assigns
+
+    case schema do
+      "attachments" ->
+        {:ok, attachment} = Attachments.delete_attachment(action_user, params)
+        {:noreply, stream_delete(socket, :attachments, attachment)}
+
+      "comments" ->
+        {:ok, comment} = Comments.delete_comment(action_user, params)
+        {:noreply, stream_delete(socket, :comments, comment)}
+
+      "approvals" ->
+        {:ok, approval} = Approvals.delete_approval(action_user, params)
+        {:noreply, stream_delete(socket, :approvals, approval)}
+    end
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +60,7 @@ defmodule ItsmWeb.Admin.RequestLive.Show do
        ) do
     opts =
       [context_key: :request, resource_name: gettext("Request")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +71,8 @@ defmodule ItsmWeb.Admin.RequestLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_request),
-    do: [push_navigate: [to: ~p"/admin/requests"]]
+  defp push_event_action(socket, :delete_request),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/admin/request_live/show.html.heex
+++ b/lib/itsm_web/live/admin/request_live/show.html.heex
@@ -27,7 +27,96 @@
     {@request.category.request_name}
   </:item>
   <:item title={gettext("Request Name")}>{@request.category.name}</:item>
+  <:item title={gettext("Requestor Crew")}>{@request.requestor_crew.name}</:item>
+  <:item title={gettext("Requestor Name")}>{@request.requestor.display_name}</:item>
 </.list>
+<br />
+
+<div class="text-lg font-bold">
+  Attachments
+</div>
+<.table
+  id="attachments"
+  rows={@streams.attachments}
+  row_click={fn {_id, attachment} -> JS.navigate(~p"/admin/attachments/#{attachment}") end}
+>
+  <:col :let={{_id, attachment}} label={gettext("Filename")}>{attachment.filename}</:col>
+  <:col :let={{_id, attachment}} label={gettext("Local Path")}>{attachment.local_path}</:col>
+  <:col :let={{_id, attachment}} label={gettext("File Type")}>{attachment.file_type}</:col>
+  <:col :let={{_id, attachment}} label={gettext("Byte Size")}>{attachment.byte_size}</:col>
+  <:col :let={{_id, attachment}} label={gettext("Status")}>{attachment.status}</:col>
+  <:col :let={{id, attachment}} label={gettext("Deleted At")}>
+    <div id={"deleted_at-#{id}"} phx-hook="LocalTime.ToLocale" utc-value={attachment.deleted_at} />
+  </:col>
+  <:action :let={{_id, attachment}}>
+    <div class="sr-only">
+      <.link navigate={~p"/admin/attachments/#{attachment}"}>Show</.link>
+    </div>
+    <.link patch={~p"/admin/attachments/#{attachment}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{_id, attachment}}>
+    <.link
+      id={attachment.id}
+      phx-click={JS.push("delete", value: %{schema: :attachments, id: attachment.id})}
+      class="phx-click-loading:opacity-50 phx-click-loading:cursor-wait"
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+<br />
+<div class="text-lg font-bold">
+  Approvals
+</div>
+<.table
+  id="approvals"
+  rows={@streams.approvals}
+  row_click={fn {_id, approval} -> JS.navigate(~p"/admin/approvals/#{approval}") end}
+>
+  <:col :let={{_id, approval}} label={gettext("Status")}>{approval.status}</:col>
+  <:col :let={{_id, approval}} label={gettext("Approver")}>{approval.approver_name}</:col>
+  <:action :let={{_id, approval}}>
+    <div class="sr-only"><.link navigate={~p"/admin/approvals/#{approval}"}>Show</.link></div>
+    <.link patch={~p"/admin/approvals/#{approval}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{_id, approval}}>
+    <.link
+      id={approval.id}
+      phx-click={JS.push("delete", value: %{schema: :approvals, id: approval.id})}
+      class="phx-click-loading:opacity-50 phx-click-loading:cursor-wait"
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+<br />
+<div class="text-lg font-bold">
+  Comments
+</div>
+<.table
+  id="comments"
+  rows={@streams.comments}
+  row_click={fn {_id, comment} -> JS.navigate(~p"/admin/comments/#{comment}") end}
+>
+  <:col :let={{_id, comment}} label={gettext("Comment")}>{comment.comment}</:col>
+  <:col :let={{_id, comment}} label={gettext("User")}>{comment.user.display_name}</:col>
+  <:action :let={{_id, comment}}>
+    <div class="sr-only"><.link navigate={~p"/admin/comments/#{comment}"}>Show</.link></div>
+    <.link patch={~p"/admin/comments/#{comment}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{_id, comment}}>
+    <.link
+      id={comment.id}
+      phx-click={JS.push("delete", value: %{schema: :comments, id: comment.id})}
+      class="phx-click-loading:opacity-50 phx-click-loading:cursor-wait"
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
 
 <.back navigate={~p"/admin/requests"}>Back to requests</.back>
 

--- a/lib/itsm_web/live/admin/user_live/form_component.ex
+++ b/lib/itsm_web/live/admin/user_live/form_component.ex
@@ -109,10 +109,13 @@ defmodule ItsmWeb.Admin.UserLive.FormComponent do
   end
 
   defp save_user(socket, :edit, user_params) do
-    %{current_user: action_user} = socket.assigns
+    %{current_user: action_user, user: user} = socket.assigns
 
-    case Accounts.update_user(action_user, socket.assigns.user, user_params) do
-      {:ok, _user} ->
+    case Accounts.update_user(action_user, user, user_params) do
+      {:ok, user} ->
+        socket =
+          if action_user.id == user.id, do: socket |> assign(:current_user, user), else: socket
+
         {:noreply, socket |> push_patch(to: socket.assigns.patch)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -123,8 +126,11 @@ defmodule ItsmWeb.Admin.UserLive.FormComponent do
   defp save_user(socket, :new, user_params) do
     %{current_user: action_user} = socket.assigns
 
-    case Accounts.register_user(action_user, user_params) do
-      {:ok, _user} ->
+    case Accounts.create_user(action_user, user_params) do
+      {:ok, user} ->
+        socket =
+          if action_user.id == user.id, do: socket |> assign(:current_user, user), else: socket
+
         {:noreply, socket |> push_patch(to: socket.assigns.patch)}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/itsm_web/live/admin/user_live/index.ex
+++ b/lib/itsm_web/live/admin/user_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.Admin.UserLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Accounts)
-
-    {:ok, stream(socket, :users, [])}
+    {:ok, socket |> stream(:users, []) |> Itsm.PubSub.Helper.subscribe(Accounts, is_admin: true)}
   end
 
   def handle_params(params, url, socket) do
@@ -16,9 +14,18 @@ defmodule ItsmWeb.Admin.UserLive.Index do
   end
 
   def handle_event("delete", %{"id" => _id} = user_params, socket) do
-    {:ok, user} = Accounts.delete_user(socket.assigns.current_user, user_params)
+    %{current_user: action_user} = socket.assigns
 
-    {:noreply, stream_delete(socket, :users, user)}
+    case Accounts.delete_user(action_user, user_params) do
+      {:ok, user} ->
+        socket =
+          if action_user.id == user.id, do: redirect(socket, to: ~p"/users/log_out"), else: socket
+
+        {:noreply, stream_delete(socket, :users, user)}
+
+      {:error, %Ecto.Changeset{} = _changeset} ->
+        {:noreply, put_flash(socket, :error, "삭제 실패: 자식 데이터가 존재합니다.")}
+    end
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -68,7 +75,7 @@ defmodule ItsmWeb.Admin.UserLive.Index do
       context_key: :user,
       resource_name: gettext("User"),
       stream_name: :users,
-      push_patch: [to: ~p"/admin/users?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/admin/user_live/show.ex
+++ b/lib/itsm_web/live/admin/user_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.Admin.UserLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Itsm.Admin.Accounts, id)
-      Itsm.Utils.subscribes(Itsm.Admin.Accounts)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:user, Accounts.get_user!(id))}
+     |> assign(:user, Accounts.get_user!(id))
+     |> Itsm.PubSub.Helper.subscribe(Accounts, id: id, is_admin: true)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.Admin.UserLive.Show do
        ) do
     opts =
       [context_key: :user, resource_name: gettext("User")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.Admin.UserLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_user),
-    do: [push_navigate: [to: ~p"/admin/users"]]
+  defp push_event_action(socket, :delete_user),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/approval_live/index.ex
+++ b/lib/itsm_web/live/approval_live/index.ex
@@ -9,9 +9,7 @@ defmodule ItsmWeb.ApprovalLive.Index do
   alias Itsm.Workflow
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Approvals)
-
-    {:ok, stream(socket, :requests, [])}
+    {:ok, socket |> stream(:requests, []) |> Itsm.PubSub.Helper.subscribe(Approvals)}
   end
 
   def handle_params(params, _url, socket) do
@@ -45,11 +43,11 @@ defmodule ItsmWeb.ApprovalLive.Index do
   end
 
   defp apply_action(socket, :index, _params) do
+    %{current_user: current_user} = socket.assigns
+
     socket
     |> assign(:page_title, "Listing Approvals")
-    |> stream(:requests, Approvals.list_pending_requests(socket.assigns.current_user),
-      reset: true
-    )
+    |> stream(:requests, Approvals.list_pending_requests(current_user), reset: true)
   end
 
   defp handle_pubsub(action_user, event, item, socket) do
@@ -57,7 +55,7 @@ defmodule ItsmWeb.ApprovalLive.Index do
       context_key: :request,
       resource_name: gettext("Approval"),
       stream_name: :requests,
-      push_patch: [to: ~p"/approvals"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply,

--- a/lib/itsm_web/live/approval_live/index.html.heex
+++ b/lib/itsm_web/live/approval_live/index.html.heex
@@ -54,6 +54,12 @@
 
   <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
 
+  <:col :let={{_id, request}} label={gettext("Requestor Crew")}>
+    {request.requestor_crew.name}
+  </:col>
+
+  <:col :let={{_id, request}} label={gettext("Assignee Crew")}>{request.assignee_crew.name}</:col>
+
   <:col :let={{_id, request}} label={gettext("Requestor Name")}>{request.requestor_name}</:col>
 
   <:col :let={{_id, request}} label={gettext("Status")}>

--- a/lib/itsm_web/live/asset_live/index.ex
+++ b/lib/itsm_web/live/asset_live/index.ex
@@ -5,9 +5,7 @@ defmodule ItsmWeb.AssetLive.Index do
   alias Itsm.Assets.Asset
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Assets)
-
-    {:ok, stream(socket, :assets, [])}
+    {:ok, socket |> stream(:assets, []) |> Itsm.PubSub.Helper.subscribe(Assets)}
   end
 
   def handle_params(params, _url, socket) do
@@ -54,7 +52,7 @@ defmodule ItsmWeb.AssetLive.Index do
       context_key: :asset,
       resource_name: gettext("Asset"),
       stream_name: :assets,
-      push_patch: [to: ~p"/assets"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/asset_live/show.ex
+++ b/lib/itsm_web/live/asset_live/show.ex
@@ -11,16 +11,12 @@ defmodule ItsmWeb.AssetLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if connected?(socket) do
-      Itsm.Utils.subscribe(Assets, id)
-      Itsm.Utils.subscribes(Assets)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:asset, Assets.get_asset_with_relations!(id))
-     |> assign_new_options()}
+     |> assign_new_options()
+     |> Itsm.PubSub.Helper.subscribe(Assets, id: id)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -81,7 +77,7 @@ defmodule ItsmWeb.AssetLive.Show do
        ) do
     opts =
       [context_key: :asset, resource_name: gettext("Asset")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     item = Itsm.Assets.with_assoc(item, service_crew: [:users], system_crew: [:users])
 
@@ -94,8 +90,8 @@ defmodule ItsmWeb.AssetLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_asset),
-    do: [push_navigate: [to: ~p"/assets"]]
+  defp push_event_action(socket, :delete_asset),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/board_live/index.ex
+++ b/lib/itsm_web/live/board_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.BoardLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Boards)
-
-    {:ok, stream(socket, :boards, [])}
+    {:ok, socket |> stream(:boards, []) |> Itsm.PubSub.Helper.subscribe(Boards)}
   end
 
   def handle_params(params, url, socket) do
@@ -58,7 +56,7 @@ defmodule ItsmWeb.BoardLive.Index do
       context_key: :board,
       resource_name: gettext("Board"),
       stream_name: :boards,
-      push_patch: [to: ~p"/boards?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/board_live/show.ex
+++ b/lib/itsm_web/live/board_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.BoardLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Itsm.Boards, id)
-      Itsm.Utils.subscribes(Itsm.Boards)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:board, Boards.get_board!(id))}
+     |> assign(:board, Boards.get_board!(id))
+     |> Itsm.PubSub.Helper.subscribe(Boards, id: id)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.BoardLive.Show do
        ) do
     opts =
       [context_key: :board, resource_name: gettext("Board")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.BoardLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_board),
-    do: [push_navigate: [to: ~p"/boards"]]
+  defp push_event_action(socket, :delete_board),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/category_live/index.ex
+++ b/lib/itsm_web/live/category_live/index.ex
@@ -7,9 +7,7 @@ defmodule ItsmWeb.CategoryLive.Index do
   alias Itsm.CommonCodes
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Categories)
-
-    {:ok, socket}
+    {:ok, socket |> stream(:categories, []) |> Itsm.PubSub.Helper.subscribe(Categories)}
   end
 
   def handle_params(params, _uri, socket) do
@@ -44,7 +42,7 @@ defmodule ItsmWeb.CategoryLive.Index do
       context_key: :category,
       resource_name: gettext("Category"),
       stream_name: :categories,
-      push_patch: [to: ~p"/categories?#{socket.assigns[:current_params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/common_k_create_vm_live/form.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/form.ex
@@ -24,12 +24,10 @@ defmodule ItsmWeb.CommonKCreateVmLive.Form do
   end
 
   def handle_params(%{"id" => id} = params, _uri, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Requests, id)
-      Itsm.Utils.subscribes(Requests)
-    end
-
-    {:noreply, socket |> apply_action(socket.assigns.live_action, params)}
+    {:noreply,
+     socket
+     |> apply_action(socket.assigns.live_action, params)
+     |> Itsm.PubSub.Helper.subscribe(Requests, id: id)}
   end
 
   def handle_params(_params, _uri, socket) do

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -19,12 +19,6 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
   end
 
   def handle_params(%{"id" => id}, _uri, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Requests, id)
-      Itsm.Utils.subscribes(Requests)
-      Itsm.Utils.subscribes(Attachments)
-    end
-
     request =
       Requests.get_request!(id)
       |> Requests.with_assoc([
@@ -43,7 +37,11 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
      |> assign(:selected_attachment, nil)
      |> assign(:attachments_count, length(attachments))
      |> stream(:attachments, attachments, reset: true)
-     |> stream(:comments, Comments.list_comments(Requests.get_request!(id)), reset: true)}
+     |> stream(:comments, Comments.list_comments_by_resource(Requests.get_request!(id)),
+       reset: true
+     )
+     |> Itsm.PubSub.Helper.subscribe(Requests, id: id)
+     |> Itsm.PubSub.Helper.subscribe(Attachments)}
   end
 
   def handle_event("view_attachment", %{"id" => id, "filename" => filename}, socket) do
@@ -109,7 +107,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
        ) do
     opts =
       [context_key: :request, resource_name: gettext("Request")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -128,7 +126,7 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
         stream_name: :comments,
         resource_name: gettext("Comment")
       ]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     item = Comments.with_assoc(item, [:user, :attachments])
 
@@ -143,10 +141,10 @@ defmodule ItsmWeb.CommonKCreateVmLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_request),
-    do: [push_navigate: [to: ~p"/requests"]]
+  defp push_event_action(socket, :delete_request),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 
   defp handle_pubsub_comment(socket, "update" <> _action, item),
     do: stream_insert(socket, :comments, item)

--- a/lib/itsm_web/live/crew_live/all_index.ex
+++ b/lib/itsm_web/live/crew_live/all_index.ex
@@ -1,46 +1,23 @@
 defmodule ItsmWeb.CrewLive.AllIndex do
+  alias Itsm.Crews.Crew
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
-  alias Itsm.Utils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
-  import ItsmWeb.CrewLive.Components
+  alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Utils.subscribes(Crews)
-
-    {:ok, socket |> assign(:org_options, Itsm.CommonCodes.get_select_options("계열사"))}
+    {:ok,
+     socket
+     |> stream(:crews, [])
+     |> assign(:org_options, Itsm.CommonCodes.get_select_options("계열사"))
+     |> Itsm.PubSub.Helper.subscribe(Crews)}
   end
 
-  def handle_params(params, _uri, socket) do
-    # 1. URL에 지저분한 파라미터가 섞이지 않도록 필요한 필터만
-    filter_params = Map.take(params, ["keyword", "organization_code"])
-
-    socket =
-      socket
-      |> assign(:page_title, "All Crew")
-      |> stream(:crews, Crews.filter_crews(params), reset: true)
-      |> assign(:form, to_form(params))
-      # 2 현재 필터 조건을 뷰에서 쓸 수 있게 assign
-      |> assign(:filter_params, filter_params)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("filter", params, socket) do
-    # URL 파라미터를 깔끔하게 정리
-    params =
-      params
-      |> Map.take(~w(keyword organization_code))
-      |> Map.reject(fn {_, v} -> v == "" end)
-
-    # push_patch는 현재 URL을 변경하고, 페이지를 새로고침하지 않음
-    # 이 경우, 현재 LiveView의 상태를 유지하면서 URL만 업데이트
-    socket = push_patch(socket, to: ~p"/crews/all?#{params}")
-
-    {:noreply, socket}
+  def handle_params(params, url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params, url)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -49,9 +26,30 @@ defmodule ItsmWeb.CrewLive.AllIndex do
 
   def handle_info(_event, socket), do: {:noreply, socket}
 
+  defp apply_action(socket, :index, params, url) do
+    opts = [
+      default_columns: [
+        :name,
+        :description,
+        leader: :display_name,
+        leader: :department
+      ],
+      preloads: [leader: [:organization_code, :department, :display_name]]
+    ]
+
+    value =
+      Crew
+      |> Paging.search_and_pagination(params, url, opts)
+
+    socket
+    |> assign(:page_title, "All Crew")
+    |> assign(:results, value.results)
+    |> stream(:crews, value.entries, reset: true)
+  end
+
   defp handle_pubsub(_action_user, event, {:crews, _crew}, socket)
        when event in [:create_crew, :update_crew, :delete_crew] do
-    %{filter_params: params} = socket.assigns
+    %{results: params} = socket.assigns
 
     {:noreply, push_patch(socket, to: ~p"/crews/all?#{params}")}
   end

--- a/lib/itsm_web/live/crew_live/all_index.html.heex
+++ b/lib/itsm_web/live/crew_live/all_index.html.heex
@@ -1,16 +1,14 @@
 <.header>{@page_title}</.header>
- <.filter_form form={@form} org_options={@org_options} />
-<.crew_table
-  crews={@streams.crews}
-  row_click={
-    fn {_id, crew} ->
-      # 3. 돌아올 URL을 미리 만듦 (필터가 포함된 URL)
-      # 예: "/crews/all?q=AAA&organization=KB국민은행"
-      return_url = ~p"/crews/all?#{@filter_params}"
 
-      # 4. return_to 파라미터에 위에서 만든 URL을 통째로 넘김
-      JS.navigate(~p"/crews/#{crew}?return_to=#{return_url}&menu_id=all_crews")
-    end
-  }
->
-</.crew_table>
+<.itsm_table_container results={assigns[:results]}>
+  <.crew_table
+    crews={@streams.crews}
+    row_click={
+      fn {_id, crew} ->
+        return_url = ~p"/crews/all?#{assigns[:results][:params] || %{}}"
+        JS.navigate(~p"/crews/#{crew}?return_to=#{return_url}&menu_id=all_crews")
+      end
+    }
+  >
+  </.crew_table>
+</.itsm_table_container>

--- a/lib/itsm_web/live/crew_live/index.ex
+++ b/lib/itsm_web/live/crew_live/index.ex
@@ -5,38 +5,32 @@ defmodule ItsmWeb.CrewLive.Index do
   alias Itsm.Crews.Crew
   alias Itsm.Accounts.User
   alias ItsmWeb.LiveUtils
-  alias Itsm.Utils
 
   # 공통 컴포넌트 임포트
   import ItsmWeb.CrewLive.TableComponents
 
   def mount(_params, _session, socket) do
-    %{current_user: user} = socket.assigns
-
-    if connected?(socket), do: Utils.subscribes(Crews)
-
-    {:ok, stream(socket, :crews, Crews.list_my_crews(user))}
+    {:ok, socket |> stream(:crews, []) |> Itsm.PubSub.Helper.subscribe(Crews)}
   end
 
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  # 1. 목록 조회 (:index)
   defp apply_action(socket, :index, _params) do
+    %{current_user: current_user} = socket.assigns
+
     socket
     |> assign(:page_title, "My Crews")
-    |> assign(:crew, nil)
+    |> stream(:crews, Crews.list_my_crews(current_user), reset: true)
   end
 
-  # 2. 생성 모달 (:new)
   defp apply_action(socket, :new, _params) do
     socket
     |> assign(:page_title, "New Crew")
     |> assign(:crew, %Crew{})
   end
 
-  # 3. 수정 모달 (:edit)
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
     |> assign(:page_title, "Edit Crew")

--- a/lib/itsm_web/live/crew_live/show.ex
+++ b/lib/itsm_web/live/crew_live/show.ex
@@ -3,7 +3,6 @@ defmodule ItsmWeb.CrewLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
-  alias Itsm.Utils
   alias ItsmWeb.LiveUtils
 
   def mount(params, _session, socket) do
@@ -13,11 +12,6 @@ defmodule ItsmWeb.CrewLive.Show do
   end
 
   def handle_params(%{"id" => id}, _params, socket) do
-    if connected?(socket) do
-      Utils.subscribe(Crews, id)
-      Utils.subscribes(Crews)
-    end
-
     crew =
       Crews.get_crew!(id)
       |> Crews.with_assoc([:leader, :users])
@@ -27,7 +21,8 @@ defmodule ItsmWeb.CrewLive.Show do
      |> assign(:page_title, "Show Crew")
      |> assign(:crew, crew)
      |> assign(:show_member_modal, false)
-     |> stream(:users, Crews.list_regular_users(crew))}
+     |> stream(:users, Crews.list_regular_users(crew))
+     |> Itsm.PubSub.Helper.subscribe(Crews, id: id)}
   end
 
   def handle_event("switch_leader", %{"user-id" => user_id}, socket) do

--- a/lib/itsm_web/live/crew_live/table_components.ex
+++ b/lib/itsm_web/live/crew_live/table_components.ex
@@ -1,7 +1,7 @@
 defmodule ItsmWeb.CrewLive.TableComponents do
   use ItsmWeb, :html
 
-  alias ItsmWeb.LiveUtils
+  import ItsmWeb.LiveUtils, only: [fetch_safe: 2]
 
   def crew_table(assigns) do
     assigns = assign_new(assigns, :action, fn -> [] end)
@@ -13,18 +13,15 @@ defmodule ItsmWeb.CrewLive.TableComponents do
       <:col :let={{_id, crew}} label={gettext("Description")}>{crew.description}</:col>
 
       <:col :let={{_id, crew}} label={gettext("Organization")}>
-        <.common_code_label
-          group="계열사"
-          code={LiveUtils.fetch_safe(crew.leader, :organization_code)}
-        />
+        <.common_code_label group="계열사" code={fetch_safe(crew.leader, :organization_code)} />
       </:col>
 
       <:col :let={{_id, crew}} label={gettext("Department")}>
-        {LiveUtils.fetch_safe(crew.leader, :department)}
+        {fetch_safe(crew.leader, :department)}
       </:col>
 
       <:col :let={{_id, crew}} label={gettext("Leader")}>
-        {LiveUtils.fetch_safe(crew.leader, :display_name)}
+        {fetch_safe(crew.leader, :display_name)}
       </:col>
 
       <%!--

--- a/lib/itsm_web/live/delegation_live/index.ex
+++ b/lib/itsm_web/live/delegation_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.DelegationLive.Index do
   alias Itsm.Accounts.User
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Delegations)
-
-    {:ok, stream(socket, :delegations, [])}
+    {:ok, socket |> stream(:delegations, []) |> Itsm.PubSub.Helper.subscribe(Delegations)}
   end
 
   def handle_params(params, _url, socket) do
@@ -80,7 +78,7 @@ defmodule ItsmWeb.DelegationLive.Index do
       context_key: :delegation,
       resource_name: gettext("Delegation"),
       stream_name: :delegations,
-      push_patch: [to: ~p"/delegations"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/lib/itsm_web/live/delegation_live/show.ex
+++ b/lib/itsm_web/live/delegation_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.DelegationLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if connected?(socket) do
-      Itsm.Utils.subscribe(Delegations, id)
-      Itsm.Utils.subscribes(Delegations)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:delegation, Delegations.get_delegation!(id))}
+     |> assign(:delegation, Delegations.get_delegation!(id))
+     |> Itsm.PubSub.Helper.subscribe(Delegations, id: id)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.DelegationLive.Show do
        ) do
     opts =
       [context_key: :delegation, resource_name: gettext("Delegation")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.DelegationLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_delegation),
-    do: [push_navigate: [to: ~p"/delegations"]]
+  defp push_event_action(socket, :delete_delegation),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/evaluation_live/index.ex
+++ b/lib/itsm_web/live/evaluation_live/index.ex
@@ -5,9 +5,7 @@ defmodule ItsmWeb.EvaluationLive.Index do
   alias Itsm.Evaluations.Evaluation
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Evaluations)
-
-    {:ok, stream(socket, :evaluations, [])}
+    {:ok, socket |> stream(:evaluations, []) |> Itsm.PubSub.Helper.subscribe(Evaluations)}
   end
 
   def handle_params(params, _url, socket) do
@@ -56,7 +54,7 @@ defmodule ItsmWeb.EvaluationLive.Index do
       context_key: :evaluation,
       resource_name: gettext("Evaluation"),
       stream_name: :evaluations,
-      push_patch: [to: ~p"/evaluations"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply,

--- a/lib/itsm_web/live/evaluation_live/show.ex
+++ b/lib/itsm_web/live/evaluation_live/show.ex
@@ -8,15 +8,11 @@ defmodule ItsmWeb.EvaluationLive.Show do
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if connected?(socket) do
-      Itsm.Utils.subscribe(Evaluations, id)
-      Itsm.Utils.subscribes(Evaluations)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:evaluation, Evaluations.get_evaluation!(id))}
+     |> assign(:evaluation, Evaluations.get_evaluation!(id))
+     |> Itsm.PubSub.Helper.subscribe(Evaluations, id: id)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule ItsmWeb.EvaluationLive.Show do
        ) do
     opts =
       [context_key: :evaluation, resource_name: gettext("Evaluation")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule ItsmWeb.EvaluationLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_evaluation),
-    do: [push_navigate: [to: ~p"/evaluations"]]
+  defp push_event_action(socket, :delete_evaluation),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/post_live/index.ex
+++ b/lib/itsm_web/live/post_live/index.ex
@@ -6,9 +6,7 @@ defmodule ItsmWeb.PostLive.Index do
   alias Itsm.Posts.Post
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Posts)
-
-    {:ok, stream(socket, :posts, [])}
+    {:ok, socket |> stream(:posts, []) |> Itsm.PubSub.Helper.subscribe(Posts)}
   end
 
   def handle_params(%{"board_id" => board_id} = params, url, socket)

--- a/lib/itsm_web/live/post_live/show.ex
+++ b/lib/itsm_web/live/post_live/show.ex
@@ -10,11 +10,6 @@ defmodule ItsmWeb.PostLive.Show do
   def handle_params(%{"id" => id, "board_id" => board_id}, _, socket)
       when board_id != nil and board_id != "" and is_binary(board_id) and
              byte_size(board_id) == 36 do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(Itsm.Posts, id)
-      Itsm.Utils.subscribes(Itsm.Posts)
-    end
-
     target_board = Itsm.Boards.get_board!(board_id)
 
     {:noreply,
@@ -22,7 +17,8 @@ defmodule ItsmWeb.PostLive.Show do
      |> assign(:board_name, Map.get(target_board, :name, ""))
      |> assign(:board_id, Map.get(target_board, :id, ""))
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:post, Posts.get_post!(id) |> Posts.with_assoc([:board, :author]))}
+     |> assign(:post, Posts.get_post!(id) |> Posts.with_assoc([:board, :author]))
+     |> Itsm.PubSub.Helper.subscribe(Posts, id: id)}
   end
 
   def handle_params(_params, _url, socket) do
@@ -46,7 +42,7 @@ defmodule ItsmWeb.PostLive.Show do
        ) do
     opts =
       [context_key: :post, resource_name: gettext("Post")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -57,8 +53,8 @@ defmodule ItsmWeb.PostLive.Show do
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_post),
-    do: [push_navigate: [to: ~p"/posts"]]
+  defp push_event_action(socket, :delete_post),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/lib/itsm_web/live/request_live/index.ex
+++ b/lib/itsm_web/live/request_live/index.ex
@@ -6,9 +6,10 @@ defmodule ItsmWeb.RequestLive.Index do
   alias Itsm.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(Requests)
-
-    {:ok, stream(socket, :requests, [])}
+    {:ok,
+     socket
+     |> stream(:requests, [])
+     |> Itsm.PubSub.Helper.subscribe(Requests)}
   end
 
   def handle_params(params, url, socket) do
@@ -33,18 +34,19 @@ defmodule ItsmWeb.RequestLive.Index do
   end
 
   defp apply_action(socket, :index, url, params) do
+    %{current_user: %{organization_code: organization_code}} = socket.assigns
+
     opts = [
       default_columns: [:title, :description, :env, :requestor_name],
       preloads: [:category, :requestor, :assignee_crew]
     ]
 
     value =
-      Paging.search_and_pagination(
-        Request,
-        params,
-        url,
-        opts
+      Request
+      |> Paging.filter_status([requestor: :organization_code], ["CM", "FG", organization_code],
+        query_cond: :in
       )
+      |> Paging.search_and_pagination(params, url, opts)
 
     socket
     |> assign(:page_title, "Listing Requests")
@@ -63,7 +65,7 @@ defmodule ItsmWeb.RequestLive.Index do
       context_key: :request,
       resource_name: gettext("Request"),
       stream_name: :requests,
-      push_patch: [to: ~p"/requests"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply,

--- a/lib/itsm_web/live/user_registration_live.ex
+++ b/lib/itsm_web/live/user_registration_live.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.UserRegistrationLive do
 
   alias Itsm.Accounts
   alias Itsm.Accounts.User
+  alias Itsm.CommonCodes
 
   def render(assigns) do
     ~H"""
@@ -35,8 +36,20 @@ defmodule ItsmWeb.UserRegistrationLive do
         <.input field={@form[:password]} type="password" label="Password" required />
         <.input field={@form[:employee_number]} type="text" label="직원번호" required />
         <.input field={@form[:display_name]} type="text" label="직원명" required />
-        <.input field={@form[:organization]} type="text" label="계열사명" required />
-        <.input field={@form[:organization_code]} type="text" label="계열사구분코드" required />
+        <.input
+          field={@form[:organization_code]}
+          type="select"
+          label={gettext("Organization")}
+          prompt="Choose a value"
+          options={@organization_options}
+        />
+        <.input
+          field={@form[:department_code]}
+          type="select"
+          label={gettext("Department")}
+          prompt="Choose a value"
+          options={@department_options}
+        />
 
         <:actions>
           <.button phx-disable-with="Creating account..." class="w-full">Create an account</.button>
@@ -53,12 +66,13 @@ defmodule ItsmWeb.UserRegistrationLive do
       socket
       |> assign(trigger_submit: false, check_errors: false)
       |> assign_form(changeset)
+      |> assign_new_options()
 
     {:ok, socket, temporary_assigns: [form: nil]}
   end
 
   def handle_event("save", %{"user" => user_params}, socket) do
-    case Accounts.register_user(user_params) do
+    case Accounts.create_user(fill_org_dept_codes(user_params)) do
       {:ok, user} ->
         {:ok, _} =
           Accounts.deliver_user_confirmation_instructions(
@@ -87,5 +101,22 @@ defmodule ItsmWeb.UserRegistrationLive do
     else
       assign(socket, form: form)
     end
+  end
+
+  defp assign_new_options(socket) do
+    socket
+    |> assign_new(:organization_options, fn -> CommonCodes.get_select_options("계열사") end)
+    |> assign_new(:department_options, fn -> CommonCodes.get_select_options("부서") end)
+  end
+
+  defp fill_org_dept_codes(attrs) do
+    org_code = attrs["organization_code"]
+    org_name = CommonCodes.get_label("계열사", org_code)
+    dept_code = attrs["department_code"]
+    dept_name = CommonCodes.get_label("부서", dept_code)
+
+    attrs
+    |> Map.put("department", dept_name)
+    |> Map.put("organization", org_name)
   end
 end

--- a/lib/itsm_web/live_utils.ex
+++ b/lib/itsm_web/live_utils.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.LiveUtils do
   ITSM 개발에 필요한 LiveView에서 사용할 Util메소드 정의 합니다.
   """
   require Logger
+  alias Itsm.Accounts.User
   alias Phoenix.LiveView
 
   def translate_error(reason, scope \\ nil, opt \\ nil)
@@ -118,6 +119,9 @@ defmodule ItsmWeb.LiveUtils do
         ) :: Phoenix.LiveView.Socket.t()
   def handle_standard_pubsub(socket, action_user, event, item, opts) do
     [action_type | _] = event |> Atom.to_string() |> String.split("_")
+
+    action_user =
+      if is_nil(action_user), do: %User{display_name: "anonymous_guest"}, else: action_user
 
     socket
     |> put_flash_by_event(action_user, action_type, opts)

--- a/lib/itsm_web/router.ex
+++ b/lib/itsm_web/router.ex
@@ -228,6 +228,13 @@ defmodule ItsmWeb.Router do
 
       live "/posts/:id", Admin.PostLive.Show, :show
       live "/posts/:id/show/edit", Admin.PostLive.Show, :edit
+
+      live "/attachments", Admin.AttachmentLive.Index, :index
+      live "/attachments/new", Admin.AttachmentLive.Index, :new
+      live "/attachments/:id/edit", Admin.AttachmentLive.Index, :edit
+
+      live "/attachments/:id", Admin.AttachmentLive.Show, :show
+      live "/attachments/:id/show/edit", Admin.AttachmentLive.Show, :edit
     end
   end
 

--- a/lib/mix/tasks/gen.Itsm.admin_live.ex
+++ b/lib/mix/tasks/gen.Itsm.admin_live.ex
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.Phx.Gen.Itsm.AdminLive do
   alias Mix.Phoenix.{Context, Schema}
   alias Mix.Tasks.Phx.Gen
 
+  # ex) mix phx.gen.itsm.admin_live Attachments Attachment attachments filename:string local_path:string file_type:string byte_size:integer status:string resource_type:string resource_id:uuid deleted_at:utc_datetime
   @doc false
   def run(args) do
     if Mix.Project.umbrella?() do

--- a/priv/templates/phx.gen.context/access_no_schema.ex
+++ b/priv/templates/phx.gen.context/access_no_schema.ex
@@ -11,7 +11,7 @@
     |> Repo.insert()
     |> case do
       {:ok, <%= schema.singular %>} ->
-       Itsm.Utils.broadcasts(__MODULE__, {action_user, :create_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_<%= schema.singular %>, <%= schema.singular %>})
        {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->
@@ -25,8 +25,7 @@
     |> Repo.update()
     |> case do
       {:ok, <%= schema.singular %>} ->
-       Itsm.Utils.broadcast(__MODULE__, {action_user, :update_<%= schema.singular %>, <%= schema.singular %>})
-       Itsm.Utils.broadcasts(__MODULE__, {action_user, :update_<%= schema.singular %>, <%= schema.singular %>})
+       Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_<%= schema.singular %>, <%= schema.singular %>}, id: <%= schema.singular %>.id)
        {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->
@@ -38,8 +37,7 @@
     Repo.delete(get_<%= schema.singular %>!(id))
     |> case do
        {:ok, <%= schema.singular %>} ->
-        Itsm.Utils.broadcast(__MODULE__, {action_user, :delete_<%= schema.singular %>, <%= schema.singular %>})
-        Itsm.Utils.broadcasts(__MODULE__, {action_user, :delete_<%= schema.singular %>, <%= schema.singular %>})
+        <%= schema.singular %>.broadcast(__MODULE__, {action_user, :delete_<%= schema.singular %>, <%= schema.singular %>}, id: <%= schema.singular %>.id)
         {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->

--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -1,20 +1,20 @@
+  alias Itsm.Accounts.User
   alias <%= inspect schema.module %>
 
   defdelegate get_<%= schema.singular %>!(id), to: Itsm.<%= inspect context.alias %>
 
   defdelegate list_<%= schema.plural %>, to: Itsm.<%= inspect context.alias %>
 
-  defdelegate create_<%= schema.singular %>(attrs \\ %{}), to: Itsm.<%= inspect context.alias %>
+  defdelegate create_<%= schema.singular %>(action_user, attrs \\ %{}), to: Itsm.<%= inspect context.alias %>
 
-  def update_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
+  def update_<%= schema.singular %>(%User{} = action_user, %<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
     <%= schema.singular %>
     |> <%= inspect schema.alias %>.changeset(attrs)
     |> Itsm.Utils.maybe_put_change(:inserted_at, attrs["inserted_at"])
     |> Repo.update()
     |> case do
       {:ok, <%= schema.singular %>} ->
-       Itsm.Utils.broadcast(__MODULE__, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
-       Itsm.Utils.broadcasts(__MODULE__, {attrs["current_user"], :update_<%= schema.singular %>, <%= schema.singular %>})
+       <%= schema.singular %>.broadcast(__MODULE__, {action_user, :update_<%= schema.singular %>, <%= schema.singular %>}, id: <%= schema.singular %>.id)
        {:ok, <%= schema.singular %>}
 
       {:error, changeset} ->
@@ -22,7 +22,7 @@
     end
   end
 
-  defdelegate delete_<%= schema.singular %>(attrs), to: Itsm.<%= inspect context.alias %>
+  defdelegate delete_<%= schema.singular %>(action_user, attrs), to: Itsm.<%= inspect context.alias %>
 
   def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
     <%= inspect schema.alias %>.changeset(<%= schema.singular %>, attrs)

--- a/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/index.ex.eex
@@ -6,9 +6,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   alias <%= inspect context.base_module %>.Paging
 
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Itsm.Utils.subscribes(<%= inspect context.alias %>)
-
-    {:ok, stream(socket, :<%= schema.collection %>, [])}
+    {:ok, socket |> stream(:<%= schema.collection %>, []) |> Itsm.PubSub.Helper.subscribe(<%= inspect context.alias %>)}
   end
 
   def handle_params(params, url, socket) do
@@ -57,7 +55,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       context_key: :<%= schema.singular %>,
       resource_name: gettext("<%= schema.human_singular %>"),
       stream_name: :<%= schema.collection %>,
-      push_patch: [to: ~p"/admin/<%= schema.collection %>?#{socket.assigns[:results][:params] || %{}}"]
+      push_patch: [to: "#{socket.assigns.current_path}"]
     ]
 
     {:noreply, socket |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}

--- a/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
+++ b/priv/templates/phx.gen.itsm.admin_live/show.ex.eex
@@ -8,15 +8,11 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def handle_params(%{"id" => id}, _, socket) do
-    if(connected?(socket)) do
-      Itsm.Utils.subscribe(<%= inspect context.module %>, id)
-      Itsm.Utils.subscribes(<%= inspect context.module %>)
-    end
-
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))}
+     |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))
+     |> Itsm.PubSub.Helper.subscribe(<%= inspect context.module %>, id: id)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -36,7 +32,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         ) do
     opts =
       [context_key: :<%= schema.singular %>, resource_name: gettext("<%= schema.human_singular %>")]
-      |> Keyword.merge(push_event_action(event))
+      |> Keyword.merge(push_event_action(socket, event))
 
     {:noreply,
      socket
@@ -47,8 +43,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     {:noreply, socket}
   end
 
-  defp push_event_action(:delete_<%= schema.singular %>),
-    do: [push_navigate: [to: ~p"/admin/<%= schema.collection %>"]]
+  defp push_event_action(socket, :delete_<%= schema.singular %>),
+    do: [push_navigate: [to: "#{socket.assigns.current_path}"]]
 
-  defp push_event_action(_), do: []
+  defp push_event_action(_socket, _), do: []
 end

--- a/test/itsm/admin/attachments_test.exs
+++ b/test/itsm/admin/attachments_test.exs
@@ -1,0 +1,73 @@
+defmodule Itsm.Admin.AttachmentsTest do
+  use Itsm.DataCase
+
+  alias Itsm.Admin.Attachments
+
+  describe "attachments" do
+    alias Itsm.Attachments.Attachment
+
+    import Itsm.Admin.AttachmentsFixtures
+
+    @invalid_attrs %{status: nil, byte_size: nil, filename: nil, local_path: nil, file_type: nil, resource_type: nil, resource_id: nil, deleted_at: nil}
+
+    test "list_attachments/0 returns all attachments" do
+      attachment = attachment_fixture()
+      assert Attachments.list_attachments() == [attachment]
+    end
+
+    test "get_attachment!/1 returns the attachment with given id" do
+      attachment = attachment_fixture()
+      assert Attachments.get_attachment!(attachment.id) == attachment
+    end
+
+    test "create_attachment/1 with valid data creates a attachment" do
+      valid_attrs = %{status: "some status", byte_size: 42, filename: "some filename", local_path: "some local_path", file_type: "some file_type", resource_type: "some resource_type", resource_id: "7488a646-e31f-11e4-aace-600308960662", deleted_at: ~U[2026-05-14 05:26:00Z]}
+
+      assert {:ok, %Attachment{} = attachment} = Attachments.create_attachment(valid_attrs)
+      assert attachment.status == "some status"
+      assert attachment.byte_size == 42
+      assert attachment.filename == "some filename"
+      assert attachment.local_path == "some local_path"
+      assert attachment.file_type == "some file_type"
+      assert attachment.resource_type == "some resource_type"
+      assert attachment.resource_id == "7488a646-e31f-11e4-aace-600308960662"
+      assert attachment.deleted_at == ~U[2026-05-14 05:26:00Z]
+    end
+
+    test "create_attachment/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Attachments.create_attachment(@invalid_attrs)
+    end
+
+    test "update_attachment/2 with valid data updates the attachment" do
+      attachment = attachment_fixture()
+      update_attrs = %{status: "some updated status", byte_size: 43, filename: "some updated filename", local_path: "some updated local_path", file_type: "some updated file_type", resource_type: "some updated resource_type", resource_id: "7488a646-e31f-11e4-aace-600308960668", deleted_at: ~U[2026-05-15 05:26:00Z]}
+
+      assert {:ok, %Attachment{} = attachment} = Attachments.update_attachment(attachment, update_attrs)
+      assert attachment.status == "some updated status"
+      assert attachment.byte_size == 43
+      assert attachment.filename == "some updated filename"
+      assert attachment.local_path == "some updated local_path"
+      assert attachment.file_type == "some updated file_type"
+      assert attachment.resource_type == "some updated resource_type"
+      assert attachment.resource_id == "7488a646-e31f-11e4-aace-600308960668"
+      assert attachment.deleted_at == ~U[2026-05-15 05:26:00Z]
+    end
+
+    test "update_attachment/2 with invalid data returns error changeset" do
+      attachment = attachment_fixture()
+      assert {:error, %Ecto.Changeset{}} = Attachments.update_attachment(attachment, @invalid_attrs)
+      assert attachment == Attachments.get_attachment!(attachment.id)
+    end
+
+    test "delete_attachment/1 deletes the attachment" do
+      attachment = attachment_fixture()
+      assert {:ok, %Attachment{}} = Attachments.delete_attachment(attachment)
+      assert_raise Ecto.NoResultsError, fn -> Attachments.get_attachment!(attachment.id) end
+    end
+
+    test "change_attachment/1 returns a attachment changeset" do
+      attachment = attachment_fixture()
+      assert %Ecto.Changeset{} = Attachments.change_attachment(attachment)
+    end
+  end
+end

--- a/test/itsm/comments_test.exs
+++ b/test/itsm/comments_test.exs
@@ -12,7 +12,7 @@ defmodule Itsm.CommentsTest do
 
     test "list_comments/0 returns all comments" do
       comment = comment_fixture()
-      assert Comments.list_comments() == [comment]
+      assert Comments.list_comments_by_resource() == [comment]
     end
 
     test "get_comment!/1 returns the comment with given id" do

--- a/test/itsm_web/live/admin/attachment_live_test.exs
+++ b/test/itsm_web/live/admin/attachment_live_test.exs
@@ -1,0 +1,113 @@
+defmodule ItsmWeb.Admin.AttachmentLiveTest do
+  use ItsmWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Itsm.Admin.AttachmentsFixtures
+
+  @create_attrs %{status: "some status", byte_size: 42, filename: "some filename", local_path: "some local_path", file_type: "some file_type", resource_type: "some resource_type", resource_id: "7488a646-e31f-11e4-aace-600308960662", deleted_at: "2026-05-14T05:26:00Z"}
+  @update_attrs %{status: "some updated status", byte_size: 43, filename: "some updated filename", local_path: "some updated local_path", file_type: "some updated file_type", resource_type: "some updated resource_type", resource_id: "7488a646-e31f-11e4-aace-600308960668", deleted_at: "2026-05-15T05:26:00Z"}
+  @invalid_attrs %{status: nil, byte_size: nil, filename: nil, local_path: nil, file_type: nil, resource_type: nil, resource_id: nil, deleted_at: nil}
+
+  defp create_attachment(_) do
+    attachment = attachment_fixture()
+    %{attachment: attachment}
+  end
+
+  describe "Index" do
+    setup [:create_attachment]
+
+    test "lists all attachments", %{conn: conn, attachment: attachment} do
+      {:ok, _index_live, html} = live(conn, ~p"/admin/attachments")
+
+      assert html =~ "Listing Attachments"
+      assert html =~ attachment.status
+    end
+
+    test "saves new attachment", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/attachments")
+
+      assert index_live |> element("a", "New Attachment") |> render_click() =~
+               "New Attachment"
+
+      assert_patch(index_live, ~p"/admin/attachments/new")
+
+      assert index_live
+             |> form("#attachment-form", attachment: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#attachment-form", attachment: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/admin/attachments")
+
+      html = render(index_live)
+      assert html =~ "Attachment created successfully"
+      assert html =~ "some status"
+    end
+
+    test "updates attachment in listing", %{conn: conn, attachment: attachment} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/attachments")
+
+      assert index_live |> element("#attachments-#{attachment.id} a", "Edit") |> render_click() =~
+               "Edit Attachment"
+
+      assert_patch(index_live, ~p"/admin/attachments/#{attachment}/edit")
+
+      assert index_live
+             |> form("#attachment-form", attachment: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#attachment-form", attachment: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/admin/attachments")
+
+      html = render(index_live)
+      assert html =~ "Attachment updated successfully"
+      assert html =~ "some updated status"
+    end
+
+    test "deletes attachment in listing", %{conn: conn, attachment: attachment} do
+      {:ok, index_live, _html} = live(conn, ~p"/admin/attachments")
+
+      assert index_live |> element("#attachments-#{attachment.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#attachments-#{attachment.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_attachment]
+
+    test "displays attachment", %{conn: conn, attachment: attachment} do
+      {:ok, _show_live, html} = live(conn, ~p"/admin/attachments/#{attachment}")
+
+      assert html =~ "Show Attachment"
+      assert html =~ attachment.status
+    end
+
+    test "updates attachment within modal", %{conn: conn, attachment: attachment} do
+      {:ok, show_live, _html} = live(conn, ~p"/admin/attachments/#{attachment}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Attachment"
+
+      assert_patch(show_live, ~p"/admin/attachments/#{attachment}/show/edit")
+
+      assert show_live
+             |> form("#attachment-form", attachment: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#attachment-form", attachment: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/admin/attachments/#{attachment}")
+
+      html = render(show_live)
+      assert html =~ "Attachment updated successfully"
+      assert html =~ "some updated status"
+    end
+  end
+end

--- a/test/support/fixtures/admin/attachments_fixtures.ex
+++ b/test/support/fixtures/admin/attachments_fixtures.ex
@@ -1,0 +1,29 @@
+defmodule Itsm.Admin.AttachmentsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Itsm.Admin.Attachments` context.
+  """
+  alias Itsm.Accounts.User
+
+  @doc """
+  Generate a attachment.
+  """
+  def attachment_fixture(attrs \\ %{}) do
+    attrs =
+      attrs
+      |> Enum.into(%{
+        byte_size: 42,
+        deleted_at: ~U[2026-05-14 05:26:00Z],
+        file_type: "some file_type",
+        filename: "some filename",
+        local_path: "some local_path",
+        resource_id: "7488a646-e31f-11e4-aace-600308960662",
+        resource_type: "some resource_type",
+        status: "some status"
+      })
+
+    {:ok, attachment} = Itsm.Admin.Attachments.create_attachment(%User{}, attrs)
+
+    attachment
+  end
+end

--- a/test/support/fixtures/assets_fixtures.ex
+++ b/test/support/fixtures/assets_fixtures.ex
@@ -1,4 +1,6 @@
 defmodule Itsm.AssetsFixtures do
+  alias Itsm.Accounts.User
+
   @moduledoc """
   This module defines test helpers for creating
   entities via the `Itsm.Assets` context.
@@ -13,7 +15,7 @@ defmodule Itsm.AssetsFixtures do
   Generate a asset.
   """
   def asset_fixture(attrs \\ %{}) do
-    {:ok, asset} =
+    attrs =
       attrs
       |> Enum.into(%{
         affiliate: :A0,
@@ -26,7 +28,8 @@ defmodule Itsm.AssetsFixtures do
         name: unique_asset_name(),
         region_type: :P_region
       })
-      |> Itsm.Assets.create_asset()
+
+    {:ok, asset} = Itsm.Assets.create_asset(%User{}, attrs)
 
     asset
   end


### PR DESCRIPTION
## 📝 Description
이 PR은 전반적인 **PubSub 인프라 구조 개선**과 함께 **관리자(Admin) 첨부파일(Attachments) CRUD 기능 구현**, 그리고 **Request/Crew 목록의 페이징 및 필터링 리팩토링**을 포함합니다. 아울러 최근 발생했던 런타임 버그들을 함께 교정했습니다.

## 🚀 Key Changes

### 1. PubSub 시스템 구조 개선
* `PubSub` 마이그레이션 및 아키텍처 변경을 반영했습니다.
* 공통으로 사용할 수 있는 PubSub 유틸리티 헬퍼 모듈을 추가했습니다. (`lib/itsm/pub_sub/helper.ex`)
* 기존 Utils에서 제거

### 2. 관리자 첨부파일(Admin Attachments) 기능 구현
* `Admin.Attachments` 컨텍스트 및 마이그레이션을 진행했습니다.
* 관리자 첨부파일 관리를 위한 LiveView CRUD 전반을 구현했습니다.
  * `index`, `show`, `form_component` 및 각 템플릿(`heex`) 추가
* 구현 기능에 대한 컨텍스트 테스트 및 LiveView 통합 테스트 코드를 작성했습니다.

### 3. Admin Request 상세 화면 보완
* Request Show 화면에 자식 리소스(Child Resource)를 함께 확인할 수 있도록 UI 및 데이터를 추가 연동했습니다.

### 4. 페이징 처리 및 필터링 리팩토링 (Requests, All Crews)
* `Request` 및 `Crew` 전체 목록 조회 시 공통 `Paging` 및 `Filter` 로직을 적용하여 데이터 로드 성능을 최적화했습니다.

### 5. 안정성 확보 및 버그 수정 (Bug Fixes)
* **Access 프로토콜 에러 수정:** `Request` 구조체를 맵처럼 대괄호(`request[:id]`)로 접근하여 `fetch/2` 에러가 나던 부분을 점 표기법(`request.id`)으로 전면 교정했습니다.
---