### PR TITLE
[feat] 결제 Multi로 트랜잭션 처리할수 있게 변경

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -8,6 +8,7 @@ alias Itsm.Crews
 alias Itsm.Crews.{Crew, CrewsUsers, CrewReference}
 alias Itsm.Attachments
 alias Itsm.Attachments.Attachment
+alias Itsm.Service.Approval
 
 import Ecto.Query
 import Ecto.Changeset

--- a/lib/itsm/approvals.ex
+++ b/lib/itsm/approvals.ex
@@ -3,11 +3,14 @@ defmodule Itsm.Approvals do
 
   alias Itsm.Repo
   alias Itsm.Accounts.User
+  alias Itsm.Comments
   alias Itsm.Service.Approval
   alias Itsm.Service.Request
-  alias Itsm.Crews.CrewsUsers
+  alias Itsm.Requests
+  alias Itsm.Crews
   alias Itsm.Workflow
   alias Itsm.Finalization
+  alias Ecto.Multi
 
   # ==================================================
   # 조회
@@ -21,17 +24,8 @@ defmodule Itsm.Approvals do
   end
 
   def list_pending_requests(%User{} = current_user) do
-    my_crew_ids =
-      from(m in CrewsUsers, where: m.user_id == ^current_user.id, select: m.crew_id)
-      |> Repo.all()
-
-    requests_i_assigned =
-      from(a in Approval,
-        where: a.approver_id == ^current_user.id,
-        where: a.status == :assignment,
-        select: a.request_id
-      )
-      |> Repo.all()
+    my_crew_ids = Crews.list_my_crews_ids(current_user)
+    assigned_request_ids = list_assigned_request_ids(current_user)
 
     Request
     |> where([r], r.status not in [:closed, :rejected])
@@ -44,7 +38,7 @@ defmodule Itsm.Approvals do
            r.assignee_crew_id in ^my_crew_ids) or
         (r.status == :check and
            r.assignee_crew_id in ^my_crew_ids and
-           r.id not in ^requests_i_assigned) or
+           r.id not in ^assigned_request_ids) or
         (r.status == :confirmation and
            r.requestor_id == ^current_user.id)
     )
@@ -53,67 +47,70 @@ defmodule Itsm.Approvals do
     |> Repo.preload([:category, :assignee_crew, :requestor_crew])
   end
 
-  # ==================================================
-  # 승인 / 반려
-  # ==================================================
-
-  def approve(%Request{} = request, %User{} = approver) do
-    process_approval(request, approver, :approve)
+  @doc """
+  현재 사용자가 담당자(접수자)로 할당된 요청 ID 목록을 조회합니다.
+  """
+  def list_assigned_request_ids(%User{} = user) do
+    Approval
+    |> where([a], a.approver_id == ^user.id and a.status == :assignment)
+    |> select([a], a.request_id)
+    |> Repo.all()
   end
 
-  def reject(%Request{} = request, %User{} = approver) do
-    process_approval(request, approver, :reject)
+  def change_approval(%Request{} = request, %User{} = approver, action) do
+    Approval.changeset(
+      %Approval{},
+      %{
+        request_id: request.id,
+        status: request.status,
+        action: action,
+        approver_id: approver.id,
+        approver_name: approver.display_name
+      }
+    )
   end
 
-  defp process_approval(%Request{} = request, %User{} = approver, action)
-       when action in [:approve, :reject] do
-    result =
-      Repo.transaction(fn ->
-        with {:ok, changeset} <- Workflow.transition(:service_request, request, action),
-             {:ok, updated_request} <- Repo.update(changeset),
-             {:ok, approval} <-
-               create_approval(approver, %{
-                 request_id: request.id,
-                 status: request.status,
-                 action: action,
-                 approver_id: approver.id,
-                 approver_name: approver.display_name
-               }) do
-          preloaded_request =
-            Repo.preload(updated_request, [
-              :category,
-              :attachments,
-              requestor_crew: [:users],
-              assignee_crew: [:users]
-            ])
+  @spec approve(%Request{}, %User{}, comment: map() | nil) :: tuple()
+  def approve(request, approver, opts \\ [])
 
-          {preloaded_request, approval}
-        else
-          {:error, reason} -> Repo.rollback(reason)
-        end
-      end)
+  def approve(%Request{} = request, %User{} = approver, opts) when is_list(opts) do
+    process_approval(request, approver, :approve, opts)
+  end
 
