### PR TITLE
[feat]"결제"리스트 stream적용 및 나의 Crew 추가 수정일자 버그수정

### DIFF
--- a/lib/itsm/attachments.ex
+++ b/lib/itsm/attachments.ex
@@ -34,17 +34,18 @@ defmodule Itsm.Attachments do
     end
   end
 
-  def create_attachments(%User{} = action_user, resource, consumer_fn, repo \\ Repo, opts \\ []) do
-    with {:ok, attachments} <- insert_attachments(resource, consumer_fn, repo) do
-      if Keyword.get(opts, :broadcast, true) do
-        Itsm.PubSub.Helper.broadcast(
-          __MODULE__,
-          {action_user, :create_attachments, attachments}
-        )
-      end
+  def create_attachments(repo, resource, consumer_fn) do
+    attachments = consumer_fn.()
 
-      {:ok, attachments}
-    end
+    Enum.reduce_while(attachments, {:ok, []}, fn attrs, {:ok, acc} ->
+      %Attachment{resource_type: Utils.resource_name(resource), resource_id: resource.id}
+      |> Attachment.changeset(attrs)
+      |> repo.insert()
+      |> case do
+        {:ok, attachment} -> {:cont, {:ok, [attachment | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
   end
 
   def delete_attachment(%User{} = action_user, id) do
@@ -65,18 +66,4 @@ defmodule Itsm.Attachments do
   end
 
   def active_attachment(), do: Attachment |> where([a], a.status == :active)
-
-  defp insert_attachments(resource, consumer_fn, repo) do
-    attachments = consumer_fn.()
-
-    Enum.reduce_while(attachments, {:ok, []}, fn attrs, {:ok, acc} ->
-      %Attachment{resource_type: Utils.resource_name(resource), resource_id: resource.id}
-      |> Attachment.changeset(attrs)
-      |> repo.insert()
-      |> case do
-        {:ok, attachment} -> {:cont, {:ok, [attachment | acc]}}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
 end

--- a/lib/itsm/crews.ex
+++ b/lib/itsm/crews.ex
@@ -3,8 +3,8 @@ defmodule Itsm.Crews do
   alias Itsm.Repo
   alias Itsm.Crews.{Crew, CrewsUsers, CrewReference}
   alias Itsm.Accounts.User
-  alias Itsm.Accounts
   alias Itsm.Utils
+  alias Ecto.Multi
 
   @doc """
   메소드 순서 get->preload->read(select)->create->update->delete-> defp
@@ -19,7 +19,7 @@ defmodule Itsm.Crews do
 
   def get_crew_with_leader_users(id) do
     get_crew!(id)
-    |> Repo.preload([:leader, :users])
+    |> Repo.preload([:leader, crews_users: :user])
   end
 
   def list_crews do
@@ -50,7 +50,7 @@ defmodule Itsm.Crews do
   end
 
   def list_regular_users(%Crew{} = crew) do
-    List.delete(crew.users, crew.leader)
+    Enum.reject(crew.crews_users, &(&1.user_id == crew.leader_id))
   end
 
   def search_live_select_crews(name, %User{} = exclude_user) do
@@ -111,12 +111,16 @@ defmodule Itsm.Crews do
   end
 
   def create_crew(%User{} = action_user, attrs) do
-    Crew.changeset(%Crew{leader: action_user, users: [action_user]}, attrs)
-    |> Repo.insert()
+    Multi.new()
+    |> Multi.insert(:create_crew, Crew.changeset(%Crew{leader: action_user}, attrs))
+    |> Multi.insert(:create_crews_users, fn %{create_crew: crew} ->
+      CrewsUsers.changeset(%CrewsUsers{crew: crew, user: action_user})
+    end)
+    |> Repo.transaction()
     |> case do
       {:ok, crew} ->
-        crew = Repo.preload(crew, [:leader, :users])
-        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_crew, crew})
+        crew = Repo.preload(crew, [:leader, crews_users: :user])
+        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :create_crew, crew}, only: :list)
         {:ok, crew}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -124,7 +128,7 @@ defmodule Itsm.Crews do
     end
   end
 
-  def create_crew_references(%_{id: id} = resource, crews, repo) when is_list(crews) do
+  def create_crew_references(repo, %_{id: id} = resource, crews) when is_list(crews) do
     Enum.reduce_while(crews, {:ok, []}, fn crew, {:ok, acc} ->
       %CrewReference{
         resource_type: Utils.resource_name(resource),
@@ -142,30 +146,43 @@ defmodule Itsm.Crews do
     end)
   end
 
-  def add_users(%User{} = action_user, %Crew{} = crew, add_user_ids) do
-    add_users = Accounts.get_users(add_user_ids)
-    crew = Repo.preload(crew, :users)
+  def add_crews_users(%User{} = action_user, %Crew{} = crew, add_user_ids) do
+    Multi.new()
+    |> Multi.run(:create_crews_users, fn repo, _changes ->
+      CrewsUsers
+      |> where([cu], cu.crew_id == ^crew.id)
+      |> select([:crew_id])
+      |> repo.all()
+      |> then(&(add_user_ids -- &1))
+      |> Enum.reduce_while({:ok, []}, fn user_id, {:ok, acc} ->
+        repo.insert(CrewsUsers.changeset(%CrewsUsers{}, %{crew_id: crew.id, user_id: user_id}))
+        |> case do
+          {:ok, crews_users} ->
+            crews_users = Repo.preload(crews_users, :user)
+            {:cont, {:ok, [crews_users | acc]}}
 
-    new_users =
-      (crew.users ++ add_users)
-      |> Enum.uniq_by(& &1.id)
-
-    crew
-    |> Crew.users_changeset(new_users)
-    |> Repo.update()
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
+      end)
+    end)
+    |> Repo.transact()
     |> case do
-      {:ok, _crew} ->
-        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :add_users, {add_users}},
+      {:ok, %{create_crews_users: crews_users}} ->
+        add_crews_users = Repo.preload(crews_users, :user)
+
+        crew = get_crew_with_leader_users(crew.id)
+
+        Itsm.PubSub.Helper.broadcast(
+          __MODULE__,
+          {action_user, :add_crews_users, {crew, crews_users}},
           id: crew.id
         )
 
-        crew = get_crew!(crew.id) |> Repo.preload([:users, :leader])
-        Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :add_users, crew})
+        {:ok, add_crews_users}
 
-        {:ok, add_users}
-
-      {:error, %Ecto.Changeset{} = _changeset} ->
-        {:error, :add_users}
+      error ->
+        error
     end
   end
 
@@ -175,7 +192,7 @@ defmodule Itsm.Crews do
     with :ok <- ensure_leader(crew, action_user),
          :ok <- ensure_crew(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
-      crew = Repo.preload(crew, [:leader, :users])
+      crew = Repo.preload(crew, [:leader, crews_users: :user])
       Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :switch_leader, crew}, id: crew.id)
 
       {:ok, crew}
@@ -194,7 +211,7 @@ defmodule Itsm.Crews do
 
     with :ok <- ensure_leader(crew, action_user),
          {:ok, crew} <- Repo.update(changeset) do
-      crew = Repo.preload(crew, [:leader, :users])
+      crew = Repo.preload(crew, [:leader, crews_users: :user])
       Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_crew, crew}, id: crew.id)
       {:ok, crew}
     else
@@ -223,19 +240,21 @@ defmodule Itsm.Crews do
     end
   end
 
-  def delete_user(%User{} = action_user, %Crew{} = crew, %User{} = target_user) do
+  def delete_crews_users(%User{} = action_user, %Crew{} = crew, %User{} = target_user) do
     crews_users = Repo.get_by(CrewsUsers, crew_id: crew.id, user_id: target_user.id)
 
     with :ok <- ensure_delete_auth(crew, target_user, action_user),
-         {:ok, _} <- Repo.delete(crews_users) do
-      Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :delete_user, {crew, target_user}},
-        id: crew.id
+         {:ok, crews_users} <- Repo.delete(crews_users) do
+      Itsm.PubSub.Helper.broadcast(
+        __MODULE__,
+        {action_user, :delete_crews_users, {crew, crews_users}},
+        only: :list
       )
 
-      {:ok, target_user}
+      {:ok, crews_users}
     else
       {:error, %Ecto.Changeset{} = _changeset} ->
-        {:error, :delete_user}
+        {:error, :delete_crews_users}
 
       error ->
         error
@@ -261,20 +280,22 @@ defmodule Itsm.Crews do
   end
 
   defp ensure_leader(crew, user)
-  defp ensure_leader(%Crew{users: []}, _user), do: :ok
+  defp ensure_leader(%Crew{crews_users: []}, _user), do: :ok
   defp ensure_leader(%Crew{leader: leader}, _user) when leader in [nil, ""], do: :ok
-  defp ensure_leader(%Crew{leader: leader}, %User{} = user) when leader == user, do: :ok
+  defp ensure_leader(%Crew{leader: leader}, %User{} = user) when leader.id == user.id, do: :ok
   defp ensure_leader(_crew, _user), do: {:error, :not_leader}
 
-  defp ensure_crew(%Crew{users: []}, _user), do: :ok
+  defp ensure_crew(%Crew{crews_users: []}, _user), do: :ok
   defp ensure_crew(%Crew{leader: leader}, _user) when leader in [nil, ""], do: :ok
 
   defp ensure_crew(%Crew{} = crew, %User{} = leader) do
-    if Enum.any?(crew.users, &(&1.id == leader.id)), do: :ok, else: {:error, :not_in_crew}
+    if Enum.any?(crew.crews_users, &(&1.user_id == leader.id)),
+      do: :ok,
+      else: {:error, :not_in_crew}
   end
 
   defp ensure_delete_auth(crew, target_user, user)
-       when user == crew.leader or user == target_user,
+       when user.id == crew.leader.id or user.id == target_user.id,
        do: :ok
 
   defp ensure_delete_auth(_crew, _target_user, _user), do: {:error, :unauthorized}

--- a/lib/itsm/crews/crew.ex
+++ b/lib/itsm/crews/crew.ex
@@ -10,8 +10,10 @@ defmodule Itsm.Crews.Crew do
     # field :organization, :string
     # field :department, :string
 
+    field :leader_updated_at, :utc_datetime
     belongs_to :leader, Itsm.Accounts.User, foreign_key: :leader_id
 
+    has_many :crews_users, Itsm.Crews.CrewsUsers
     many_to_many :users, Itsm.Accounts.User, join_through: Itsm.Crews.CrewsUsers
 
     timestamps(type: :utc_datetime)
@@ -48,10 +50,12 @@ defmodule Itsm.Crews.Crew do
     |> put_assoc(:users, users)
   end
 
-  def leader_changeset(crew, %{id: leader_id}) do
+  def leader_changeset(crew, leader) do
     crew
-    |> cast(%{leader_id: leader_id}, [:leader_id])
-    |> validate_required([:leader_id])
+    |> change()
+    |> put_change(:leader_updated_at, DateTime.utc_now() |> DateTime.truncate(:second))
+    |> put_change(:leader_id, leader.id)
+    |> validate_required([:leader_id, :leader_updated_at])
   end
 
   # Crew 이름을 대문자로 변환

--- a/lib/itsm/crews/crews_users.ex
+++ b/lib/itsm/crews/crews_users.ex
@@ -2,8 +2,7 @@ defmodule Itsm.Crews.CrewsUsers do
   use Ecto.Schema
   import Ecto.Changeset
 
-  # @primary_key {:id, :binary_id, autogenerate: true}
-  @primary_key false
+  @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "crews_users" do
     belongs_to :crew, Itsm.Crews.Crew, type: :binary_id, primary_key: true

--- a/lib/itsm/posts.ex
+++ b/lib/itsm/posts.ex
@@ -111,7 +111,7 @@ defmodule Itsm.Posts do
       update_post(action_user, post, attrs, selected_board_metadata, repo, broadcast: false)
     end)
     |> Ecto.Multi.run(:create_attachments, fn repo, %{update_post: post} ->
-      Attachments.create_attachments(action_user, post, consumer_fn, repo, broadcast: false)
+      Attachments.create_attachments(repo, post, consumer_fn)
     end)
     |> Repo.transact()
     |> case do
@@ -136,7 +136,7 @@ defmodule Itsm.Posts do
       create_post(action_user, attrs, selected_board_metadata, repo, broadcast: false)
     end)
     |> Ecto.Multi.run(:create_attachments, fn repo, %{create_post: post} ->
-      Attachments.create_attachments(action_user, post, consumer_fn, repo, broadcast: false)
+      Attachments.create_attachments(repo, post, consumer_fn)
     end)
     |> Repo.transact()
     |> case do

--- a/lib/itsm/requests.ex
+++ b/lib/itsm/requests.ex
@@ -80,24 +80,13 @@ defmodule Itsm.Requests do
     end
   end
 
-  def update_request(%User{} = action_user, %Request{} = request, attrs, repo \\ Repo, opts \\ []) do
+  def update_request(repo, %Request{} = request, attrs) do
     request
     |> Request.changeset(attrs)
     |> repo.update()
     |> case do
-      {:ok, request} ->
-        request = request |> repo.preload(:category)
-
-        if Keyword.get(opts, :broadcast, true) do
-          Itsm.PubSub.Helper.broadcast(__MODULE__, {action_user, :update_request, request},
-            id: request.id
-          )
-        end
-
-        {:ok, request}
-
-      {:error, changeset} ->
-        {:error, changeset}
+      {:ok, request} -> {:ok, request}
+      {:error, changeset} -> {:error, changeset}
     end
   end
 

--- a/lib/itsm/service.ex
+++ b/lib/itsm/service.ex
@@ -27,10 +27,10 @@ defmodule Itsm.Service do
     |> Multi.insert(:create_request, Requests.change_request(action_user, category, attrs))
     |> check_minimum_k_vms(attrs)
     |> Multi.run(:create_attachments, fn repo, %{create_request: request} ->
-      Attachments.create_attachments(action_user, request, consumer_fn, repo, broadcast: false)
+      Attachments.create_attachments(repo, request, consumer_fn)
     end)
     |> Multi.run(:create_crew_references, fn repo, %{create_request: request} ->
-      Crews.create_crew_references(request, crews, repo)
+      Crews.create_crew_references(repo, request, crews)
     end)
     |> Repo.transact()
     |> case do
@@ -60,19 +60,25 @@ defmodule Itsm.Service do
       ) do
     Ecto.Multi.new()
     |> Multi.run(:update_request, fn repo, _ ->
-      Requests.update_request(action_user, request, attrs, repo, broadcast: false)
+      Requests.update_request(repo, request, attrs)
     end)
     |> Multi.run(:create_attachments, fn repo, %{update_request: request} ->
-      Attachments.create_attachments(action_user, request, consumer_fn, repo, broadcast: false)
+      Attachments.create_attachments(repo, request, consumer_fn)
     end)
     |> sync_crew_references(request, attrs["referenced_crews"])
     |> Repo.transact()
     |> case do
       {:ok, %{update_request: request, create_attachments: attachment}} ->
-        request = Repo.preload(request, :category)
+        request =
+          Repo.preload(request, [:category, requestor_crew: [:users], assignee_crew: [:users]])
+
+        Itsm.PubSub.Helper.broadcast(Requests, {action_user, :update_request, {request, nil}},
+          id: request.id
+        )
 
         Itsm.PubSub.Helper.broadcast(Requests, {action_user, :update_request, request},
-          id: request.id
+          id: request.id,
+          only: :detail
         )
 
         Itsm.PubSub.Helper.broadcast(Attachments, {action_user, :create_attachments, attachment})
@@ -116,7 +122,7 @@ defmodule Itsm.Service do
       Comments.create_comment(action_user, resource, attrs, repo, broadcast: false)
     end)
     |> Multi.run(:create_attachments, fn repo, %{create_comment: comment} ->
-      Attachments.create_attachments(action_user, comment, consumer_fn, repo, broadcast: false)
+      Attachments.create_attachments(repo, comment, consumer_fn)
     end)
     |> Repo.transact()
     |> case do
@@ -167,7 +173,7 @@ defmodule Itsm.Service do
       end)
     end)
     |> Ecto.Multi.run(:create, fn repo, %{diff: %{add_id_list: add_id_list}} ->
-      Crews.create_crew_references(resource, Crews.get_crews(add_id_list), repo)
+      Crews.create_crew_references(repo, resource, Crews.get_crews(add_id_list))
     end)
   end
 

--- a/lib/itsm_web/components/create_comment_dialog.ex
+++ b/lib/itsm_web/components/create_comment_dialog.ex
@@ -68,6 +68,7 @@ defmodule ItsmWeb.CreateCommentDialog do
   defp approve_or_reject(socket, :reject, params) do
     %{request: request, current_user: action_user} = socket.assigns
 
+    # 거부시 댓글 필수 체크 안해도 되도록, 빈 문자열이면 nil로 전달
     params = if params["comment"] == "", do: nil, else: params
 
     case Approvals.reject(request, action_user, comment: params) do

--- a/lib/itsm_web/live/approval_live/index.ex
+++ b/lib/itsm_web/live/approval_live/index.ex
@@ -12,8 +12,8 @@ defmodule ItsmWeb.ApprovalLive.Index do
   def mount(_params, _session, socket) do
     {:ok,
      initial_page(socket)
-     |> Itsm.PubSub.Helper.subscribe(Crews)
      |> assign(:page_title, "Listing Approvals")
+     |> Itsm.PubSub.Helper.subscribe(Crews)
      |> Itsm.PubSub.Helper.subscribe(Requests)}
   end
 
@@ -43,14 +43,27 @@ defmodule ItsmWeb.ApprovalLive.Index do
 
   defp initial_page(socket) do
     %{current_user: current_user} = socket.assigns
+
     my_crews_ids = Crews.list_my_crews_ids(current_user)
 
     Enum.reduce(my_crews_ids, socket, fn crew_id, acc_socket ->
-      Itsm.PubSub.Helper.subscribe(acc_socket, Crews, id: crew_id)
+      Itsm.PubSub.Helper.subscribe(acc_socket, Crews, id: crew_id, only: :detail)
     end)
+    |> unsubscribe_my_crews(my_crews_ids)
     |> assign(:my_crew_ids, my_crews_ids)
     |> stream(:requests, Approvals.list_pending_requests(current_user), reset: true)
   end
+
+  defp unsubscribe_my_crews(
+         %{assigns: %{my_crew_ids: previous_my_crew_ids}} = socket,
+         my_crews_ids
+       ) do
+    Enum.reduce(previous_my_crew_ids -- my_crews_ids, socket, fn crew_id, acc_socket ->
+      Itsm.PubSub.Helper.unsubscribe(acc_socket, Crews, id: crew_id, only: :detail)
+    end)
+  end
+
+  defp unsubscribe_my_crews(socket, _my_crews_ids), do: socket
 
   defp apply_action(socket, :approve, %{"request_id" => id}) do
     request = Requests.get_request!(id)
@@ -74,14 +87,9 @@ defmodule ItsmWeb.ApprovalLive.Index do
 
   defp apply_action(socket, :index, _params), do: socket
 
-  defp handle_pubsub(action_user, event, request, socket)
-       when event in [:update_crew, :delete_crew] do
-    opts = [resource_name: gettext("Crew")]
-
-    {:noreply,
-     socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, request, opts)
-     |> initial_page()}
+  defp handle_pubsub(_action_user, event, _item, socket)
+       when event in [:update_crew, :delete_crew, :add_crews_users, :delete_crews_users] do
+    {:noreply, initial_page(socket)}
   end
 
   defp handle_pubsub(action_user, :create_request = event, request, socket) do

--- a/lib/itsm_web/live/crew_live/index.ex
+++ b/lib/itsm_web/live/crew_live/index.ex
@@ -3,7 +3,7 @@ defmodule ItsmWeb.CrewLive.Index do
 
   alias Itsm.Crews
   alias Itsm.Crews.Crew
-  alias Itsm.Accounts.User
+  alias Itsm.Crews.CrewsUsers
   alias ItsmWeb.LiveUtils
 
   # 공통 컴포넌트 임포트
@@ -65,22 +65,17 @@ defmodule ItsmWeb.CrewLive.Index do
   def handle_info(_event, socket), do: {:noreply, socket}
 
   defp handle_pubsub(action_user, event, %Crew{} = item, socket)
-       when event in [:update_crew, :add_users, :switch_leader] do
-    %{current_user: user} = socket.assigns
+       when event in [:update_crew, :switch_leader] do
+    modify_crew(socket, action_user, event, item)
+  end
 
-    if(Enum.any?(item.users, &(&1.id == user.id)) || user.id == item.leader.id) do
-      opts = [
-        resource_name: get_resource_name(event),
-        target_key: :crews
-      ]
-
-      {:noreply,
-       socket
-       |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)
-       |> stream_insert(:crews, item)}
-    else
-      {:noreply, socket}
-    end
+  defp handle_pubsub(
+         action_user,
+         :add_crews_users = event,
+         {%Crew{} = item, _crews_users},
+         socket
+       ) do
+    modify_crew(socket, action_user, event, item)
   end
 
   defp handle_pubsub(action_user, :delete_crew = event, %Crew{} = item, socket) do
@@ -96,19 +91,18 @@ defmodule ItsmWeb.CrewLive.Index do
 
   defp handle_pubsub(
          action_user,
-         :delete_user = event,
-         {%Crew{} = item, %User{} = deleted_user},
+         :delete_crews_users = event,
+         {%Crew{} = item, %CrewsUsers{} = crews_users},
          socket
        ) do
     %{current_user: user} = socket.assigns
 
-    if(user.id == deleted_user.id) do
-      opts = [
-        resource_name: gettext("Member"),
-        target_key: :crews
-      ]
+    if(user.id == crews_users.user_id) do
+      opts = [resource_name: gettext("Member")]
 
-      {:noreply, ItsmWeb.LiveUtils.handle_standard_pubsub(socket, action_user, event, item, opts)}
+      {:noreply,
+       ItsmWeb.LiveUtils.handle_standard_pubsub(socket, action_user, event, item, opts)
+       |> stream_delete(:crews, item)}
     else
       {:noreply, socket}
     end
@@ -118,7 +112,22 @@ defmodule ItsmWeb.CrewLive.Index do
     {:noreply, socket}
   end
 
+  defp modify_crew(socket, action_user, event, %Crew{} = item) do
+    %{current_user: user} = socket.assigns
+
+    if(Enum.any?(item.crews_users, &(&1.user_id == user.id)) || user.id == item.leader.id) do
+      opts = [resource_name: get_resource_name(event)]
+
+      {:noreply,
+       socket
+       |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, item, opts)
+       |> stream_insert(:crews, item)}
+    else
+      {:noreply, socket}
+    end
+  end
+
   defp get_resource_name(:update_crew), do: gettext("Crew")
-  defp get_resource_name(:add_users), do: gettext("Members")
+  defp get_resource_name(:add_crews_users), do: gettext("Members")
   defp get_resource_name(:switch_leader), do: gettext("Crew Leader")
 end

--- a/lib/itsm_web/live/crew_live/index.html.heex
+++ b/lib/itsm_web/live/crew_live/index.html.heex
@@ -47,6 +47,6 @@
     action={@live_action}
     crew={@crew}
     current_user={@current_user}
-    patch={~p"/crews"}
+    patch={~p"/crews?menu_id=crews"}
   />
 </.modal>

--- a/lib/itsm_web/live/crew_live/show.ex
+++ b/lib/itsm_web/live/crew_live/show.ex
@@ -3,6 +3,7 @@ defmodule ItsmWeb.CrewLive.Show do
   use ItsmWeb, :live_view
 
   alias Itsm.Crews
+  alias Itsm.Crews.CrewsUsers
   alias Itsm.Accounts
   alias ItsmWeb.LiveUtils
 
@@ -20,8 +21,8 @@ defmodule ItsmWeb.CrewLive.Show do
      |> assign(:page_title, "Show Crew")
      |> assign(:crew, crew)
      |> assign(:show_member_modal, false)
-     |> stream(:users, Crews.list_regular_users(crew))
-     |> Itsm.PubSub.Helper.subscribe(Crews, id: id)}
+     |> stream(:crews_userses, Crews.list_regular_users(crew), reset: true)
+     |> Itsm.PubSub.Helper.subscribe(Crews, id: crew.id)}
   end
 
   def handle_event("switch_leader", %{"user-id" => user_id}, socket) do
@@ -35,8 +36,8 @@ defmodule ItsmWeb.CrewLive.Show do
 
     target_user = Accounts.get_user!(user_id)
 
-    case Crews.delete_user(action_user, crew, target_user) do
-      {:ok, _target_user} ->
+    case Crews.delete_crews_users(action_user, crew, target_user) do
+      {:ok, crews_users} ->
         msg =
           if action_user == target_user,
             do: "You have left the crew",
@@ -45,7 +46,7 @@ defmodule ItsmWeb.CrewLive.Show do
         socket =
           socket
           |> assign(:show_member_modal, false)
-          |> stream_delete(:users, target_user)
+          |> stream_delete(:crews_userses, crews_users)
           |> put_flash(:info, msg)
 
         {:noreply, socket}
@@ -59,7 +60,7 @@ defmodule ItsmWeb.CrewLive.Show do
     %{crew: crew, current_user: action_user} = socket.assigns
 
     # 리더가 없을경우 현재 로그인 사람 리더가 됨
-    if Enum.empty?(crew.users) and crew.leader in ["", nil] do
+    if Enum.empty?(crew.crews_users) and crew.leader in ["", nil] do
       switch_leader(socket, action_user)
     else
       {:noreply, assign(socket, :show_member_modal, true)}
@@ -69,14 +70,14 @@ defmodule ItsmWeb.CrewLive.Show do
   def handle_info({ItsmWeb.SearchUsersDialog, :users_selected, user_ids}, socket) do
     %{crew: crew, current_user: action_user} = socket.assigns
 
-    case Crews.add_users(action_user, crew, user_ids) do
-      {:ok, users} ->
+    case Crews.add_crews_users(action_user, crew, user_ids) do
+      {:ok, crews_userses} ->
         {:noreply,
-         stream(socket, :users, users)
+         stream(socket, :crews_userses, crews_userses)
          |> assign(:show_member_modal, false)
          |> put_flash(:info, "Members added successfully")}
 
-      {:error, step} ->
+      {:error, step, _changeset, _so_far_changeset} ->
         {:noreply, put_flash(socket, :error, LiveUtils.translate_error(step, :crew))}
     end
   end
@@ -99,24 +100,34 @@ defmodule ItsmWeb.CrewLive.Show do
     {:noreply, ItsmWeb.LiveUtils.handle_standard_pubsub(socket, action_user, event, crew, opts)}
   end
 
-  defp handle_pubsub(_action_user, :add_users = _event, {add_users}, socket) do
+  defp handle_pubsub(
+         _action_user,
+         :add_crews_users = _event,
+         {_crew, %CrewsUsers{} = crews_userses},
+         socket
+       ) do
     {:noreply,
      socket
-     |> stream(:users, add_users)
+     |> stream(:crews_userses, crews_userses)
      |> assign(:show_member_modal, false)}
   end
 
-  defp handle_pubsub(action_user, :delete_user = event, {_crew, target_user}, socket) do
+  defp handle_pubsub(
+         action_user,
+         :delete_crews_users = event,
+         {_crew, %CrewsUsers{} = crews_users},
+         socket
+       ) do
     %{back_path: back_path, current_user: user} = socket.assigns
 
     opts =
-      [resource_name: gettext("Member"), target_key: :users]
-      |> add_back_path(user.id == target_user.id, back_path)
+      [resource_name: gettext("Member")]
+      |> add_back_path(user.id == crews_users.user_id, back_path)
 
     {:noreply,
      socket
-     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, target_user, opts)
-     |> stream_delete(:users, target_user)
+     |> ItsmWeb.LiveUtils.handle_standard_pubsub(action_user, event, crews_users, opts)
+     |> stream_delete(:crews_userses, crews_users)
      |> assign(:show_member_modal, false)}
   end
 
@@ -164,7 +175,7 @@ defmodule ItsmWeb.CrewLive.Show do
           socket
           |> assign(:show_member_modal, false)
           |> assign(:crew, crew)
-          |> stream(:users, Crews.list_regular_users(crew), reset: true)
+          |> stream(:crews_userses, Crews.list_regular_users(crew), reset: true)
           |> put_flash(:info, "Leader changed successfully")
 
         {:noreply, socket}

--- a/lib/itsm_web/live/crew_live/show.html.heex
+++ b/lib/itsm_web/live/crew_live/show.html.heex
@@ -2,7 +2,7 @@
   {@crew.name}
   <:subtitle>{@crew.description}</:subtitle>
    <%!-- 리더만 멤버추가 가능 --%>
-  <:actions :if={@current_user == @crew.leader or Enum.empty?(@crew.users)}>
+  <:actions :if={Enum.empty?(@crew.crews_users) or @current_user.id == @crew.leader.id}>
     <.button phx-click="show_member_modal">Add Member</.button>
   </:actions>
 </.header>
@@ -25,7 +25,7 @@
             <span
               id="leader-updated-at"
               phx-hook="LocalTime.ToLocale"
-              utc-value={if @crew.leader, do: @crew.leader.updated_at, else: ""}
+              utc-value={if @crew.leader, do: @crew.leader_updated_at, else: ""}
             >
             </span>
           </p>
@@ -46,28 +46,30 @@
     
     <div id="members" phx-update="stream" class="space-y-1">
       <div
-        :for={{dom_id, user} <- @streams.users}
+        :for={{dom_id, crews_users} <- @streams.crews_userses}
         id={dom_id}
         class="flex items-center justify-between py-2 transition-all duration-500 animate-in fade-in slide-in-from-top-2"
         phx-remove={JS.transition("duration-300 opacity-0 scale-95")}
       >
         <div class="flex items-center gap-3">
           <div>
-            <p class="text-sm text-gray-900 break-all">{user.display_name} ({user.email})</p>
+            <p class="text-sm text-gray-900 break-all">
+              {crews_users.user.display_name} ({crews_users.user.email})
+            </p>
             
             <p class="text-xs text-gray-500">
               Added
               <span
-                id={"member-inserted-at-#{user.id}"}
+                id={"member-inserted-at-#{crews_users.user.id}"}
                 phx-hook="LocalTime.ToLocale"
-                utc-value={user.inserted_at}
+                utc-value={crews_users.inserted_at}
               >
               </span>
             </p>
           </div>
            <%!-- 접속한 본인 you 표시 --%>
           <span
-            :if={user == @current_user}
+            :if={crews_users.user == @current_user}
             class="ml-12 px-2 py-1 bg-blue-50 text-blue-700 text-xs rounded-full"
           >
             You
@@ -77,18 +79,18 @@
         <div class="flex gap-1">
           <%!-- leader 위임 버튼 --%>
           <button
-            :if={@current_user == @crew.leader or @crew.leader in ["", nil]}
+            :if={@current_user.id == @crew.leader.id or @crew.leader in ["", nil]}
             phx-click="switch_leader"
-            phx-value-user-id={user.id}
+            phx-value-user-id={crews_users.user_id}
             class="text-gray-400 hover:text-gray-600 px-2 py-1"
             data-confirm="Are you sure you want to change the crew leader?"
           >
             <.icon name="hero-trophy" class="w-4 h-4" />
           </button>
           <button
-            :if={@current_user == @crew.leader or @current_user == user}
+            :if={@current_user.id == @crew.leader.id or @current_user.id == crews_users.user_id}
             phx-click="remove_member"
-            phx-value-user-id={user.id}
+            phx-value-user-id={crews_users.user_id}
             class="text-gray-400 hover:text-gray-600 px-2 py-1"
             data-confirm="Are you sure you want to remove the member?"
           >

--- a/priv/repo/migrations/20250927074139_create_crews.exs
+++ b/priv/repo/migrations/20250927074139_create_crews.exs
@@ -6,6 +6,7 @@ defmodule Itsm.Repo.Migrations.CreateCrews do
       add :id, :binary_id, primary_key: true
       add :name, :string
       add :description, :text
+      add :leader_updated_at, :utc_datetime
       add :leader_id, references(:users, on_delete: :nilify_all, type: :binary_id)
 
       timestamps(type: :utc_datetime)

--- a/priv/repo/migrations/20251014074203_create_crews_users.exs
+++ b/priv/repo/migrations/20251014074203_create_crews_users.exs
@@ -3,11 +3,9 @@ defmodule Itsm.Repo.Migrations.CreateCrewsUsers do
 
   def change do
     create table(:crews_users, primary_key: false) do
-      add :crew_id, references(:crews, on_delete: :delete_all, type: :binary_id),
-        primary_key: true
-
-      add :user_id, references(:users, on_delete: :delete_all, type: :binary_id),
-        primary_key: true
+      add :id, :binary_id, primary_key: true
+      add :crew_id, references(:crews, on_delete: :delete_all, type: :binary_id)
+      add :user_id, references(:users, on_delete: :delete_all, type: :binary_id)
 
       timestamps(type: :utc_datetime)
     end


### PR DESCRIPTION
"결제" 리스트 내용의 변경 사항을 stream 으로 받을수 있게 로직 개발
"나의 Crew" 의 리더수정일자, 멤버추가일자가 인사정보 추가 일자라서 변경
Crew에 Schema에 leader_updated_at 리더수정일자 컬럼 추가
Attachments.create_attachments의 메소드안에 Pubsub 제거

***pull 받은후 유의사항***
1. itsm\_build\dev 폴더 삭제
2. mix ecto.reset 순서대로 작업할것

이슈 번호 : #154