-    # 트랜잭션 커밋 후 broadcast
-    case result do
-      {:ok, {preloaded_request, _approval}} ->
-        # TODO : Sync 호출 (자산 한번에 10개 이상 신청 대응)
-        # 상태가 :finish(또는 워크플로우에 맞는 완료 상태)일 때 바로 실행
-        if preloaded_request.status == :confirmation do
-          Finalization.execute_after_finish(approver, preloaded_request)
+  @spec reject(%Request{}, %User{}, comment: map() | nil) :: tuple()
+  def reject(request, approver, opts \\ [])
+
+  def reject(%Request{} = request, %User{} = approver, opts) do
+    process_approval(request, approver, :reject, opts)
+  end
+
+  defp process_approval(%Request{} = request, %User{} = approver, action, opts) do
+    Multi.new()
+    |> Multi.insert(:create_approval, change_approval(request, approver, action))
+    |> Multi.update(:update_request, Workflow.transition(:service_request, request, action))
+    |> create_comment_mult(approver, request, opts)
+    |> Repo.transact()
+    |> case do
+      {:ok, %{update_request: request, create_approval: approval}} ->
+        request =
+          Repo.preload(request, [
+            :category,
+            :attachments,
+            requestor_crew: [:users],
+            assignee_crew: [:users]
+          ])
+
+        if request.status == :confirmation do
+          Finalization.execute_after_finish(approver, request)
         end
 
-        Itsm.PubSub.Helper.broadcast(__MODULE__, {approver, :request_updated, preloaded_request})
-
-        result
+        Itsm.PubSub.Helper.broadcast(Requests, {approver, :update_request, {request, approval}})
+        {:ok, %{request: request, approval: approval}}
 
       error ->
         error
     end
   end
-
-  # ==================================================
-  # CUD
-  # ==================================================
 
   def create_approval(%User{} = action_user, attrs) do
     %Approval{}
@@ -155,4 +152,16 @@ defmodule Itsm.Approvals do
     |> where([a], a.request_id == ^id)
     |> Repo.one()
   end
+
+  defp create_comment_mult(%Ecto.Multi{} = multi, %User{} = approver, %_{} = resource,
+         comment: comment
+       ) do
+    Multi.insert(
+      multi,
+      :create_comment,
+      Comments.change_comment_for_resource(approver, resource, comment)
+    )
+  end
+
+  defp create_comment_mult(multi, _action_user, _resource, _opts), do: multi
 end

--- a/lib/itsm/comments.ex
+++ b/lib/itsm/comments.ex
@@ -19,7 +19,9 @@ defmodule Itsm.Comments do
     |> Repo.all()
   end
 
-  def changeset_comment(%User{} = action_user, resource, attrs \\ %{}) do
+  def change_comment_for_resource(action_user, resource, attrs \\ %{})
+
+  def change_comment_for_resource(%User{} = action_user, resource, attrs) when is_map(attrs) do
     %Comment{
       user: action_user,
       resource_type: Utils.resource_name(resource),
@@ -34,7 +36,7 @@ defmodule Itsm.Comments do
 
   def create_comment(%User{} = action_user, resource, attrs, repo \\ Repo, opts \\ []) do
     action_user
-    |> changeset_comment(resource, attrs)
+    |> change_comment_for_resource(resource, attrs)
     |> repo.insert()
     |> case do
       {:ok, comment} ->

--- a/lib/itsm/comments/comment.ex
+++ b/lib/itsm/comments/comment.ex
@@ -27,7 +27,7 @@ defmodule Itsm.Comments.Comment do
   @doc false
   def changeset(comment, attrs \\ %{}) do
     comment
-    |> cast(attrs, [:comment, :resource_type, :resource_id])
+    |> cast(attrs, [:comment])
     |> validate_required([:comment, :resource_type, :resource_id])
     |> validate_length(:comment, min: 1, max: 1000)
     |> assoc_constraint(:user)

--- a/lib/itsm/crews.ex
+++ b/lib/itsm/crews.ex
@@ -42,6 +42,13 @@ defmodule Itsm.Crews do
     |> Map.get(:crews)
   end
 
+  def list_my_crews_ids(%User{} = user) do
+    CrewsUsers
+    |> where([cu], cu.user_id == ^user.id)
+    |> select([cu], cu.crew_id)
+    |> Repo.all()
+  end
+
   def list_regular_users(%Crew{} = crew) do
     List.delete(crew.users, crew.leader)
   end
@@ -117,14 +124,7 @@ defmodule Itsm.Crews do
     end
   end
 
-  def create_crew_references(
-        %User{} = action_user,
-        %_{id: id} = resource,
-        crews,
-        repo \\ Repo,
-        opts \\ []
-      )
-      when is_list(crews) do
+  def create_crew_references(%_{id: id} = resource, crews, repo) when is_list(crews) do
     Enum.reduce_while(crews, {:ok, []}, fn crew, {:ok, acc} ->
       %CrewReference{
         resource_type: Utils.resource_name(resource),
@@ -140,18 +140,6 @@ defmodule Itsm.Crews do
           {:halt, {:error, reason}}
       end
     end)
-    |> case do
-      {:ok, crew_references} ->
-        if Keyword.get(opts, :broadcast, true) do
-          Itsm.PubSub.Helper.broadcast(
-            __MODULE__,
-            {action_user, :create_crew_references, crew_references}
-          )
-        end
-
-      error ->
-        error
-    end
   end
 
   def add_users(%User{} = action_user, %Crew{} = crew, add_user_ids) do

--- a/lib/itsm/service.ex
+++ b/lib/itsm/service.ex
@@ -24,31 +24,25 @@ defmodule Itsm.Service do
       )
       when is_list(crews) and is_function(consumer_fn) do
     Multi.new()
-    |> Multi.run(:create_request, fn repo, _ ->
-      Requests.create_request(action_user, category, attrs, repo, broadcast: false)
-    end)
+    |> Multi.insert(:create_request, Requests.change_request(action_user, category, attrs))
     |> check_minimum_k_vms(attrs)
-    |> Multi.run(:create_approval, fn repo, %{create_request: request} ->
-      Approvals.create_approval(action_user, repo, request, broadcast: false)
-    end)
     |> Multi.run(:create_attachments, fn repo, %{create_request: request} ->
       Attachments.create_attachments(action_user, request, consumer_fn, repo, broadcast: false)
     end)
     |> Multi.run(:create_crew_references, fn repo, %{create_request: request} ->
-      Crews.create_crew_references(action_user, request, crews, repo, broadcast: false)
+      Crews.create_crew_references(request, crews, repo)
     end)
     |> Repo.transact()
     |> case do
       {:ok,
        %{
          create_request: request,
-         create_approval: approval,
          create_attachments: attachments
        }} ->
-        request = Repo.preload(request, [:category])
+        request =
+          Repo.preload(request, [:category, requestor_crew: [:users], assignee_crew: [:users]])
 
         Itsm.PubSub.Helper.broadcast(Requests, {action_user, :create_request, request})
-        Itsm.PubSub.Helper.broadcast(Approvals, {action_user, :create_approval, approval})
         Itsm.PubSub.Helper.broadcast(Attachments, {action_user, :create_attachments, attachments})
 
         {:ok, request}
@@ -71,7 +65,7 @@ defmodule Itsm.Service do
     |> Multi.run(:create_attachments, fn repo, %{update_request: request} ->
       Attachments.create_attachments(action_user, request, consumer_fn, repo, broadcast: false)
     end)
-    |> sync_crew_references(action_user, request, attrs["referenced_crews"])
+    |> sync_crew_references(request, attrs["referenced_crews"])
     |> Repo.transact()
     |> case do
       {:ok, %{update_request: request, create_attachments: attachment}} ->
@@ -144,7 +138,6 @@ defmodule Itsm.Service do
 
   defp sync_crew_references(
          %Ecto.Multi{} = mult,
-         %User{} = action_user,
          %_{} = resource,
          crews_ids
        ) do
@@ -174,9 +167,7 @@ defmodule Itsm.Service do
       end)
     end)
     |> Ecto.Multi.run(:create, fn repo, %{diff: %{add_id_list: add_id_list}} ->
-      Crews.create_crew_references(action_user, resource, Crews.get_crews(add_id_list), repo,
-        broadcast: false
-      )
+      Crews.create_crew_references(resource, Crews.get_crews(add_id_list), repo)
     end)
   end
 

--- a/lib/itsm/service/approval.ex
+++ b/lib/itsm/service/approval.ex
@@ -14,9 +14,7 @@ defmodule Itsm.Service.Approval do
       default: :request
 
     # 승인/거부
-    field :action, Ecto.Enum,
-      values: [:approve, :reject],
-      default: :approve
+    field :action, Ecto.Enum, values: [:approve, :reject]
 
     # field :approver_id, :string
     field :approver_name, :string

--- a/lib/itsm/workflow.ex
+++ b/lib/itsm/workflow.ex
@@ -149,7 +149,7 @@ defmodule Itsm.Workflow do
 
   # reject: 상태 유지 (거부 이력은 Approval에서 관리)
   def transition(_workflow_type, resource, _action = :reject) do
-    {:ok, Ecto.Changeset.change(resource, status: :rejected)}
+    Ecto.Changeset.change(resource, status: :rejected)
   end
 
   # approve: 다음 상태로 전이
@@ -160,25 +160,24 @@ defmodule Itsm.Workflow do
 
   # service_request: validation → Assignment (승인 시 담당 Crew 할당 단계로)
   defp do_transition(:service_request, resource, :validation, :assignment) do
-    {:ok, Ecto.Changeset.change(resource, status: :assignment)}
+    Ecto.Changeset.change(resource, status: :assignment)
   end
 
   # service_request: finish → verify (요청자에게 검증 요청)
   defp do_transition(:service_request, resource, :finish, :confirmation) do
-    {:ok,
-     Ecto.Changeset.change(resource,
-       status: :confirmation
-     )}
+    Ecto.Changeset.change(resource,
+      status: :confirmation
+    )
   end
 
   # service_request: verify → closed (완료, assignee 초기화)
   defp do_transition(:service_request, resource, :confirmation, :closed) do
-    {:ok, Ecto.Changeset.change(resource, status: :closed)}
+    Ecto.Changeset.change(resource, status: :closed)
   end
 
   # 기본 전이: status만 변경
   defp do_transition(_workflow_type, resource, _from, to) do
-    {:ok, Ecto.Changeset.change(resource, status: to)}
+    Ecto.Changeset.change(resource, status: to)
   end
 
   # Crew 담당 단계 조회

--- a/lib/itsm_web/components/create_comment_dialog.ex
+++ b/lib/itsm_web/components/create_comment_dialog.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.CreateCommentDialog do
   alias Itsm.Comments
   alias Itsm.Comments.Comment
   alias Itsm.Approvals
+  alias ItsmWeb.LiveUtils
 
   def update(assigns, socket) do
     {:ok,
@@ -20,7 +21,7 @@ defmodule ItsmWeb.CreateCommentDialog do
         {@title} Request
         <:subtitle>Add a comment for this approval</:subtitle>
       </.header>
-
+      
       <.simple_form
         for={@form}
         id="approval-comment-form"
@@ -40,58 +41,48 @@ defmodule ItsmWeb.CreateCommentDialog do
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
-  # def handle_event("save", %{"comment" => comment_params}, socket) do
-  #   %{request: request, action: action, current_user: user} = socket.assigns
-
-  #   case Comments.create_comment(request, user, comment_params) do
-  #     {:ok, _comment} ->
-  #       case action do
-  #         :approve ->
-  #           Service.approve_request(request, user)
-  #           # :reject -> Service.reject_request(request, user)
-  #       end
-
-  #       {:noreply, push_navigate(socket, to: ~p"/approvals")}
-
-  #     {:error, changeset} ->
-  #       {:noreply, assign(socket, form: to_form(changeset))}
-  #   end
-  # end
-
-  # def handle_event("save", %{"comment" => comment_params}, socket) do
-  #   %{request: request, action: action, current_user: user} = socket.assigns
-
-  #   with {:ok, _comment} <- Comments.create_comment(request, user, comment_params),
-  #        {:ok, _} <- Service.approve_or_reject_request(request, user, action) do
-  #     {:noreply, push_navigate(socket, to: ~p"/approvals")}
-  #   else
-  #     {:error, _} ->
-  #       {:noreply, put_flash(socket, :error, "Failed")}
-  #   end
-  # end
-
   def handle_event("save", %{"comment" => comment_params}, socket) do
-    %{request: request, action: action, current_user: action_user} = socket.assigns
+    approve_or_reject(socket, socket.assigns.action, comment_params)
+  end
 
-    with {:ok, _comment} <- Comments.create_comment(action_user, request, comment_params),
-         {:ok, _} <- do_action(action, request, action_user) do
-      {:noreply,
-       socket
-       |> clear_flash()
-       |> push_patch(to: ~p"/approvals")}
-    else
-      {:error, %Ecto.Changeset{}} ->
-        {:noreply, put_flash(socket, :error, "Failed")}
+  defp approve_or_reject(socket, :approve, params) do
+    %{request: request, current_user: action_user} = socket.assigns
+
+    case Approvals.approve(request, action_user, comment: params) do
+      {:ok, result} ->
+        notify_parent({:approve, result})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "request approved")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, :create_comment, %Ecto.Changeset{} = changeset, _so_far_changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+
+      {:error, step, _changeset, _so_far_changeset} ->
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step))}
     end
   end
 
-  defp do_action(:approve, request, action_user), do: Approvals.approve(request, action_user)
-  defp do_action(:reject, request, action_user), do: Approvals.reject(request, action_user)
-  # defp perform_action(:approve, request, user) do
-  #   Service.approve_or_reject_request(request, user, :approve)
-  # end
+  defp approve_or_reject(socket, :reject, params) do
+    %{request: request, current_user: action_user} = socket.assigns
 
-  # defp perform_action(:reject, request, user) do
-  #   Service.approve_or_reject_request(request, user, :reject)
-  # end
+    params = if params["comment"] == "", do: nil, else: params
+
+    case Approvals.reject(request, action_user, comment: params) do
+      {:ok, result} ->
+        notify_parent({:reject, result})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "request rejected")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, step, _changeset, _so_far_changeset} ->
+        {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step))}
+    end
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 end

--- a/lib/itsm_web/components/workflow_sidebar.ex
+++ b/lib/itsm_web/components/workflow_sidebar.ex
@@ -1,15 +1,17 @@
 defmodule ItsmWeb.Components.WorkflowSidebar do
   @moduledoc """
-  워크플로우 진행 상태 사이드바 컴포넌트.
+  워크플로우 진행 상태 사이드바 LiveComponent.
 
   ## 사용 예시
-      <.workflow_sidebar
+      <.live_component
+        module={ItsmWeb.Components.WorkflowSidebar}
+        id="workflow-sidebar"
         workflow_type={:service_request}
         resource={@request}
       />
   """
 
-  use Phoenix.Component
+  use ItsmWeb, :live_component
   use Gettext, backend: ItsmWeb.Gettext
   import ItsmWeb.CoreComponents
 
@@ -17,28 +19,21 @@ defmodule ItsmWeb.Components.WorkflowSidebar do
   alias Itsm.Approvals
   import ItsmWeb.CustomComponents
 
-  attr :workflow_type, :atom, required: true
-  attr :resource, :map, required: true
+  @impl true
+  def update(assigns, socket) do
+    step_data = build_step_data(assigns.workflow_type, assigns.resource)
+    {:ok, assign(socket, assigns) |> assign(:step_data, step_data)}
+  end
 
-  def workflow_sidebar(assigns) do
-    steps = Workflow.steps(assigns.workflow_type)
-    approvals_by_status = load_approvals_by_status(assigns.resource.id)
-
-    step_data =
-      build_step_data(assigns.workflow_type, approvals_by_status, steps, assigns.resource)
-
-    assigns =
-      assigns
-      |> assign(:steps, steps)
-      |> assign(:step_data, step_data)
-
+  @impl true
+  def render(assigns) do
     ~H"""
     <div class="w-64 flex-shrink-0">
       <div class="sticky top-4 bg-white rounded-xl shadow-lg border border-gray-100 p-5">
         <div class="text-center mb-5 pb-4 border-b border-gray-100">
           <.label>WorkFlow</.label>
         </div>
-
+        
         <div class="space-y-3">
           <.workflow_step
             :for={step <- @step_data}
@@ -55,7 +50,6 @@ defmodule ItsmWeb.Components.WorkflowSidebar do
   # ==================================================
   # Private Components
   # ==================================================
-
   attr :step, :map, required: true
   attr :resource, :map, required: true
   attr :workflow_type, :atom, required: true
@@ -74,88 +68,96 @@ defmodule ItsmWeb.Components.WorkflowSidebar do
               {@step.index + 1}
           <% end %>
         </div>
-
+        
         <div><span class={step_label_class(@step.status)}>{@step.label}</span></div>
       </div>
-
+      
       <div class="text-right">
-        <.step_info step={@step} resource={@resource} workflow_type={@workflow_type} />
+        <.step_detail step={@step} resource={@resource} workflow_type={@workflow_type} />
       </div>
     </div>
     """
   end
 
-  defp step_info(assigns) do
+  # 1. Workflow Step인 경우 요청자 정보와 생성 일시를 표시
+  defp step_detail(%{step: %{index: 0}} = assigns) do
     ~H"""
-    <.step_detail
-      status={@step.status}
-      approval={@step.approval}
-      step={@step.step}
-      workflow_type={@workflow_type}
-      requestor_crew={@resource.requestor_crew}
-      requestor_name={@resource.requestor_name}
-      assignee_crew={@resource.assignee_crew}
-    />
-    """
-  end
-
-  # 1. 완료된 단계 - 승인자 정보 표시
-  defp step_detail(%{status: :done, approval: approval} = assigns)
-       when not is_nil(approval) do
-    ~H"""
-    <div class="text-xs font-medium text-green-700">{@approval.approver_name}</div>
+    <div class="text-xs font-medium text-green-700">{@resource.requestor_name}</div>
 
     <div
-      id={"approval-#{@status}-date-#{@approval.id}"}
+      id={"approval-#{@step.status}-date-#{@resource.requestor_id}"}
       class="text-xs text-green-500"
       phx-hook="LocalTime.ToLocale"
       format="MM/DD HH:mm"
-      utc-value={@approval.inserted_at}
+      utc-value={@resource.inserted_at}
     />
     """
   end
 
-  # 2. :validation 단계 - 요청자 Crew
-  defp step_detail(%{status: :active, step: :validation, requestor_crew: crew} = assigns)
-       when not is_nil(crew) do
+  # 2. 완료된 단계 - 승인자 정보 표시
+  defp step_detail(%{step: %{status: :done}} = assigns) do
     ~H"""
-    <.crew_tooltip crew={@requestor_crew} />
-    """
-  end
-
-  # 3. :assignment, :check, :start, :finish - 담당 Crew
-  defp step_detail(%{status: :active, step: step, assignee_crew: crew} = assigns)
-       when step in [:assignment, :check, :start, :finish] and not is_nil(crew) do
-    ~H"""
-    <.crew_tooltip crew={@assignee_crew} />
-    """
-  end
-
-  # 4. :confirmation 단계 - 요청자
-  defp step_detail(%{status: :active, step: :confirmation, requestor_name: name} = assigns)
-       when not is_nil(name) do
-    ~H"""
-    <div class="text-xs font-semibold text-blue-600">{@requestor_name}</div>
-    """
-  end
-
-  # 5. rejected 단계 - 거부한 승인자 정보 표시
-  defp step_detail(%{status: :denied, approval: approval} = assigns)
-       when not is_nil(approval) do
-    ~H"""
-    <div class="text-xs font-medium text-red-700">{@approval.approver_name}</div>
+    <div class="text-xs font-medium text-green-700">{@step.approval.approver_name}</div>
 
     <div
-      id={"approval-#{@status}-date-#{@approval.id}"}
+      id={"approval-#{@step.approval.status}-date-#{@step.approval.id}"}
+      class="text-xs text-green-500"
+      phx-hook="LocalTime.ToLocale"
+      format="MM/DD HH:mm"
+      utc-value={@step.approval.inserted_at}
+    />
+    """
+  end
+
+  # 3. :validation 단계 - 요청자 Crew
+  defp step_detail(
+         %{step: %{status: :active, step: :validation}, resource: %{requestor_crew: crew}} =
+           assigns
+       )
+       when not is_nil(crew) do
+    ~H"""
+    <.crew_tooltip crew={@resource.requestor_crew} />
+    """
+  end
+
+  # 4. :assignment, :check, :start, :finish - 담당 Crew
+  defp step_detail(
+         %{step: %{status: :active, step: step}, resource: %{assignee_crew: crew}} = assigns
+       )
+       when step in [:assignment, :check, :start, :finish] and not is_nil(crew) do
+    ~H"""
+    <.crew_tooltip crew={@resource.assignee_crew} />
+    """
+  end
+
+  # 5. :confirmation 단계 - 요청자
+  defp step_detail(
+         %{step: %{status: :active, step: :confirmation}, resource: %{requestor_name: name}} =
+           assigns
+       )
+       when not is_nil(name) do
+    ~H"""
+    <div class="text-xs font-semibold text-blue-600">{@resource.requestor_name}</div>
+    """
+  end
+
+  # 6. rejected 단계 - 거부한 승인자 정보 표시
+  defp step_detail(%{step: %{status: :denied, approval: approval}} = assigns)
+       when not is_nil(approval) do
+    ~H"""
+    <div class="text-xs font-medium text-red-700">{@step.approval.approver_name}</div>
+
+    <div
+      id={"approval-#{@step.status}-date-#{@step.approval.id}"}
       class="text-xs text-red-500"
       phx-hook="LocalTime.ToLocale"
       format="MM/DD HH:mm"
-      utc-value={@approval.inserted_at}
+      utc-value={@step.approval.inserted_at}
     />
     """
   end
 
-  # 6. :active 외 pending 단계
+  # 7. :active 외 pending 단계
   defp step_detail(assigns) do
     ~H"""
     <span class="text-xs text-gray-400">-</span>
@@ -168,17 +170,20 @@ defmodule ItsmWeb.Components.WorkflowSidebar do
     |> Map.new(&{&1.status, &1})
   end
 
-  defp build_step_data(workflow_type, approvals_by_status, steps, resource) do
-    steps
+  defp build_step_data(workflow_type, resource) do
+    approvals_by_status = load_approvals_by_status(resource.id)
+
+    workflow_type
+    |> Workflow.steps()
     |> Enum.with_index()
     |> Enum.map(fn {step, index} ->
       approval = Map.get(approvals_by_status, step)
 
       status =
         cond do
-          approval && approval.action == :reject -> :denied
-          approval && approval.action == :approve -> :done
           step == resource.status -> :active
+          approval && approval.action == :reject -> :denied
+          index == 0 || (approval && approval.action == :approve) -> :done
           true -> :waiting
         end
 

--- a/lib/itsm_web/live/approval_live/components.ex
+++ b/lib/itsm_web/live/approval_live/components.ex
@@ -13,27 +13,27 @@ defmodule ItsmWeb.ApprovalLive.Components do
         <span class="text-gray-400">closed</span>
       <% {:feedback, label} -> %>
         <.link
-          navigate={~p"/approvals/#{@request.id}/feedback"}
+          patch={~p"/approvals/#{@request.id}/feedback"}
           class="text-green-600 font-bold hover:underline"
         >
           {label}
         </.link>
       <% {:approve, label, true} -> %>
         <.link
-          navigate={~p"/approvals/#{@request.id}/approve"}
+          patch={~p"/approvals/#{@request.id}/approve"}
           class="text-blue-600 hover:underline font-bold"
         >
           {label}
         </.link>
         <.link
-          navigate={~p"/approvals/#{@request.id}/reject"}
+          patch={~p"/approvals/#{@request.id}/reject"}
           class="text-red-600 ml-2 hover:underline"
         >
           반려
         </.link>
       <% {:approve, label, false} -> %>
         <.link
-          navigate={~p"/approvals/#{@request.id}/approve"}
+          patch={~p"/approvals/#{@request.id}/approve"}
           class="text-indigo-600 font-bold hover:underline"
         >
           {label}

--- a/lib/itsm_web/live/approval_live/index.ex
+++ b/lib/itsm_web/live/approval_live/index.ex
@@ -5,15 +5,34 @@ defmodule ItsmWeb.ApprovalLive.Index do
 
   alias Phoenix.LiveView.JS
   alias Itsm.Requests
+  alias Itsm.Crews
   alias Itsm.Approvals
   alias Itsm.Workflow
 
   def mount(_params, _session, socket) do
-    {:ok, socket |> stream(:requests, []) |> Itsm.PubSub.Helper.subscribe(Approvals)}
+    {:ok,
+     initial_page(socket)
+     |> Itsm.PubSub.Helper.subscribe(Crews)
+     |> assign(:page_title, "Listing Approvals")
+     |> Itsm.PubSub.Helper.subscribe(Requests)}
   end
 
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  def handle_info(
+        {ItsmWeb.CreateCommentDialog, {event, %{request: request, approval: approval}}},
+        %{assigns: %{current_user: current_user}} = socket
+      )
+      when event == :reject or approval.status == :assignment or
+             (request.status == :confirmation and request.requester_id != current_user.id) do
+    {:noreply, stream_delete(socket, :requests, request)}
+  end
+
+  def handle_info({ItsmWeb.CreateCommentDialog, {event, %{request: request}}}, socket)
+      when event == :approve do
+    {:noreply, stream_insert(socket, :requests, request)}
   end
 
   def handle_info({:pubsub, {action_user, event, item}}, socket) do
@@ -21,6 +40,17 @@ defmodule ItsmWeb.ApprovalLive.Index do
   end
 
   def handle_info(_event, socket), do: {:noreply, socket}
+
+  defp initial_page(socket) do
+    %{current_user: current_user} = socket.assigns
+    my_crews_ids = Crews.list_my_crews_ids(current_user)
+
+    Enum.reduce(my_crews_ids, socket, fn crew_id, acc_socket ->
+      Itsm.PubSub.Helper.subscribe(acc_socket, Crews, id: crew_id)
+    end)
+    |> assign(:my_crew_ids, my_crews_ids)
+    |> stream(:requests, Approvals.list_pending_requests(current_user), reset: true)
+  end
 
   defp apply_action(socket, :approve, %{"request_id" => id}) do
     request = Requests.get_request!(id)
@@ -42,23 +72,105 @@ defmodule ItsmWeb.ApprovalLive.Index do
     |> assign(:request, Requests.get_request!(id))
   end
 
-  defp apply_action(socket, :index, _params) do
-    %{current_user: current_user} = socket.assigns
+  defp apply_action(socket, :index, _params), do: socket
 
-    socket
-    |> assign(:page_title, "Listing Approvals")
-    |> stream(:requests, Approvals.list_pending_requests(current_user), reset: true)
-  end
-
-  defp handle_pubsub(action_user, event, item, socket) do
-    opts = [
-      resource_name: gettext("Approval"),
-      target_key: :requests,
-      push_patch: [to: "#{socket.assigns.current_path}"]
-    ]
+  defp handle_pubsub(action_user, event, request, socket)
+       when event in [:update_crew, :delete_crew] do
+    opts = [resource_name: gettext("Crew")]
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)}
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, request, opts)
+     |> initial_page()}
+  end
+
+  defp handle_pubsub(action_user, :create_request = event, request, socket) do
+    %{current_user: current_user, my_crew_ids: my_crew_ids} = socket.assigns
+
+    my_crew? = request.requestor_crew_id in my_crew_ids
+    opts = [resource_name: gettext("Approval")]
+
+    socket
+    |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, request, opts)
+    |> stream_where_requests(request, nil, current_user, my_crew?)
+  end
+
+  defp handle_pubsub(action_user, :update_request = event, {request, approval}, socket) do
+    %{current_user: current_user, my_crew_ids: my_crew_ids} = socket.assigns
+
+    my_crew? = request.requestor_crew_id in my_crew_ids
+
+    opts = [resource_name: gettext("Approval")]
+
+    socket
+    |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, request, opts)
+    |> stream_where_requests(request, approval, current_user, my_crew?)
+  end
+
+  defp handle_pubsub(_action_user, _event, _item, socket), do: {:noreply, socket}
+
+  defp stream_where_requests(
+         socket,
+         request,
+         _approval,
+         _current_user,
+         _my_crew?
+       )
+       when request.status in [:closed, :rejected] do
+    {:noreply, stream_delete(socket, :requests, request)}
+  end
+
+  defp stream_where_requests(
+         socket,
+         request,
+         _approval,
+         current_user,
+         my_crew?
+       )
+       when request.status == :validation and request.requestor_id != current_user.id and my_crew? do
+    {:noreply, stream_insert(socket, :requests, request)}
+  end
+
+  defp stream_where_requests(
+         socket,
+         request,
+         _approval,
+         _current_user,
+         my_crew?
+       )
+       when request.status in [:assignment, :start, :finish] and my_crew? do
+    {:noreply, stream_insert(socket, :requests, request)}
+  end
+
+  defp stream_where_requests(
+         socket,
+         request,
+         approval,
+         current_user,
+         my_crew?
+       )
+       when request.status == :check and approval.approver_id != current_user.id and my_crew? do
+    {:noreply, stream_insert(socket, :requests, request)}
+  end
+
+  defp stream_where_requests(
+         socket,
+         request,
+         _approval,
+         current_user,
+         _my_crew?
+       )
+       when request.status == :confirmation and request.requester_id == current_user.id do
+    {:noreply, stream_insert(socket, :requests, request)}
+  end
+
+  defp stream_where_requests(
+         socket,
+         request,
+         _approval,
+         _current_user,
+         _my_crew?
+       ) do
+    {:noreply, stream_delete(socket, :requests, request)}
   end
 end

--- a/lib/itsm_web/live/approval_live/index.html.heex
+++ b/lib/itsm_web/live/approval_live/index.html.heex
@@ -2,7 +2,7 @@
   :if={@live_action in [:approve, :reject]}
   id="approval-modal"
   show
-  on_cancel={JS.navigate(~p"/approvals")}
+  on_cancel={JS.patch(~p"/approvals")}
 >
   <.live_component
     module={ItsmWeb.CreateCommentDialog}
@@ -11,6 +11,7 @@
     action={@live_action}
     request={@request}
     current_user={@current_user}
+    patch={~p"/approvals"}
   />
 </.modal>
 
@@ -18,7 +19,7 @@
   :if={@live_action == :feedback}
   id="feedback-modal"
   show
-  on_cancel={JS.navigate(~p"/approvals")}
+  on_cancel={JS.patch(~p"/approvals")}
 >
   <.live_component
     module={ItsmWeb.EvaluationDialog}
@@ -28,6 +29,7 @@
     request={@request}
     crew_id={@request.assignee_crew_id}
     current_user={@current_user}
+    patch={~p"/approvals"}
   />
 </.modal>
 
@@ -43,28 +45,28 @@
   <:col :let={{_id, request}} label={gettext("Title")}>
     <div class="w-[90px] truncate">{request.title}</div>
   </:col>
-
+  
   <:col :let={{_id, request}} label={gettext("Environment")}>
     <.common_code_label group="운영_구분" code={request.env} />
   </:col>
-
+  
   <:col :let={{id, request}} label={gettext("Due Date")}>
     <span id={"due-date-#{id}"} phx-hook="LocalTime.ToLocale" utc-value={request.due_date}></span>
   </:col>
-
+  
   <:col :let={{_id, request}} label={gettext("Request Name")}>{request.category.name}</:col>
-
+  
   <:col :let={{_id, request}} label={gettext("Requestor Crew")}>
     {request.requestor_crew.name}
   </:col>
-
+  
   <:col :let={{_id, request}} label={gettext("Assignee Crew")}>{request.assignee_crew.name}</:col>
-
+  
   <:col :let={{_id, request}} label={gettext("Requestor Name")}>{request.requestor_name}</:col>
-
+  
   <:col :let={{_id, request}} label={gettext("Status")}>
     {Workflow.status_label(:service_request, request)}
   </:col>
-
+  
   <:action :let={{_id, request}}><.action_cell request={request} /></:action>
 </.table>

--- a/lib/itsm_web/live/common_k_create_vm_live/show.ex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.ex
@@ -1,7 +1,6 @@
 defmodule ItsmWeb.CommonKCreateVmLive.Show do
   use ItsmWeb, :live_view
 
-  import ItsmWeb.Components.WorkflowSidebar
   import ItsmWeb.CommonKCreateVmLive.Components
 
   alias Itsm.Comments

--- a/lib/itsm_web/live/common_k_create_vm_live/show.html.heex
+++ b/lib/itsm_web/live/common_k_create_vm_live/show.html.heex
@@ -19,7 +19,7 @@
         attachment={attachment}
       />
     </.attachments_section>
-    <.comments_section streams={@streams} />
+     <.comments_section streams={@streams} />
     <.comment_form
       :if={@request.status not in [:closed, :rejected]}
       form={@form}
@@ -27,8 +27,10 @@
     />
     <.back navigate={~p"/requests"}>Back</.back>
   </div>
-  <%!-- Work Flow sidebar--%>
-  <.workflow_sidebar
+   <%!-- Work Flow sidebar--%>
+  <.live_component
+    module={ItsmWeb.Components.WorkflowSidebar}
+    id="workflow-sidebar"
     workflow_type={:service_request}
     resource={@request}
   />


### PR DESCRIPTION
1. 결제 메소드 Multi 적용
2. 결제 리스트에 PubSub 적용
3. WorkFlow Component를 Function Component -> LiveView Component 변경
4. 팝업 link의 navigate -> patch로 변경
5. 서비스요청시 Validation 단계에는 Approval를 생성하지 않게 로직수정


이슈 번호 : #149